### PR TITLE
Rename the form submit button to Save for Person and Group

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,14 +86,6 @@ en:
       show:
         community: Community
         community_unset: Not specified
-    helpers:
-      submit:
-        person:
-          create: "Create"
-          update: "Update"
-        group:
-          create: "Create"
-          update: "Update"
     reminder_mailer:
       inadequate_profile:
         subject: "Reminder: update your profile today"
@@ -152,3 +144,12 @@ en:
         skills_and_expertise_hint: "You can add tags to your profile to allow people to find you based on<br/>your specific skills or expertise. Add them using the field below and<br/>remove them at any time with the 'X'."
         team_deletable: "Note that team deletion cannot be undone."
         team_not_deletable: "Team deletion is only possible if there are no people associated with it."
+
+  helpers:
+    submit:
+      person:
+        create: "Save"
+        update: "Save"
+      group:
+        create: "Save"
+        update: "Save"

--- a/spec/features/audit_trail_spec.rb
+++ b/spec/features/audit_trail_spec.rb
@@ -10,7 +10,7 @@ feature 'Audit trail' do
       person = create(:person, surname: 'original surname')
       visit edit_person_path(person)
       fill_in 'Surname', with: 'something else'
-      click_button 'Update'
+      click_button 'Save'
 
       visit '/audit_trail'
       expect(page).to have_text('Peoplefinder::Person Edited')
@@ -28,7 +28,7 @@ feature 'Audit trail' do
       visit new_person_path
       fill_in 'First name', with: 'Jon'
       fill_in 'Surname', with: 'Smith'
-      click_button 'Create'
+      click_button 'Save'
 
       visit '/audit_trail'
 
@@ -63,7 +63,7 @@ feature 'Audit trail' do
       group = create(:group, name: 'original name')
       visit edit_group_path(group)
       fill_in 'Team name', with: 'something else'
-      click_button 'Update'
+      click_button 'Save'
 
       visit '/audit_trail'
       expect(page).to have_text('Peoplefinder::Group Edited')
@@ -76,7 +76,7 @@ feature 'Audit trail' do
       visit new_group_path
       fill_in 'Team name', with: 'Jon'
       fill_in 'Team email address', with: 'something@example.com'
-      click_button 'Create'
+      click_button 'Save'
 
       visit '/audit_trail'
       expect(page).to have_text('New Peoplefinder::Group')
@@ -101,7 +101,7 @@ feature 'Audit trail' do
       person = create(:person)
       visit edit_person_path(person)
       attach_file('person[image]', sample_image)
-      click_button 'Update'
+      click_button 'Save'
 
       visit '/audit_trail'
       expect(page).to have_text('Peoplefinder::Person Edited')
@@ -118,7 +118,7 @@ feature 'Audit trail' do
       visit edit_person_path(person)
       click_in_org_browser 'Digital Justice'
       fill_in('Job title', with: 'Jefe')
-      click_button 'Update'
+      click_button 'Save'
 
       visit '/audit_trail'
 

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -15,7 +15,7 @@ feature 'Group maintenance' do
     fill_in 'Team description', with: 'about my team'
     fill_in 'Team responsibilities (optional)', with: 'my responsibilities'
     add_team_email_address
-    click_button 'Create'
+    click_button 'Save'
 
     expect(page).to have_content('Created Ministry of Justice')
 
@@ -36,7 +36,7 @@ feature 'Group maintenance' do
     name = 'CSG'
     fill_in 'Team name', with: name
     add_team_email_address
-    click_button 'Create'
+    click_button 'Save'
 
     expect(page).to have_content('Created CSG')
 
@@ -55,7 +55,7 @@ feature 'Group maintenance' do
     name = 'Digital Services'
     fill_in 'Team name', with: name
     add_team_email_address
-    click_button 'Create'
+    click_button 'Save'
 
     expect(page).to have_content('Created Digital Services')
 
@@ -73,7 +73,7 @@ feature 'Group maintenance' do
     fill_in 'Team name', with: 'Digital Services'
     click_in_org_browser 'Corporate Services'
     add_team_email_address
-    click_button 'Create'
+    click_button 'Save'
 
     within('.breadcrumbs ol') do
       expect(page).to have_content('Corporate Services Digital Services')
@@ -117,7 +117,7 @@ feature 'Group maintenance' do
     end
 
     click_in_org_browser 'Ministry of Justice'
-    click_button 'Update'
+    click_button 'Save'
 
     expect(page).to have_content('Updated Cyberdigital Cyberservices')
     expect(page).not_to have_text('You are currently editing this page')
@@ -143,7 +143,7 @@ feature 'Group maintenance' do
     end
 
     click_in_org_browser 'Digital Services'
-    click_button 'Update'
+    click_button 'Save'
 
     group.reload
     expect(group.name).to eql(new_name)
@@ -157,7 +157,7 @@ feature 'Group maintenance' do
 
     fill_in 'Team name', with: 'Digital'
     add_team_email_address
-    click_button 'Create'
+    click_button 'Save'
     expect(page).to have_selector('.search-box')
     expect(page).not_to have_text('You are currently editing this page')
 

--- a/spec/features/person_communities_spec.rb
+++ b/spec/features/person_communities_spec.rb
@@ -13,7 +13,7 @@ feature "Communities" do
     fill_in 'First name', with: 'Jane'
     fill_in 'Surname', with: 'Doe'
     select('Advanced cybernetics', from: 'Community')
-    click_button "Create"
+    click_button 'Save'
 
     expect(page).to have_text("Jane Doe")
     expect(page).to have_text("Advanced cybernetics")

--- a/spec/features/person_edit_notifications_spec.rb
+++ b/spec/features/person_edit_notifications_spec.rb
@@ -11,7 +11,7 @@ feature 'Person edit notifications' do
     fill_in 'First name', with: 'Bob'
     fill_in 'Surname', with: 'Smith'
     fill_in 'Email', with: 'bob.smith@digital.justice.gov.uk'
-    expect { click_button 'Create' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect { click_button 'Save' }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
     expect(last_email.subject).to eq('A new profile on MOJ People Finder has been created for you')
 
@@ -25,7 +25,7 @@ feature 'Person edit notifications' do
     fill_in 'First name', with: 'Bob'
     fill_in 'Surname', with: 'Smith'
     fill_in 'Email', with: 'test.user@digital.justice.gov.uk'
-    expect { click_button 'Create' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Creating a person with email from invalid domain' do
@@ -33,7 +33,7 @@ feature 'Person edit notifications' do
 
     fill_in 'Surname', with: 'Smith'
     fill_in 'Email', with: 'test.user@something-else.example.com'
-    expect { click_button 'Create' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Creating a person with invalid email' do
@@ -42,7 +42,7 @@ feature 'Person edit notifications' do
     fill_in 'First name', with: 'Bob'
     fill_in 'Surname', with: 'Smith'
     fill_in 'Email', with: 'test.user'
-    expect { click_button 'Create' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Creating a person with nil email' do
@@ -50,7 +50,7 @@ feature 'Person edit notifications' do
 
     fill_in 'First name', with: 'Bob'
     fill_in 'Surname', with: 'Smith'
-    expect { click_button 'Create' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Deleting a person with different email' do
@@ -91,7 +91,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Surname', with: 'Smelly Pants'
-    expect { click_button 'Update' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect { click_button 'Save' }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
     expect(last_email.subject).to eq('Your profile on MOJ People Finder has been edited')
 
@@ -104,7 +104,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Surname', with: 'Smelly Pants'
-    expect { click_button 'Update' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Editing a person with same email' do
@@ -112,7 +112,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Surname', with: 'Smelly Pants'
-    expect { click_button 'Update' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Editing a person with nil email' do
@@ -120,7 +120,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Surname', with: 'Smelly Pants'
-    expect { click_button 'Update' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Editing a person with invalid email' do
@@ -128,7 +128,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Surname', with: 'Smelly Pants'
-    expect { click_button 'Update' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Editing a person from same email to different email' do
@@ -136,7 +136,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Email', with: 'bob.smith@digital.justice.gov.uk'
-    expect { click_button 'Update' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect { click_button 'Save' }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
     expect(last_email.subject).to eq('This email address has been added to a profile on MOJ People Finder')
 
@@ -149,7 +149,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Email', with: 'test.user@digital.justice.gov.uk'
-    expect { click_button 'Update' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    expect { click_button 'Save' }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
     expect(last_email.subject).to eq('This email address has been removed from a profile on MOJ People Finder')
 
@@ -162,7 +162,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Email', with: 'bob.smithe@digital.justice.gov.uk'
-    expect { click_button 'Update' }.to change { ActionMailer::Base.deliveries.count }.by(2)
+    expect { click_button 'Save' }.to change { ActionMailer::Base.deliveries.count }.by(2)
   end
 
   scenario 'Editing a person from invalid email to invalid email' do
@@ -170,7 +170,7 @@ feature 'Person edit notifications' do
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Email', with: 'test.user'
-    expect { click_button 'Update' }.not_to change { ActionMailer::Base.deliveries.count }
+    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
   scenario 'Verifying the link to bob that is render in the emails' do

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -13,13 +13,13 @@ feature 'Person maintenance' do
     expect(page).to have_title("New profile - #{ app_title }")
     fill_in_complete_profile_details
 
-    click_button 'Create'
+    click_button 'Save'
     check_creation_of_profile_details
   end
 
   scenario 'Creating an invalid person' do
     visit new_person_path
-    click_button 'Create'
+    click_button 'Save'
     expect(page).to have_text('Please review the problems')
     within('div.person_surname') do
       expect(page).to have_text('can\'t be blank')
@@ -35,7 +35,7 @@ feature 'Person maintenance' do
     visit new_person_path
     fill_in_complete_profile_details
 
-    click_button 'Create'
+    click_button 'Save'
 
     expect(page).to have_text('1 result found')
     click_button 'Continue'
@@ -50,7 +50,7 @@ feature 'Person maintenance' do
 
     fill_in 'First name', with: person_attributes[:given_name]
     fill_in 'Surname', with: person_attributes[:surname]
-    click_button 'Create'
+    click_button 'Save'
 
     click_link 'Return to home page'
     expect(Peoplefinder::Person.where(surname: person_attributes[:surname]).count).to eql(1)
@@ -64,7 +64,7 @@ feature 'Person maintenance' do
 
     fill_in 'First name', with: person_attributes[:given_name]
     fill_in 'Surname', with: person_attributes[:surname]
-    click_button 'Update'
+    click_button 'Save'
 
     expect(page).to have_title("Duplicate names found - #{ app_title }")
     click_button 'Continue'
@@ -94,7 +94,7 @@ feature 'Person maintenance' do
     expect(page).to have_title("Edit profile - #{ app_title }")
     fill_in 'First name', with: 'Jane'
     fill_in 'Surname', with: 'Doe'
-    click_button 'Update'
+    click_button 'Save'
 
     expect(page).to have_content('Updated Jane Doe’s profile')
     within('h1') do
@@ -106,7 +106,7 @@ feature 'Person maintenance' do
     visit person_path(create(:person, person_attributes))
     click_link 'Edit this profile'
     fill_in 'Surname', with: ''
-    click_button 'Update'
+    click_button 'Save'
 
     expect(page).to have_text('Please review the problems')
     within('div.person_surname') do
@@ -119,7 +119,7 @@ feature 'Person maintenance' do
     fill_in 'Surname', with: person_attributes[:surname]
     attach_file 'person[image]', sample_image
     expect(page).not_to have_link('Crop image')
-    click_button 'Create'
+    click_button 'Save'
 
     person = Peoplefinder::Person.find_by_surname(person_attributes[:surname])
     visit person_path(person)
@@ -190,7 +190,7 @@ feature 'Person maintenance' do
     expect(page).to have_text('You are currently editing this page')
 
     fill_in 'Surname', with: person_attributes[:surname]
-    click_button 'Create'
+    click_button 'Save'
     expect(page).to have_selector('.search-box')
     expect(page).not_to have_text('You are currently editing this page')
 
@@ -226,7 +226,7 @@ feature 'Person maintenance' do
     fill_in('person_secondary_phone_number', with: 'my-secondary-phone')
 
     check('No phone number')
-    click_button 'Update'
+    click_button 'Save'
     expect(Peoplefinder::Person.last.primary_phone_number).to be_blank
     expect(Peoplefinder::Person.last.secondary_phone_number).to be_blank
 
@@ -259,7 +259,7 @@ feature 'Person maintenance' do
     visit new_person_path
     fill_in 'Surname', with: 'Smith'
     fill_in 'person_tags', with: 'ruby,cakes and bakes'
-    click_button 'Create'
+    click_button 'Save'
 
     expect(page).to have_text('Skills and expertise')
     within '.tags' do
@@ -291,7 +291,7 @@ feature 'Person maintenance' do
     page.execute_script("i.val('washing dishes').trigger('keydown');")
     find('.select2-results li:first-child').click
 
-    click_button 'Update'
+    click_button 'Save'
     within '.tags' do
       expect(page).not_to have_text('Cooking')
       expect(page).to have_text('Baking')

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -14,7 +14,7 @@ feature "Peoplefinder::Person maintenance" do
     fill_in 'Job title', with: 'Head Honcho'
     click_in_org_browser 'Digital Justice'
     check 'leader'
-    click_button "Create"
+    click_button 'Save'
 
     membership = Peoplefinder::Person.last.memberships.last
     expect(membership.role).to eql('Head Honcho')
@@ -30,7 +30,7 @@ feature "Peoplefinder::Person maintenance" do
     click_link 'Edit'
 
     fill_in 'Job title', with: 'Head Honcho'
-    click_button 'Update'
+    click_button 'Save'
 
     membership = Peoplefinder::Person.last.memberships.last
     expect(membership.role).to eql('Head Honcho')
@@ -51,7 +51,7 @@ feature "Peoplefinder::Person maintenance" do
       fill_in 'Job title', with: 'Talker'
     end
 
-    click_button 'Update'
+    click_button 'Save'
     expect(Peoplefinder::Person.last.memberships.length).to eql(2)
   end
 


### PR DESCRIPTION
The **peoplefinder** namespace we have in the `i18n/en.yml` file can be used for custom translations, but not for Rails defaults (like form builder).

I want to take a look at the specs if I can remove some repetition and maintenance overhead. It's fine for this bit, though. 
