### PR TITLE
Validate e-mails to be unique

### DIFF
--- a/app/models/peoplefinder/person.rb
+++ b/app/models/peoplefinder/person.rb
@@ -16,7 +16,7 @@ class Peoplefinder::Person < ActiveRecord::Base
   attr_accessor :crop_x, :crop_y, :crop_w, :crop_h, :role_names
 
   validates :surname, presence: true
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: true
 
   has_many :memberships,
     -> { includes(:group).order('groups.name')  },

--- a/app/views/peoplefinder/people/_form.html.haml
+++ b/app/views/peoplefinder/people/_form.html.haml
@@ -17,7 +17,8 @@
   .form-group{ :class => ('gov-uk-field-error' if @person.errors.include?(:surname)) }
     = f.label :surname, class: 'form-label-bold' do
       Surname
-      %span.error= @person.errors[:surname].first if @person.errors.include?(:surname)
+      - if @person.errors.include?(:surname)
+        %span.error= @person.errors[:surname].first
     = f.text_field :surname, class: 'form-control'
 
 
@@ -45,7 +46,8 @@
         .form-group{ :class => ('gov-uk-field-error' if @person.errors.include?(:email)) }
           = f.label :email, class: 'form-label-bold' do
             Email
-            %span.error= @person.errors[:email].first if @person.errors.include?(:email)
+            - if @person.errors.include?(:email)
+              %span.error= @person.errors[:email].first
           = f.text_field :email, class: 'form-control', readonly: @person.persisted?
 
       .form-group

--- a/spec/features/person_edit_notifications_spec.rb
+++ b/spec/features/person_edit_notifications_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 feature 'Person edit notifications' do
+  let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
   before do
-    omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
+    omni_auth_log_in_as(person.email)
   end
 
   scenario 'Creating a person with different email' do
@@ -16,16 +17,7 @@ feature 'Person edit notifications' do
     expect(last_email.subject).to eq('A new profile on MOJ People Finder has been created for you')
 
     check_email_to_and_from
-    check_email_has_token_link_to(Peoplefinder::Person.last)
-  end
-
-  scenario 'Creating a person with same email' do
-    visit new_person_path
-
-    fill_in 'First name', with: 'Bob'
-    fill_in 'Surname', with: 'Smith'
-    fill_in 'Email', with: 'test.user@digital.justice.gov.uk'
-    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
+    check_email_has_token_link_to(Peoplefinder::Person.where(email: 'bob.smith@digital.justice.gov.uk').first)
   end
 
   scenario 'Creating a person with email from invalid domain' do
@@ -45,14 +37,6 @@ feature 'Person edit notifications' do
     expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
   end
 
-  scenario 'Creating a person with nil email' do
-    visit new_person_path
-
-    fill_in 'First name', with: 'Bob'
-    fill_in 'Surname', with: 'Smith'
-    expect { click_button 'Save' }.not_to change { ActionMailer::Base.deliveries.count }
-  end
-
   scenario 'Deleting a person with different email' do
     person = create(:person, email: 'bob.smith@digital.justice.gov.uk')
     visit edit_person_path(person)
@@ -63,7 +47,6 @@ feature 'Person edit notifications' do
   end
 
   scenario 'Deleting a person with same email' do
-    person = create(:person, email: 'test.user@digital.justice.gov.uk')
     visit edit_person_path(person)
     expect { click_link('Delete this profile') }.not_to change { ActionMailer::Base.deliveries.count }
   end
@@ -102,7 +85,6 @@ feature 'Person edit notifications' do
   end
 
   scenario 'Editing a person with same email' do
-    person = create(:person, given_name: 'Bob', surname: 'Smith', email: 'test.user@digital.justice.gov.uk')
     visit person_path(person)
     click_link 'Edit this profile'
     fill_in 'Surname', with: 'Smelly Pants'

--- a/spec/models/peoplefinder/person_spec.rb
+++ b/spec/models/peoplefinder/person_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Peoplefinder::Person, type: :model do
   let(:person) { build(:person) }
   it { should validate_presence_of(:surname) }
   it { should validate_presence_of(:email) }
+  it { should validate_uniqueness_of(:email) }
   it { should have_many(:groups) }
 
   describe '.name' do

--- a/spec/support/profile.rb
+++ b/spec/support/profile.rb
@@ -34,10 +34,11 @@ module SpecSupport
 
     def check_creation_of_profile_details
       click_button 'Update Image'
-      person = Peoplefinder::Person.last
 
-      expect(page).to have_title("#{ person } - #{ app_title }")
-      within('h1') { expect(page).to have_text(person) }
+      name = "#{person_attributes[:given_name]} #{person_attributes[:surname]}"
+
+      expect(page).to have_title("#{name} - #{ app_title }")
+      within('h1') { expect(page).to have_text(name) }
       expect(page).to have_text(person_attributes[:email])
       expect(page).to have_text(person_attributes[:primary_phone_number])
       expect(page).to have_text(person_attributes[:secondary_phone_number])


### PR DESCRIPTION
I found out that some of our tests were relying on creating a duplicated profile to test some features of the logged in user. Hopefully I tackled those, but almost all the 'person maintenance' features still should be cleared up as well.