### PR TITLE
Upgrade to work with 4.2.0rc1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,8 +45,9 @@ Style/GuardClause:
   Enabled: false
 
 # Allow long lines in specs, as it's almost impossible to fit RSpec's
-# expectations into 80 characters.
+# expectations into 100 characters.
 Metrics/LineLength:
+  Max: 100
   Exclude:
     - 'spec/**/*'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ services:
 before_install:
   - sudo apt-get install -qq phantomjs
 before_script:
-  - psql -c 'create database pf_engine_test;' -U postgres
+  - bundle exec rake db:setup
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 ruby '2.1.4'
-gem 'rails', '~> 4.1.5'
+gem 'rails', '~> 4.2.0rc1'
 
 gem 'carrierwave',
   git: 'https://github.com/carrierwaveuploader/carrierwave.git',

--- a/app/controllers/peoplefinder/information_requests_controller.rb
+++ b/app/controllers/peoplefinder/information_requests_controller.rb
@@ -18,7 +18,7 @@ module Peoplefinder
       @information_request.sender_email = current_user.email
 
       if @information_request.save
-        ReminderMailer.information_request(@information_request).deliver
+        ReminderMailer.information_request(@information_request).deliver_later
         notice :message_sent, person: @person
         redirect_to person_path(@person)
       else

--- a/app/controllers/peoplefinder/reported_profiles_controller.rb
+++ b/app/controllers/peoplefinder/reported_profiles_controller.rb
@@ -10,7 +10,7 @@ module Peoplefinder
       init_reported_profile
 
       if @reported_profile.save
-        ReminderMailer.reported_profile(@reported_profile).deliver
+        ReminderMailer.reported_profile(@reported_profile).deliver_later
         notice :message_sent, person: @person
         redirect_to person_path(@person)
       else

--- a/app/controllers/peoplefinder/tokens_controller.rb
+++ b/app/controllers/peoplefinder/tokens_controller.rb
@@ -7,7 +7,7 @@ module Peoplefinder
     def create
       @token = Token.new(token_params)
       if @token.save
-        TokenMailer.new_token_email(@token).deliver
+        TokenMailer.new_token_email(@token).deliver_later
         render
       else
         render action: :new

--- a/app/models/peoplefinder/concerns/notifications.rb
+++ b/app/models/peoplefinder/concerns/notifications.rb
@@ -8,7 +8,7 @@ module Peoplefinder::Concerns::Notifications
       if should_send_email_notification?(email, current_user)
         Peoplefinder::UserUpdateMailer.new_profile_email(
           self, current_user.email
-        ).deliver
+        ).deliver_later
       end
     end
 
@@ -24,7 +24,7 @@ module Peoplefinder::Concerns::Notifications
       if should_send_email_notification?(email, current_user)
         Peoplefinder::UserUpdateMailer.updated_profile_email(
           self, current_user.email
-        ).deliver
+        ).deliver_later
       end
     end
 
@@ -32,12 +32,12 @@ module Peoplefinder::Concerns::Notifications
       if should_send_email_notification?(email, current_user)
         Peoplefinder::UserUpdateMailer.updated_address_to_email(
           self, current_user.email, old_email
-        ).deliver
+        ).deliver_later
       end
       if should_send_email_notification?(old_email, current_user)
         Peoplefinder::UserUpdateMailer.updated_address_from_email(
           self, current_user.email, old_email
-        ).deliver
+        ).deliver_later
       end
     end
 
@@ -45,7 +45,7 @@ module Peoplefinder::Concerns::Notifications
       if should_send_email_notification?(email, current_user)
         Peoplefinder::UserUpdateMailer.deleted_profile_email(
           self, current_user.email
-        ).deliver
+        ).deliver_later
       end
     end
 

--- a/app/models/peoplefinder/home.rb
+++ b/app/models/peoplefinder/home.rb
@@ -13,4 +13,8 @@ class Peoplefinder::Home
   def self.path
     [instance]
   end
+
+  def persisted?
+    true
+  end
 end

--- a/config/initializers/deprecation_silencer.rb
+++ b/config/initializers/deprecation_silencer.rb
@@ -1,0 +1,14 @@
+current_behavior = ActiveSupport::Deprecation.behavior
+ActiveSupport::Deprecation.behavior = lambda do |message, callstack|
+  deprecations_to_silence = [
+    /cannot be used here as a full URL is required/,
+    /`serialized_attributes` is deprecated without replacement/,
+    /`#reset_updated_at!` is deprecated and will be removed on Rails 5/
+  ]
+
+  return if deprecations_to_silence.any? { |pattern| message =~ pattern }
+
+  Array.wrap(current_behavior).each do |behavior|
+    behavior.call(message, callstack)
+  end
+end

--- a/lib/tasks/peoplefinder.rake
+++ b/lib/tasks/peoplefinder.rake
@@ -31,7 +31,7 @@ namespace :peoplefinder do
       recipients.each do |recipient|
 
         if Peoplefinder::EmailAddress.new(recipient.email).valid_address?
-          Peoplefinder::ReminderMailer.inadequate_profile(recipient).deliver
+          Peoplefinder::ReminderMailer.inadequate_profile(recipient).deliver_later
           puts "Email sent to: #{ recipient.email }"
 
         else

--- a/peoplefinder.gemspec
+++ b/peoplefinder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENCE.txt", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency 'rails', '~> 4.2.0rc1'
+  s.add_dependency 'rails', '~> 4.2.0'
   s.add_dependency 'ancestry'
   s.add_dependency 'carrierwave', '~> 0.10.0'
   s.add_dependency 'elasticsearch-model', '~> 0.1.4'

--- a/peoplefinder.gemspec
+++ b/peoplefinder.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENCE.txt", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency 'rails', '~> 4.1.5'
+  s.add_dependency 'rails', '~> 4.2.0rc1'
   s.add_dependency 'ancestry'
   s.add_dependency 'carrierwave', '~> 0.10.0'
   s.add_dependency 'elasticsearch-model', '~> 0.1.4'

--- a/spec/controllers/peoplefinder/memberships_controller_spec.rb
+++ b/spec/controllers/peoplefinder/memberships_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Peoplefinder::MembershipsController, type: :controller do
     it 'deletes the record' do
       delete :destroy, id: membership.to_param, referer: people_path
       expect {
-        Peoplefinder::Membership.find(membership)
+        Peoplefinder::Membership.find(membership.id)
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 

--- a/spec/controllers/peoplefinder/versions_controller_spec.rb
+++ b/spec/controllers/peoplefinder/versions_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Peoplefinder::VersionsController, type: :controller do
         version = PaperTrail::Version.last
         put :undo, id: version.id
 
-        expect { Peoplefinder::Person.find(person) }.
+        expect { Peoplefinder::Person.find(person.id) }.
           to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe Peoplefinder::VersionsController, type: :controller do
         version = PaperTrail::Version.last
         put :undo, id: version.id
 
-        expect(Peoplefinder::Membership.find(membership)).to be_present
+        expect(Peoplefinder::Membership.find(membership.id)).to be_present
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Peoplefinder::VersionsController, type: :controller do
         version = PaperTrail::Version.last
         put :undo, id: version.id
 
-        expect { Peoplefinder::Membership.find(membership) }.
+        expect { Peoplefinder::Membership.find(membership.id) }.
           to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -42,5 +42,7 @@ module Dummy
     config.app_title = 'People Finder Dummy'
 
     config.elastic_search_url = ''
+
+    config.active_record.raise_in_transactional_callbacks = true
   end
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(mangle: false)

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -87,7 +87,7 @@ feature 'Group maintenance' do
     click_link('Delete this team')
 
     expect(page).to have_content("Deleted #{group.name}")
-    expect { Peoplefinder::Group.find(group) }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { Peoplefinder::Group.find(group.id) }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   scenario 'Prevent deletion of a team that has memberships' do

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -75,7 +75,7 @@ feature 'Person maintenance' do
     person = create(:person)
     visit edit_person_path(person)
     click_link('Delete this profile')
-    expect { Peoplefinder::Person.find(person) }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { Peoplefinder::Person.find(person.id) }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   scenario 'Allow deletion of a person even when there are memberships' do
@@ -83,8 +83,8 @@ feature 'Person maintenance' do
     person = membership.person
     visit edit_person_path(person)
     click_link('Delete this profile')
-    expect { Peoplefinder::Membership.find(membership) }.to raise_error(ActiveRecord::RecordNotFound)
-    expect { Peoplefinder::Person.find(person) }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { Peoplefinder::Membership.find(membership.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { Peoplefinder::Person.find(person.id) }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   scenario 'Editing a person' do

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -60,7 +60,7 @@ feature 'Token Authentication' do
 
   scenario 'following a link from an inadequate profile email' do
     person = create(:person, email: 'test.user@digital.justice.gov.uk')
-    Peoplefinder::ReminderMailer.inadequate_profile(person).deliver
+    Peoplefinder::ReminderMailer.inadequate_profile(person).deliver_now
 
     visit links_in_email(last_email).last
     within('h1') do

--- a/spec/mailers/peoplefinder/reminder_mailer_spec.rb
+++ b/spec/mailers/peoplefinder/reminder_mailer_spec.rb
@@ -7,7 +7,7 @@ end
 RSpec.describe Peoplefinder::ReminderMailer do
   describe '.inadequate_profile' do
     let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
-    let(:mail) { described_class.inadequate_profile(person).deliver }
+    let(:mail) { described_class.inadequate_profile(person).deliver_now }
 
     it 'sets the sender' do
       expect(mail.from).to include(Rails.configuration.support_email)
@@ -43,7 +43,7 @@ RSpec.describe Peoplefinder::ReminderMailer do
     let(:sender_email) { "test.sender@digital.justice.gov.uk" }
     let(:message) { "this is the information request message body" }
     let(:information_request) { create(:information_request, recipient: person, sender_email: sender_email, message: message) }
-    let(:mail) { described_class.information_request(information_request).deliver }
+    let(:mail) { described_class.information_request(information_request).deliver_now }
 
     it 'sets the sender' do
       expect(mail.from).to include(Rails.configuration.support_email)
@@ -81,7 +81,7 @@ RSpec.describe Peoplefinder::ReminderMailer do
         additional_details: 'more info')
     end
 
-    let(:mail) { described_class.reported_profile(reported_profile).deliver }
+    let(:mail) { described_class.reported_profile(reported_profile).deliver_now }
 
     it 'sets the recipient' do
       expect(mail.to).to include('recipient@example.com')

--- a/spec/mailers/peoplefinder/user_update_mailer_spec.rb
+++ b/spec/mailers/peoplefinder/user_update_mailer_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe Peoplefinder::UserUpdateMailer do
   let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
 
   describe ".new_profile_email" do
-    subject(:mail) { described_class.new_profile_email(person).deliver }
+    subject(:mail) { described_class.new_profile_email(person).deliver_now }
 
     include_examples "observe token_auth feature flag"
   end
 
   describe ".updated_profile_email" do
-    subject(:mail) { described_class.updated_profile_email(person).deliver }
+    subject(:mail) { described_class.updated_profile_email(person).deliver_now }
 
     include_examples "observe token_auth feature flag"
   end
@@ -37,7 +37,7 @@ RSpec.describe Peoplefinder::UserUpdateMailer do
     subject(:mail) {
       described_class.updated_address_from_email(
         person, 'updater@example.com', 'test.user@digital.justice.gov.uk'
-      ).deliver
+      ).deliver_now
     }
 
     include_examples "observe token_auth feature flag"
@@ -47,7 +47,7 @@ RSpec.describe Peoplefinder::UserUpdateMailer do
     subject(:mail) {
       described_class.updated_address_to_email(
         person, 'updater@example.com', 'test.user@digital.justice.gov.uk'
-      ).deliver
+      ).deliver_now
     }
 
     include_examples "observe token_auth feature flag"

--- a/spec/models/peoplefinder/group_spec.rb
+++ b/spec/models/peoplefinder/group_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Peoplefinder::Group, type: :model do
     it 'deletes the record when it is deletable' do
       allow(group).to receive(:deletable?).once.and_return(true)
       group.destroy
-      expect { described_class.find(group) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.find(group.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 


### PR DESCRIPTION
@threedaymonk @novotnyjakub 

As per deprecation warnings, all calls to `deliver` have been changed to `deliver_now` or `deliver_later`, so we're automatically integrated with ActiveJob.

I've silenced some deprecation warnings:

* Using `_path` instead of `_url` helpers anywhere in an `ActionMailer` appears to trigger a warnings. We pass a `desired_path` around in parameters, which is probably vulnerable to an open redirect, but also isn't the failure mode this deprecation warning is trying to guard us against, so I ignored it.
* The other two appeared to be from library code that hasn't been fixed yet.

Silencing deprecations that we either can't fix or will probably be fixed by libraries later just feels horrible. It's problematic to do this from the engine because it's silencing them for wrapper applications too. Any suggestions for how to make this nicer would be appreciated.

## Why I didn't backport

`activejob_backport` doesn't implement the `deliver_later` integration with `ActionMailer`. My options then were to:

1. Re-implement `deliver_later`, and have to subsequently remove that implementation once we upgraded.
2. Create jobs or a generic job and change all instances of `deliver` to use it (the same or more amount of work as 1).

Since we're at rc1, I figured it would be less work overall just to go ahead with the upgrade.

Any feedback welcome!
