### PR TITLE
Changes cookie serializer to :hybrid

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/spec/dummy/config/initializers/cookies_serializer.rb
+++ b/spec/dummy/config/initializers/cookies_serializer.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION
Serialising sessions using `Marshal` leaves Rails applications open to remote code execution should the `secret_key_base` be divulged. This change limits the damage to being able to read/write session data only.

The `:hybrid` option will transparently convert sessions from `Marshal` to `JSON` formats, so existing sessions will still be accepted.
