### PR TITLE
Use elasticsearch#refresh instead of sleep

### DIFF
--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -14,7 +14,7 @@ feature 'Search for people', elastic: true do
     before do
       create(:department)
       Peoplefinder::Person.import
-      sleep 1
+      Peoplefinder::Person.__elasticsearch__.client.indices.refresh
       omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
     end
 

--- a/spec/models/peoplefinder/concerns/searchable_spec.rb
+++ b/spec/models/peoplefinder/concerns/searchable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Searchable', elastic: true do # rubocop:disable RSpec/DescribeCl
   context 'with some people' do
     before do
       Peoplefinder::Person.import
-      sleep 1
+      Peoplefinder::Person.__elasticsearch__.client.indices.refresh
     end
 
     it 'searches by surname' do


### PR DESCRIPTION
By default elasticsearch does not commit data to its index immediately.
Instead it is held in memory and periodically flushed to the index.

However it is possible to force the data to be in the index immediately
using a 'refresh' command[1,2].

This should resolve some of the intermittent test failures with elasticsearch.

[1] http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-refresh.html
[2] http://www.rubydoc.info/gems/elasticsearch-api/Elasticsearch/API/Indices/Actions#refresh-instance_method
