### PR TITLE
Superadmin view audit

### DIFF
--- a/app/controllers/peoplefinder/people_controller.rb
+++ b/app/controllers/peoplefinder/people_controller.rb
@@ -14,7 +14,9 @@ module Peoplefinder
 
     # GET /people/1
     def show
-      @versions = AuditVersionPresenter.wrap(@person.versions)
+      if current_user.admin?
+        @versions = AuditVersionPresenter.wrap(@person.versions)
+      end
     end
 
     # GET /people/new

--- a/app/controllers/peoplefinder/people_controller.rb
+++ b/app/controllers/peoplefinder/people_controller.rb
@@ -14,7 +14,7 @@ module Peoplefinder
 
     # GET /people/1
     def show
-      if current_user.admin?
+      if current_user.super_admin?
         @versions = AuditVersionPresenter.wrap(@person.versions)
       end
     end

--- a/app/controllers/peoplefinder/people_controller.rb
+++ b/app/controllers/peoplefinder/people_controller.rb
@@ -14,6 +14,7 @@ module Peoplefinder
 
     # GET /people/1
     def show
+      @versions = AuditVersionPresenter.wrap(@person.versions)
     end
 
     # GET /people/new

--- a/app/models/peoplefinder/person.rb
+++ b/app/models/peoplefinder/person.rb
@@ -87,6 +87,16 @@ class Peoplefinder::Person < ActiveRecord::Base
       split(',').uniq.sort.join(',')
   end
 
+  def changes_for_paper_trail
+    super.tap { |changes|
+      if changes.key?('image')
+        changes['image'].map! do |value|
+          value.url && File.basename(value.url)
+        end
+      end
+    }
+  end
+
 private
 
   def group_path(hint_group)

--- a/app/presenters/peoplefinder/audit_version_presenter.rb
+++ b/app/presenters/peoplefinder/audit_version_presenter.rb
@@ -1,0 +1,24 @@
+require 'forwardable'
+require 'yaml'
+module Peoplefinder
+  class AuditVersionPresenter
+    extend Forwardable
+    def_delegators :@version, :event, :whodunnit, :created_at
+
+    def initialize(version)
+      @version = version
+    end
+
+    def changes
+      YAML.load(@version.object_changes).map do |field, (_, new)|
+        "#{field} => #{new}"
+      end
+    end
+
+    def self.wrap(versions)
+      Array(versions).map do |version|
+        AuditVersionPresenter.new(version)
+      end
+    end
+  end
+end

--- a/app/views/peoplefinder/people/_audit.html.haml
+++ b/app/views/peoplefinder/people/_audit.html.haml
@@ -1,0 +1,19 @@
+%table.audit
+  %thead
+    %tr
+      %th Event
+      %th By
+      %th At
+      %th Change
+  %tbody
+    -person.versions.reverse.each do |v|
+      %tr
+        %td= v.event
+        %td= v.whodunnit || 'Programmatic'
+        %td= v.created_at
+        %td
+          %ul
+            - YAML.load(v.object_changes).map {|k,v| "#{k.to_s} => #{v[1]}" }.each do |change|
+              %li=change
+
+

--- a/app/views/peoplefinder/people/_audit.html.haml
+++ b/app/views/peoplefinder/people/_audit.html.haml
@@ -9,7 +9,7 @@
     -person.versions.reverse.each do |v|
       %tr
         %td= v.event
-        %td= v.whodunnit || 'Programmatic'
+        %td= v.whodunnit
         %td= v.created_at
         %td
           %ul

--- a/app/views/peoplefinder/people/_audit.html.haml
+++ b/app/views/peoplefinder/people/_audit.html.haml
@@ -6,14 +6,14 @@
       %th At
       %th Change
   %tbody
-    -person.versions.reverse.each do |v|
+    -versions.reverse.each do |v|
       %tr
         %td= v.event
         %td= v.whodunnit
         %td= v.created_at
         %td
           %ul
-            - YAML.load(v.object_changes).map {|k,v| "#{k.to_s} => #{v[1]}" }.each do |change|
+            - v.changes.each do |change|
               %li=change
 
 

--- a/app/views/peoplefinder/people/show.html.haml
+++ b/app/views/peoplefinder/people/show.html.haml
@@ -75,6 +75,6 @@
       <br/>
       = link_to info_text('request_information_link'), new_person_information_request_path(@person)
 
-- if current_user.super_admin?
+- unless @versions.nil?
   %h1 Audit Log
   =render 'audit', versions: @versions

--- a/app/views/peoplefinder/people/show.html.haml
+++ b/app/views/peoplefinder/people/show.html.haml
@@ -77,4 +77,4 @@
 
 - if current_user.super_admin?
   %h1 Audit Log
-  =render 'audit', person: @person
+  =render 'audit', versions: @versions

--- a/app/views/peoplefinder/people/show.html.haml
+++ b/app/views/peoplefinder/people/show.html.haml
@@ -74,3 +74,7 @@
       = info_text('request_information')
       <br/>
       = link_to info_text('request_information_link'), new_person_information_request_path(@person)
+
+- if current_user.super_admin?
+  %h1 Audit Log
+  =render 'audit', person: @person

--- a/db/migrate/20150210115300_detoxify_yaml.rb
+++ b/db/migrate/20150210115300_detoxify_yaml.rb
@@ -1,0 +1,20 @@
+require 'peoplefinder/image_uploader'
+require 'peoplefinder/person'
+class DetoxifyYaml < ActiveRecord::Migration
+  class Version < ActiveRecord::Base
+  end
+
+  def up
+    Version.all.each do |version|
+      serialized = version.object_changes
+      serialized.gsub!(/ !ruby\/object:Peoplefinder::ImageUploader::Uploader\d+/, '')
+      changes = YAML.load(serialized)
+      if changes.key?('image')
+        changes['image'].map! do |value|
+          value.url && File.basename(value.url)
+        end
+      end
+      version.update! object_changes: YAML.dump(changes)
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150129121619) do
+ActiveRecord::Schema.define(version: 20150210115300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/audit_trail_spec.rb
+++ b/spec/features/audit_trail_spec.rb
@@ -106,7 +106,7 @@ feature 'Audit trail' do
 
       visit '/audit_trail'
       expect(page).to have_text('Peoplefinder::Person Edited')
-      expect(page).to have_text(/Image set to.*placeholder/)
+      expect(page).to have_text('Image changed from no_photo.png to placeholder.png')
     end
   end
 

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -9,10 +9,15 @@ feature 'View person audit' do
   let!(:person)      { with_versioning { create(:person) } }
   let(:profile_page) { Pages::Profile.new }
 
+  let(:sample_image) {
+    File.open(File.join(Peoplefinder::Engine.root, 'spec', 'fixtures', 'placeholder.png'))
+  }
+
   before do
     with_versioning do
       person.update description: description
       person.update primary_phone_number: phone_number
+      person.update image: sample_image
     end
   end
 
@@ -22,9 +27,10 @@ feature 'View person audit' do
 
     expect(profile_page).to have_audit
     profile_page.audit.versions.tap do |v|
-      expect(v[0]).to have_text "primary_phone_number => #{phone_number}"
-      expect(v[1]).to have_text "description => #{description}"
-      expect(v[2]).to have_text "email => #{person.email}"
+      expect(v[0]).to have_text "image => placeholder.png"
+      expect(v[1]).to have_text "primary_phone_number => #{phone_number}"
+      expect(v[2]).to have_text "description => #{description}"
+      expect(v[3]).to have_text "email => #{person.email}"
     end
   end
 

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -7,6 +7,7 @@ feature 'View person audit' do
   let(:description)  { 'The best person' }
   let(:phone_number) { '55555555555' }
   let!(:person)      { with_versioning { create(:person) } }
+  let(:profile_page) { Pages::Profile.new }
 
   before do
     with_versioning do
@@ -17,13 +18,13 @@ feature 'View person audit' do
 
   scenario 'View audit as an admin user' do
     omni_auth_log_in_as(super_admin.email)
-    visit person_path(person)
+    profile_page.load(slug: person.slug)
 
-    expect(page).to have_selector 'table.audit tbody tr', count: 3
-    within 'table.audit tbody' do
-      expect(find('tr:nth-child(1)')).to have_text "primary_phone_number => #{phone_number}"
-      expect(find('tr:nth-child(2)')).to have_text "description => #{description}"
-      expect(find('tr:nth-child(3)')).to have_text "email => #{person.email}"
+    expect(profile_page).to have_audit
+    profile_page.audit.versions.tap do |v|
+      expect(v[0]).to have_text "primary_phone_number => #{phone_number}"
+      expect(v[1]).to have_text "description => #{description}"
+      expect(v[2]).to have_text "email => #{person.email}"
     end
   end
 

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -1,20 +1,35 @@
 require 'rails_helper'
 
 feature 'View person audit' do
-  let(:email) { 'test.user@digital.justice.gov.uk' }
-  let!(:person) { create(:person) }
+  let(:super_admin_email)  { 'test.user@digital.justice.gov.uk' }
+  let!(:super_admin)  { create(:super_admin, email: super_admin_email) }
+
+  let(:description)  { 'The best person' }
+  let(:phone_number) { '55555555555' }
+  let!(:person)      { with_versioning { create(:person) } }
 
   before do
-    person.update_attributes description: 'The best person'
-    person.update_attributes primary_phone_number: '55555555555'
-     
-    # login as a super admin
-    create(:super_admin, email: email)
-    omni_auth_log_in_as(email)
+    with_versioning do
+      person.update description: 'The best person'
+      person.update primary_phone_number: '55555555555'
+    end
   end
 
-  scenario 'View a profile as an admin user' do
+  scenario 'View audit as an admin user' do
+    omni_auth_log_in_as(super_admin.email)
     visit person_path(person)
+
     expect(page).to have_selector 'table.audit tbody tr', count: 3
+    within 'table.audit tbody' do
+      expect(find('tr:nth-child(1)')).to have_text "primary_phone_number => #{phone_number}"
+      expect(find('tr:nth-child(2)')).to have_text "description => #{description}"
+      expect(find('tr:nth-child(3)')).to have_text "email => #{person.email}"
+    end
+  end
+
+  scenario 'Hide audit as regular user' do
+    omni_auth_log_in_as(person.email)
+    visit person_path(person)
+    expect(page).to_not have_selector 'table.audit'
   end
 end

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -30,7 +30,7 @@ feature 'View person audit' do
 
   scenario 'Hide audit as regular user' do
     omni_auth_log_in_as(person.email)
-    visit person_path(person)
-    expect(page).to_not have_selector 'table.audit'
+    profile_page.load(slug: person.slug)
+    expect(profile_page).to_not have_audit
   end
 end

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+feature 'View person audit' do
+  let(:email) { 'test.user@digital.justice.gov.uk' }
+  let!(:person) { create(:person) }
+
+  before do
+    person.update_attributes description: 'The best person'
+    person.update_attributes primary_phone_number: '55555555555'
+     
+    # login as a super admin
+    create(:super_admin, email: email)
+    omni_auth_log_in_as(email)
+  end
+
+  scenario 'View a profile as an admin user' do
+    visit person_path(person)
+    expect(page).to have_selector 'table.audit tbody tr', count: 3
+  end
+end

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -10,8 +10,8 @@ feature 'View person audit' do
 
   before do
     with_versioning do
-      person.update description: 'The best person'
-      person.update primary_phone_number: '55555555555'
+      person.update description: description
+      person.update primary_phone_number: phone_number
     end
   end
 

--- a/spec/presenters/peoplefinder/audit_version_presenter_spec.rb
+++ b/spec/presenters/peoplefinder/audit_version_presenter_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Peoplefinder::AuditVersionPresenter, type: :presenter do
+  let(:whodunnit)  { 'Tom Smith' }
+  let(:event)      { 'update' }
+  let(:created_at) { DateTime.now }
+
+  let(:previous_email) { 'f.smith@smithmeister.com' }
+  let(:new_email)      { 'f.smith@digital.justice.gov.uk' }
+  let(:new_given_name) { 'Fred' }
+  let(:new_surname)    { 'Smith' }
+  let(:object_changes) {
+    "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess
+    email:
+    - #{previous_email}
+    - #{new_email}
+    given_name:
+    -
+    - #{new_given_name}
+    surname:
+    -
+    - #{new_surname}"
+  }
+
+  let(:version) {
+    double('version',
+      created_at: created_at,
+      whodunnit: whodunnit,
+      event: event,
+      object_changes: object_changes
+    )
+  }
+  let(:presenter)  { described_class.new(version) }
+  let(:changes)    { presenter.changes }
+
+  describe '#event' do
+    it 'delegates to version' do
+      expect(presenter.event).to eq event
+    end
+  end
+
+  describe '#whodunnit' do
+    it 'delegates to version' do
+      expect(presenter.whodunnit).to eq whodunnit
+    end
+  end
+
+  describe '#created_at' do
+    it 'delegates to version' do
+      expect(presenter.created_at).to eq created_at
+    end
+  end
+
+  describe '#changes' do
+    it 'contains expected strings' do
+      expect(changes).to include("email => #{new_email}")
+      expect(changes).to include("given_name => #{new_given_name}")
+      expect(changes).to include("surname => #{new_surname}")
+    end
+  end
+
+  describe ".wrap" do
+    let(:object)           { Object.new }
+    let(:presenter)        { double('presenter') }
+    let(:object_array)     { [object, object, object] }
+    let(:wrapped_array)    { described_class.wrap(object_array) }
+    let(:presented_array)  { [presenter, presenter, presenter] }
+
+    before do
+      allow(described_class).to receive(:new).and_return presenter
+    end
+
+    it 'wraps an array of objects' do
+      expect(wrapped_array).to eq presented_array
+    end
+  end
+end

--- a/spec/support/pages/profile.rb
+++ b/spec/support/pages/profile.rb
@@ -1,0 +1,8 @@
+require_relative 'sections/audit'
+
+module Pages
+  class Profile < SitePrism::Page
+    set_url '/people{/slug}'
+    section :audit, Sections::Audit, '.audit'
+  end
+end

--- a/spec/support/pages/sections/audit.rb
+++ b/spec/support/pages/sections/audit.rb
@@ -1,0 +1,7 @@
+module Pages
+  module Sections
+    class Audit < SitePrism::Section
+      elements :versions, 'tbody tr'
+    end
+  end
+end


### PR DESCRIPTION
Don't think this is ready to merge just yet. Here's some things I could do with a bit of advice on:

1. The tests are quite locked into the current HTML structure, any ideas on generalising these a little? It would be good if we could keep the order tested though.

2. Related to 1, I get the feeling that accessing the HTML directly isn't in keeping with the other tests. Any suggestions as to how to do these tests generally better would be appreciated.

3. `YAML::load` in the view!? My thinking is to pre-process the array of versions so that we effectively can do:

```ruby
# in a helper controller
def version_log_for(person)
  versions = VersionsCollectionPresenterOrSomething.new(person.versions)
  render 'audit', versions: versions
end
```

```haml
# in the partial
...
%ul
  - version.changes.each do |change|
    %li=change
```

If you don't like that, we can skip the helper and do the pre-processing in the controller instead.

Any of your thoughts re: the above or other problems appreciated.

Cheers,

@novotnyjakub, @cfq 