### PR TITLE
Eliminate unnecessary use of html_safe

### DIFF
--- a/app/helpers/peoplefinder/application_helper.rb
+++ b/app/helpers/peoplefinder/application_helper.rb
@@ -25,7 +25,9 @@ module Peoplefinder
       return if messages.empty?
       content_tag(:div, class: 'inner-block') {
         content_tag(:div, id: 'flash-messages') {
-          messages.map { |type| flash_message(type) }.join.html_safe
+          messages.inject(ActiveSupport::SafeBuffer.new) { |html, type|
+            html << flash_message(type)
+          }
         }
       }
     end
@@ -35,7 +37,7 @@ module Peoplefinder
     end
 
     def info_text(key)
-      t(key, scope: %w[peoplefinder views info_text].join('.')).html_safe
+      t(key, scope: 'peoplefinder.views.info_text')
     end
 
     def page_title

--- a/app/views/peoplefinder/people/_form.html.haml
+++ b/app/views/peoplefinder/people/_form.html.haml
@@ -97,7 +97,7 @@
     .form-group.line-above
       = f.label :tags, class: 'form-label-bold' do
         Skills and expertise
-        %p.form-hint= info_text('skills_and_expertise_hint')
+        %p.form-hint= info_text('skills_and_expertise_hint_html')
 
       #person_tag_chooser
       = hidden_field_tag :tag_list, Peoplefinder::Person.tag_list

--- a/app/views/peoplefinder/shared/_editing_alert.html.haml
+++ b/app/views/peoplefinder/shared/_editing_alert.html.haml
@@ -1,6 +1,6 @@
 .inner-block
   .editing-alert
     - if params['prompt'] == 'profile'
-      = info_text('complete_your_profile_alert')
+      = info_text('complete_your_profile_alert_html')
     - else
       = info_text('editing_alert')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,7 +125,7 @@ en:
     views:
       info_text:
         building_alert: "You are creating a profile - click the Save button to finish"
-        complete_your_profile_alert: "Start building your profile now so colleagues and co-workers can get the latest information on you.<br/>We’ll send you regular reminders until it’s complete."
+        complete_your_profile_alert_html: "Start building your profile now so colleagues and co-workers can get the latest information on you.<br/>We’ll send you regular reminders until it’s complete."
         delete_this_profile: "Delete this profile"
         delete_this_team: "Delete this team"
         duplicate_names_hint: "There are existing profiles that have the same name. Check that it’s not one of these before continuing."
@@ -144,7 +144,7 @@ en:
         reported_profile_additional_details_label: "Additional details (optional)"
         request_information: "Is this profile complete?"
         request_information_link: "Ask the person to update their details"
-        skills_and_expertise_hint: "You can add tags to your profile to allow people to find you based on<br/>your specific skills or expertise. Add them using the field below and<br/>remove them at any time with the ‘X’."
+        skills_and_expertise_hint_html: "You can add tags to your profile to allow people to find you based on<br/>your specific skills or expertise. Add them using the field below and<br/>remove them at any time with the ‘X’."
         team_deletable: "Note that team deletion cannot be undone."
         team_not_deletable: "Team deletion is only possible if there are no people associated with it."
   activerecord:


### PR DESCRIPTION
By using concatenation on a SafeBuffer and `_html` suffixes on keys for translations containing HTML, we make two occurrences of `html_safe` unnecessary.

Fixes #44.