### PR TITLE
Accept emails with apostrophe

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,9 @@ Metrics/MethodLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/CyclomaticComplexity:
+  Max: 7
+
 # Enforce single quotes everywhere except in specs (because there's a lot of
 # human text with apostrophes in spec names, and using double quotes for all
 # of those is more consistent. There shouldn't be much human-readable text in

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,9 +55,6 @@ Metrics/MethodLength:
   Exclude:
     - 'spec/**/*'
 
-Metrics/CyclomaticComplexity:
-  Max: 7
-
 # Enforce single quotes everywhere except in specs (because there's a lot of
 # human text with apostrophes in spec names, and using double quotes for all
 # of those is more consistent. There shouldn't be much human-readable text in

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -50,14 +50,14 @@ private
 
   def globally_addressable_domain?
     domain && domain.match(/
-      \A         # beginning of string
-      [^\s\.]+   # domain part (anything except whitespace or dot)
-      (?:        # one or more of:
-        \.       #   dot
-        [^\s\.]+ #   domain part
-      )+         #
-      \z         # end of string
-    /x)
+      \A           # beginning of string
+      (?:          # one or more of:
+        [0-9a-z-]+ #   domain part (can include digits and hyphens)
+        \.         #   dot
+      )+           #
+      [a-z]+       # top-level domain (no digits or hyphens)
+      \z           # end of string
+    /xi)
   end
 
   def default_valid_login_domains

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -22,11 +22,8 @@ class Peoplefinder::EmailAddress
 
   def valid_format?
     return false unless @parsed_ok
-    return false unless domain && address == @raw_address
-    return false unless domain.match(/\A\S+\z/)
-    domain_dot_elements = domain.split(/\./)
-    return false unless domain_dot_elements.size > 1 && domain_dot_elements.all?(&:present?)
-
+    return false unless address == @raw_address
+    return false unless globally_addressable_domain?
     true
   end
 
@@ -49,6 +46,14 @@ class Peoplefinder::EmailAddress
 private
 
   attr_reader :valid_login_domains
+
+  def globally_addressable_domain?
+    return false unless domain
+    return false unless domain.match(/\A\S+\z/)
+    domain_dot_elements = domain.split(/\./)
+    return false unless domain_dot_elements.size > 1 && domain_dot_elements.all?(&:present?)
+    true
+  end
 
   def default_valid_login_domains
     Rails.configuration.try(:valid_login_domains) || []

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -23,7 +23,7 @@ class Peoplefinder::EmailAddress
   def valid_format?
     return false unless @parsed_ok
     return false unless domain && address == @raw_address
-    return false unless domain.match(/^\S+$/)
+    return false unless domain.match(/\A\S+\z/)
     domain_dot_elements = domain.split(/\./)
     return false unless domain_dot_elements.size > 1 && domain_dot_elements.all?(&:present?)
 

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -22,7 +22,7 @@ class Peoplefinder::EmailAddress
 
   def valid_format?
     return false unless @parsed_ok
-    return false unless address == @raw_address
+    return false unless canonical_address?
     return false unless globally_addressable_domain?
     true
   end
@@ -46,6 +46,10 @@ class Peoplefinder::EmailAddress
 private
 
   attr_reader :valid_login_domains
+
+  def canonical_address?
+    address == @raw_address
+  end
 
   def globally_addressable_domain?
     domain && domain.match(/

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -48,11 +48,15 @@ private
   attr_reader :valid_login_domains
 
   def globally_addressable_domain?
-    return false unless domain
-    return false unless domain.match(/\A\S+\z/)
-    domain_dot_elements = domain.split(/\./)
-    return false unless domain_dot_elements.size > 1 && domain_dot_elements.all?(&:present?)
-    true
+    domain && domain.match(/
+      \A         # beginning of string
+      [^\s\.]+   # domain part (anything except whitespace or dot)
+      (?:        # one or more of:
+        \.       #   dot
+        [^\s\.]+ #   domain part
+      )+         #
+      \z         # end of string
+    /x)
   end
 
   def default_valid_login_domains

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -8,11 +8,9 @@ class Peoplefinder::EmailAddress
   def initialize(string, valid_login_domains = nil)
     @raw_address = string
     @valid_login_domains = valid_login_domains || default_valid_login_domains
-    begin
-      @mail_address = Mail::Address.new(string)
-    rescue Mail::Field::ParseError
-      @parse_error = true
-    end
+    @mail_address = Mail::Address.new(string)
+  rescue Mail::Field::ParseError
+    @parse_error = true
   end
 
   def valid_domain?

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -1,7 +1,6 @@
 require 'peoplefinder'
 
 class Peoplefinder::EmailAddress < Mail::Address
-  VALID_EMAIL_PATTERN = /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/
 
   def initialize(string, valid_login_domains = nil)
     return false unless valid_email_address?(string)

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -21,10 +21,7 @@ class Peoplefinder::EmailAddress
   end
 
   def valid_format?
-    return false unless @parsed_ok
-    return false unless canonical_address?
-    return false unless globally_addressable_domain?
-    true
+    @parsed_ok && canonical_address? && globally_addressable_domain?
   end
 
   def valid_address?

--- a/app/models/peoplefinder/email_address.rb
+++ b/app/models/peoplefinder/email_address.rb
@@ -9,8 +9,9 @@ class Peoplefinder::EmailAddress
     @raw_address = string
     @valid_login_domains = valid_login_domains || default_valid_login_domains
     @mail_address = Mail::Address.new(string)
+    @parsed_ok = true
   rescue Mail::Field::ParseError
-    @parse_error = true
+    @parsed_ok = false
   end
 
   def valid_domain?
@@ -20,7 +21,7 @@ class Peoplefinder::EmailAddress
   end
 
   def valid_format?
-    return false if @parse_error
+    return false unless @parsed_ok
     return false unless domain && address == @raw_address
     return false unless domain.match(/^\S+$/)
     domain_dot_elements = domain.split(/\./)

--- a/spec/models/peoplefinder/email_address_spec.rb
+++ b/spec/models/peoplefinder/email_address_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Peoplefinder::EmailAddress do
 
   subject { described_class.new(email, valid_login_domains) }
 
+  describe '.to_s' do
+    let(:email_string) { 'valid@something.gov.uk' }
+    let(:email_address) { described_class.new(email_string) }
+    it 'returns string passed to initializer' do
+      expect(email_address.to_s).to eq email_string
+    end
+  end
+
   describe '.valid_domain' do
     context 'with strings to match login domains' do
       let(:valid_login_domains) { ['dept.gov.uk'] }

--- a/spec/models/peoplefinder/email_address_spec.rb
+++ b/spec/models/peoplefinder/email_address_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe Peoplefinder::EmailAddress do
     it 'is valid' do
       expect(described_class.new("me@something.gov.uk", valid_login_domains)).to be_valid_address
     end
+
+    it "contains an apostrophe" do
+      expect(described_class.new("michael.o'postrophe@something.gov.uk", valid_login_domains)).to be_valid_address
+    end
   end
 
   context 'name inferral' do

--- a/spec/models/peoplefinder/email_address_spec.rb
+++ b/spec/models/peoplefinder/email_address_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe Peoplefinder::EmailAddress do
     it "contains an apostrophe" do
       expect(described_class.new("michael.o'postrophe@something.gov.uk", valid_login_domains)).to be_valid_address
     end
+
+    it "contains capital letters in the mailbox part" do
+      expect(described_class.new("Important.Person@something.gov.uk", valid_login_domains)).to be_valid_address
+    end
   end
 
   context 'name inferral' do


### PR DESCRIPTION
I don't like that the definition of `valid_email_address?` creates an instance of the superclass here and uses that for validation, but I couldn't see an easy way around it. Rubocop is giving me a cyclomatic complexity error and I suspect this is the reason why.

One option would be to break format validation into it's own separate thing. Thoughts? @threedaymonk 