### PR TITLE
Subgroups with long names don't break our grid

### DIFF
--- a/app/assets/stylesheets/peoplefinder/groups.css.scss
+++ b/app/assets/stylesheets/peoplefinder/groups.css.scss
@@ -38,12 +38,14 @@
 }
 .subgroup {
   margin-bottom: 20px;
-  min-height: 220px;
 
   a.subgroup-link-block {
+    position: relative;
     display: block;
     color: $black;
     text-decoration: none;
+    height: 220px;
+    overflow: hidden;
 
     h3 {
       color: $link-colour;
@@ -57,27 +59,22 @@
      color: $link-hover-colour;
     }
 
-    div.about-subgroup {
-      position: relative;
-      height: 200px;
-      overflow: hidden;
-
-      &:before {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        height: 40px;
-        content: '';
-        background: -moz-linear-gradient(top,  rgba(255,255,255,0) 0%, rgba(255,255,255,1) 70%); /* FF3.6+ */
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0)), color-stop(70%,rgba(255,255,255,1))); /* Chrome,Safari4+ */
-        background: -webkit-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* Chrome10+,Safari5.1+ */
-        background: -o-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* Opera 11.10+ */
-        background: -ms-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* IE10+ */
-        background: linear-gradient(to bottom,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* W3C */
-        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=0 ); /* IE6-8 */
-      }
+    &:before {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 40px;
+      content: '';
+      background: -moz-linear-gradient(top,  rgba(255,255,255,0) 0%, rgba(255,255,255,1) 70%); /* FF3.6+ */
+      background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0)), color-stop(70%,rgba(255,255,255,1))); /* Chrome,Safari4+ */
+      background: -webkit-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* Chrome10+,Safari5.1+ */
+      background: -o-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* Opera 11.10+ */
+      background: -ms-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* IE10+ */
+      background: linear-gradient(to bottom,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* W3C */
+      filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=0 ); /* IE6-8 */
     }
+
   }
 
   h3 {


### PR DESCRIPTION
When subgroups had names that span two lines, it used to break our hand-woven fragile grid.

That's not the case anymore.

Addresses:  https://trello.com/c/sflS0NpH/248-layout-issues-on-team-pages