### PR TITLE
Capitalise the first letter in an inferred name

### DIFF
--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -21,15 +21,11 @@ class Peoplefinder::EmailAddress < Mail::Address
   end
 
   def inferred_last_name
-    if multipart_local?
-      local.split('.')[1]
-    else
-      local.split('.')[0]
-    end
+    capitalise(local.split('.')[(multipart_local? ? 1 : 0)])
   end
 
   def inferred_first_name
-    local.split('.')[0] if multipart_local?
+    capitalise(local.split('.')[0]) if multipart_local?
   end
 
   def multipart_local?
@@ -42,5 +38,11 @@ private
     Rails.configuration.valid_login_domains
   rescue
     []
+  end
+
+  def capitalise(word)
+    word.downcase.to_s.gsub(/\b('?\S)/u) do
+      (Regexp.last_match[1]).upcase
+    end
   end
 end

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -57,7 +57,7 @@ feature 'Token Authentication' do
 
   scenario 'logging out' do
     token_log_in_as('james.darling@digital.justice.gov.uk')
-    expect(page).to have_text('james darling')
+    expect(page).to have_text('James Darling')
     click_link 'Log out'
     expect(page).not_to have_text('james.darling@digital.justice.gov.uk')
     expect(page).to have_text('Log in to the people finder')

--- a/spec/models/peoplefinder/concerns/authentication_spec.rb
+++ b/spec/models/peoplefinder/concerns/authentication_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Authentication' do # rubocop:disable RSpec/DescribeClass
 
     it 'creates a new person from a valid token' do
       expect(person.email).to eql(token.user_email)
-      expect(person.name).to eql('aled jones')
+      expect(person.name).to eql('Aled Jones')
     end
 
     it 'returns an existing person called aled jones from a valid token' do

--- a/spec/models/peoplefinder/email_address_spec.rb
+++ b/spec/models/peoplefinder/email_address_spec.rb
@@ -54,24 +54,33 @@ RSpec.describe Peoplefinder::EmailAddress do
   context 'name inferral' do
     let(:email_john_smith) { described_class.new('john.smith.1@example.com') }
     let(:email_smithy) { described_class.new('smithy@example.com') }
+    let(:email_anne_marie) { described_class.new('anne-marie.boris-smythe@example.com') }
 
     describe '.inferred_given_name' do
       it 'returns john.smith' do
-        expect(email_john_smith.inferred_first_name).to eql('john')
+        expect(email_john_smith.inferred_first_name).to eql('John')
       end
 
       it 'returns nil' do
         expect(email_smithy.inferred_first_name).to be_nil
       end
+
+      it 'returns Anne-Marie' do
+        expect(email_anne_marie.inferred_first_name).to eql('Anne-Marie')
+      end
     end
 
     describe '.inferred_last_name' do
       it 'returns smith' do
-        expect(email_john_smith.inferred_last_name).to eql('smith')
+        expect(email_john_smith.inferred_last_name).to eql('Smith')
       end
 
       it 'returns smithy' do
-        expect(email_smithy.inferred_last_name).to eql('smithy')
+        expect(email_smithy.inferred_last_name).to eql('Smithy')
+      end
+
+      it 'returns Boris-Smythe' do
+        expect(email_anne_marie.inferred_last_name).to eql('Boris-Smythe')
       end
     end
   end


### PR DESCRIPTION
- Popular opinion appears to be that write a script
  to capitalise names will never be entirely successful.
- This is a modest implementation, aiming to resolve
  first and last, single and double-barreled names.
