### PR TITLE
Make email uniqueness validation case insensitive

### DIFF
--- a/app/models/peoplefinder/person.rb
+++ b/app/models/peoplefinder/person.rb
@@ -19,7 +19,8 @@ class Peoplefinder::Person < ActiveRecord::Base
 
   validates :given_name, presence: true, on: :update
   validates :surname, presence: true
-  validates :email, presence: true, uniqueness: true, 'peoplefinder/email' => true
+  validates :email,
+    presence: true, uniqueness: { case_sensitive: false }, 'peoplefinder/email' => true
 
   sanitise_fields :given_name, :surname, :email
 

--- a/spec/models/peoplefinder/person_spec.rb
+++ b/spec/models/peoplefinder/person_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Peoplefinder::Person, type: :model do
   it { should validate_presence_of(:given_name).on(:update) }
   it { should validate_presence_of(:surname) }
   it { should validate_presence_of(:email) }
-  it { should validate_uniqueness_of(:email) }
+  it { should validate_uniqueness_of(:email).case_insensitive }
   it { should have_many(:groups) }
 
   describe '.name' do


### PR DESCRIPTION
This is a fix for already existing uniqueness validation. 