### PR TITLE
Record and show more information about people who make changes

### DIFF
--- a/app/controllers/peoplefinder/application_controller.rb
+++ b/app/controllers/peoplefinder/application_controller.rb
@@ -14,6 +14,10 @@ module Peoplefinder
       logged_in? ? current_user.id : nil
     end
 
+    def info_for_paper_trail
+      { ip_address: request.remote_ip }
+    end
+
     def current_user
       @current_user ||= Peoplefinder::Login.current_user(session)
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/peoplefinder/application_controller.rb
+++ b/app/controllers/peoplefinder/application_controller.rb
@@ -15,7 +15,7 @@ module Peoplefinder
     end
 
     def info_for_paper_trail
-      { ip_address: request.remote_ip }
+      { ip_address: request.remote_ip, user_agent: request.user_agent }
     end
 
     def current_user

--- a/app/controllers/peoplefinder/application_controller.rb
+++ b/app/controllers/peoplefinder/application_controller.rb
@@ -11,7 +11,7 @@ module Peoplefinder
   private
 
     def user_for_paper_trail
-      logged_in? ? current_user.to_s : Peoplefinder::Version.public_user
+      logged_in? ? current_user.id : nil
     end
 
     def current_user

--- a/app/models/peoplefinder/group.rb
+++ b/app/models/peoplefinder/group.rb
@@ -3,7 +3,8 @@ require 'peoplefinder'
 class Peoplefinder::Group < ActiveRecord::Base
   self.table_name = 'groups'
 
-  has_paper_trail ignore: [:updated_at, :created_at, :slug, :id]
+  has_paper_trail class_name: 'Peoplefinder::Version',
+                  ignore: [:updated_at, :created_at, :slug, :id]
 
   extend FriendlyId
   friendly_id :slug_candidates, use: :slugged

--- a/app/models/peoplefinder/membership.rb
+++ b/app/models/peoplefinder/membership.rb
@@ -3,7 +3,8 @@ require 'peoplefinder'
 class Peoplefinder::Membership < ActiveRecord::Base
   self.table_name = 'memberships'
 
-  has_paper_trail ignore: [:updated_at, :created_at, :id]
+  has_paper_trail class_name: 'Peoplefinder::Version',
+                  ignore: [:updated_at, :created_at, :id]
 
   belongs_to :person, touch: true
   belongs_to :group, touch: true

--- a/app/models/peoplefinder/person.rb
+++ b/app/models/peoplefinder/person.rb
@@ -10,7 +10,8 @@ class Peoplefinder::Person < ActiveRecord::Base
   include Peoplefinder::Concerns::WorkDays
   include Peoplefinder::Concerns::Sanitisable
 
-  has_paper_trail ignore: [:updated_at, :created_at, :id, :slug,
+  has_paper_trail class_name: 'Peoplefinder::Version',
+                  ignore: [:updated_at, :created_at, :id, :slug,
                            :login_count, :last_login_at]
   mount_uploader :image, Peoplefinder::ImageUploader
 

--- a/app/models/peoplefinder/version.rb
+++ b/app/models/peoplefinder/version.rb
@@ -39,4 +39,14 @@ class Peoplefinder::Version < PaperTrail::Version
       "#{ item_type } Edited"
     end
   end
+
+  def whodunnit
+    stored = super
+    case stored
+    when /\A\d+\z/
+      Peoplefinder::Person.find_by(id: stored.to_i)
+    else
+      stored
+    end
+  end
 end

--- a/app/presenters/peoplefinder/audit_version_presenter.rb
+++ b/app/presenters/peoplefinder/audit_version_presenter.rb
@@ -3,7 +3,7 @@ require 'yaml'
 module Peoplefinder
   class AuditVersionPresenter
     extend Forwardable
-    def_delegators :@version, :event, :whodunnit, :created_at
+    def_delegators :@version, :event, :whodunnit, :created_at, :ip_address
 
     def initialize(version)
       @version = version

--- a/app/presenters/peoplefinder/audit_version_presenter.rb
+++ b/app/presenters/peoplefinder/audit_version_presenter.rb
@@ -1,5 +1,7 @@
 require 'forwardable'
 require 'yaml'
+require 'user_agent'
+
 module Peoplefinder
   class AuditVersionPresenter
     extend Forwardable
@@ -14,6 +16,12 @@ module Peoplefinder
       YAML.load(@version.object_changes).map do |field, (_, new)|
         "#{field} => #{new}"
       end
+    end
+
+    def user_agent_summary
+      return nil if user_agent.blank?
+      ua = UserAgent.parse(user_agent)
+      '%s %s' % [ua.browser, ua.version]
     end
 
     def self.wrap(versions)

--- a/app/presenters/peoplefinder/audit_version_presenter.rb
+++ b/app/presenters/peoplefinder/audit_version_presenter.rb
@@ -3,7 +3,8 @@ require 'yaml'
 module Peoplefinder
   class AuditVersionPresenter
     extend Forwardable
-    def_delegators :@version, :event, :whodunnit, :created_at, :ip_address
+    def_delegators :@version, :event, :whodunnit, :created_at, :ip_address,
+      :user_agent
 
     def initialize(version)
       @version = version

--- a/app/views/peoplefinder/people/_audit.html.haml
+++ b/app/views/peoplefinder/people/_audit.html.haml
@@ -3,6 +3,7 @@
     %tr
       %th Event
       %th By
+      %th IP address
       %th At
       %th Change
   %tbody
@@ -13,6 +14,7 @@
           %td= link_to v.whodunnit.to_s, v.whodunnit
         - else
           %td= v.whodunnit
+        %td= v.ip_address
         %td= v.created_at
         %td
           %ul

--- a/app/views/peoplefinder/people/_audit.html.haml
+++ b/app/views/peoplefinder/people/_audit.html.haml
@@ -4,6 +4,7 @@
       %th Event
       %th By
       %th IP address
+      %th Browser
       %th At
       %th Change
   %tbody
@@ -15,6 +16,7 @@
         - else
           %td= v.whodunnit
         %td= v.ip_address
+        %td= v.user_agent
         %td= v.created_at
         %td
           %ul

--- a/app/views/peoplefinder/people/_audit.html.haml
+++ b/app/views/peoplefinder/people/_audit.html.haml
@@ -9,7 +9,10 @@
     -versions.reverse.each do |v|
       %tr
         %td= v.event
-        %td= v.whodunnit
+        -if v.whodunnit.is_a?(Peoplefinder::Person)
+          %td= link_to v.whodunnit.to_s, v.whodunnit
+        - else
+          %td= v.whodunnit
         %td= v.created_at
         %td
           %ul

--- a/app/views/peoplefinder/people/_audit.html.haml
+++ b/app/views/peoplefinder/people/_audit.html.haml
@@ -16,7 +16,7 @@
         - else
           %td= v.whodunnit
         %td= v.ip_address
-        %td= v.user_agent
+        %td{title: v.user_agent}=v.user_agent_summary
         %td= v.created_at
         %td
           %ul

--- a/db/migrate/20150211153741_add_ip_address_to_versions.rb
+++ b/db/migrate/20150211153741_add_ip_address_to_versions.rb
@@ -1,0 +1,5 @@
+class AddIpAddressToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :ip_address, :string
+  end
+end

--- a/db/migrate/20150211164821_add_user_agent_to_versions.rb
+++ b/db/migrate/20150211164821_add_user_agent_to_versions.rb
@@ -1,0 +1,5 @@
+class AddUserAgentToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :user_agent, :string
+  end
+end

--- a/peoplefinder.gemspec
+++ b/peoplefinder.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'unicorn', '~> 4.8.3'
   s.add_dependency 'will_paginate', '~> 3.0'
   s.add_dependency 'unf'
+  s.add_dependency 'useragent', '~> 0.10.0'
 
   s.add_development_dependency 'brakeman'
   s.add_development_dependency 'pry-rails'

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150211153741) do
+ActiveRecord::Schema.define(version: 20150211164821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 20150211153741) do
     t.datetime "created_at"
     t.text     "object_changes"
     t.string   "ip_address"
+    t.string   "user_agent"
   end
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150210115300) do
+ActiveRecord::Schema.define(version: 20150211153741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 20150210115300) do
     t.text     "object"
     t.datetime "created_at"
     t.text     "object_changes"
+    t.string   "ip_address"
   end
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -13,30 +13,73 @@ feature 'View person audit' do
     File.open(File.join(Peoplefinder::Engine.root, 'spec', 'fixtures', 'placeholder.png'))
   }
 
-  before do
-    with_versioning do
-      person.update description: description
-      person.update primary_phone_number: phone_number
-      person.update image: sample_image
+  let(:author) { create(:person) }
+
+  context 'modern versioning' do
+    before do
+      with_versioning do
+        PaperTrail.whodunnit = author.id
+        person.update description: description
+        person.update primary_phone_number: phone_number
+        person.update image: sample_image
+      end
+    end
+
+    context 'as an admin user' do
+      before do
+        omni_auth_log_in_as(super_admin.email)
+      end
+
+      scenario 'view audit' do
+        profile_page.load(slug: person.slug)
+
+        expect(profile_page).to have_audit
+        profile_page.audit.versions.tap do |v|
+          expect(v[0]).to have_text "image => placeholder.png"
+          expect(v[1]).to have_text "primary_phone_number => #{phone_number}"
+          expect(v[2]).to have_text "description => #{description}"
+          expect(v[3]).to have_text "email => #{person.email}"
+        end
+      end
+
+      scenario 'link to author of a change' do
+        profile_page.load(slug: person.slug)
+
+        profile_page.audit.versions.tap do |v|
+          expect(v[0]).to have_link author.to_s, href: "/people/#{author.slug}"
+        end
+      end
+    end
+
+    context 'as a regular user' do
+      before do
+        omni_auth_log_in_as(person.email)
+      end
+
+      scenario 'hide audit' do
+        profile_page.load(slug: person.slug)
+        expect(profile_page).not_to have_audit
+      end
     end
   end
 
-  scenario 'View audit as an admin user' do
-    omni_auth_log_in_as(super_admin.email)
-    profile_page.load(slug: person.slug)
+  context 'legacy versioning as an admin' do
+    before do
+      with_versioning do
+        PaperTrail.whodunnit = 'Michael Mouse'
+        person.update description: description
+      end
 
-    expect(profile_page).to have_audit
-    profile_page.audit.versions.tap do |v|
-      expect(v[0]).to have_text "image => placeholder.png"
-      expect(v[1]).to have_text "primary_phone_number => #{phone_number}"
-      expect(v[2]).to have_text "description => #{description}"
-      expect(v[3]).to have_text "email => #{person.email}"
+      omni_auth_log_in_as(super_admin.email)
     end
-  end
 
-  scenario 'Hide audit as regular user' do
-    omni_auth_log_in_as(person.email)
-    profile_page.load(slug: person.slug)
-    expect(profile_page).to_not have_audit
+    scenario 'show text for change author' do
+      profile_page.load(slug: person.slug)
+
+      expect(profile_page).to have_audit
+      profile_page.audit.versions.tap do |v|
+        expect(v[0]).to have_text 'Michael Mouse'
+      end
+    end
   end
 end

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -49,6 +49,15 @@ feature 'View person audit' do
           expect(v[0]).to have_link author.to_s, href: "/people/#{author.slug}"
         end
       end
+
+      scenario 'show IP address of author of a change' do
+        Peoplefinder::Version.last.update ip_address: '1.2.3.4'
+        profile_page.load(slug: person.slug)
+
+        profile_page.audit.versions.tap do |v|
+          expect(v[0]).to have_text '1.2.3.4'
+        end
+      end
     end
 
     context 'as a regular user' do

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -60,11 +60,12 @@ feature 'View person audit' do
       end
 
       scenario 'show browser used by author of a change' do
-        Peoplefinder::Version.last.update user_agent: 'NCSA Mosaic/3.0 (Windows 95)'
+        ua = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)'
+        Peoplefinder::Version.last.update user_agent: ua
         profile_page.load(slug: person.slug)
 
         profile_page.audit.versions.tap do |v|
-          expect(v[0]).to have_text 'NCSA Mosaic/3.0 (Windows 95)'
+          expect(v[0]).to have_text 'Internet Explorer 6.0'
         end
       end
     end

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -58,6 +58,15 @@ feature 'View person audit' do
           expect(v[0]).to have_text '1.2.3.4'
         end
       end
+
+      scenario 'show browser used by author of a change' do
+        Peoplefinder::Version.last.update user_agent: 'NCSA Mosaic/3.0 (Windows 95)'
+        profile_page.load(slug: person.slug)
+
+        profile_page.audit.versions.tap do |v|
+          expect(v[0]).to have_text 'NCSA Mosaic/3.0 (Windows 95)'
+        end
+      end
     end
 
     context 'as a regular user' do

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -129,6 +129,8 @@ feature 'Person maintenance' do
     scenario 'Recording audit details' do
       allow_any_instance_of(ActionDispatch::Request).
         to receive(:remote_ip).and_return('1.2.3.4')
+      allow_any_instance_of(ActionDispatch::Request).
+        to receive(:user_agent).and_return('NCSA Mosaic/3.0 (Windows 95)')
 
       with_versioning do
         person = create(:person, person_attributes)
@@ -140,6 +142,7 @@ feature 'Person maintenance' do
 
       version = Peoplefinder::Version.last
       expect(version.ip_address).to eq('1.2.3.4')
+      expect(version.user_agent).to eq('NCSA Mosaic/3.0 (Windows 95)')
       expect(version.whodunnit).to eq(person)
     end
 

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -126,6 +126,23 @@ feature 'Person maintenance' do
       end
     end
 
+    scenario 'Recording audit details' do
+      allow_any_instance_of(ActionDispatch::Request).
+        to receive(:remote_ip).and_return('1.2.3.4')
+
+      with_versioning do
+        person = create(:person, person_attributes)
+        visit edit_person_path(person)
+
+        fill_in 'First name', with: 'Jane'
+        click_button 'Save'
+      end
+
+      version = Peoplefinder::Version.last
+      expect(version.ip_address).to eq('1.2.3.4')
+      expect(version.whodunnit).to eq(person)
+    end
+
     scenario 'Editing a person and giving them a name that already exists' do
       create(:person, given_name: person_attributes[:given_name], surname: person_attributes[:surname])
       person = create(:person, given_name: 'Bobbie', surname: 'Browne')

--- a/spec/models/peoplefinder/version_spec.rb
+++ b/spec/models/peoplefinder/version_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Peoplefinder::Version, type: :model do
+  context 'whodunnit' do
+    let(:author) { create(:person) }
+
+    it 'returns a string for the user when a string was stored' do
+      subject = described_class.new(whodunnit: 'Michael Mouse')
+      expect(subject.whodunnit).to eq('Michael Mouse')
+    end
+
+    it 'returns a user when their ID was stored' do
+      subject = described_class.new(whodunnit: author.id.to_s)
+      expect(subject.whodunnit).to eq(author)
+    end
+
+    it 'returns nil when an orphaned ID was stored' do
+      subject = described_class.new(whodunnit: author.id.to_s)
+      author.destroy
+      expect(subject.whodunnit).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
> As a member of the People Finder Product team I want to be able to accurately identify who is making changes to the content or structure of the People Finder product so that I can take appropriate action when errors occur [(Trello)](https://trello.com/c/9pR3N0bK/181-m-as-a-member-of-the-people-finder-product-team-i-want-to-be-able-to-accurately-identify-who-is-making-changes-to-the-content-or)

* Store the ID of the person, and link to them from the audit log
* Record their IP address
* Record browser details

The [useragent](https://github.com/josh/useragent) gem is used to reduce raw user agent strings down to a simple and easy-to-read form in the audit log, though the full string is still available on hover via the `title` attribute.

Old version records where the user was stored as a string are displayed correctly, but there is no link to the person responsible. Retroactively fixing these would be possible, but I don't think it's worthwhile.