### PR TITLE
Remove team email address

### DIFF
--- a/app/controllers/peoplefinder/groups_controller.rb
+++ b/app/controllers/peoplefinder/groups_controller.rb
@@ -82,7 +82,7 @@ module Peoplefinder
     # through.
     def group_params
       params.require(:group).
-        permit(:parent_id, :name, :description, :team_email_address)
+        permit(:parent_id, :name, :description)
     end
 
     def collection

--- a/app/controllers/peoplefinder/reported_profiles_controller.rb
+++ b/app/controllers/peoplefinder/reported_profiles_controller.rb
@@ -33,7 +33,7 @@ module Peoplefinder
     def init_reported_profile
       @reported_profile = ReportedProfile.new(reported_profile_params)
       @reported_profile.subject = @person
-      @reported_profile.recipient_email = @person.support_email
+      @reported_profile.recipient_email = Rails.configuration.support_email
       @reported_profile.notifier = current_user
     end
   end

--- a/app/models/peoplefinder/group.rb
+++ b/app/models/peoplefinder/group.rb
@@ -25,7 +25,6 @@ class Peoplefinder::Group < ActiveRecord::Base
 
   validates :name, presence: true
   validates :slug, uniqueness: true
-  validates :team_email_address, presence: true
 
   default_scope { order(name: :asc) }
 

--- a/app/models/peoplefinder/person.rb
+++ b/app/models/peoplefinder/person.rb
@@ -75,14 +75,6 @@ class Peoplefinder::Person < ActiveRecord::Base
     return secondary_phone_number if secondary_phone_number.present?
   end
 
-  def support_email
-    if groups.present?
-      groups.first.team_email_address
-    else
-      Rails.configuration.support_email
-    end
-  end
-
   def community_name
     community.try(:name)
   end

--- a/app/views/peoplefinder/groups/_form.html.haml
+++ b/app/views/peoplefinder/groups/_form.html.haml
@@ -39,12 +39,6 @@
               .title= breadcrumbs(@group.parent.path)
             .cta= link_to 'Edit', '#', class: 'show-editable-fields'
 
-  .form-group{ :class => ('gov-uk-field-error' if @group.errors.include?(:team_email_address)) }
-    = f.label :team_email_address, class: 'form-label-bold' do
-      Team email address
-      %span.error= @group.errors[:team_email_address].first if @group.errors.include?(:team_email_address)
-    = f.text_field :team_email_address, class: 'form-control'
-
   .form-group
     = f.submit class: 'button'
     .cancel

--- a/db/migrate/20150219154520_remove_team_email_address_from_group.rb
+++ b/db/migrate/20150219154520_remove_team_email_address_from_group.rb
@@ -1,0 +1,5 @@
+class RemoveTeamEmailAddressFromGroup < ActiveRecord::Migration
+  def change
+    remove_column :groups, :team_email_address
+  end
+end

--- a/spec/controllers/peoplefinder/reported_profiles_controller_spec.rb
+++ b/spec/controllers/peoplefinder/reported_profiles_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Peoplefinder::ReportedProfilesController, type: :controller do
       end
 
       it 'sets the recipient email' do
-        expect(assigns(:reported_profile).recipient_email).to eql(person.support_email)
+        expect(assigns(:reported_profile).recipient_email).to eql(Rails.configuration.support_email)
       end
 
       it 'sets the subject' do

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -72,8 +72,7 @@ CREATE TABLE groups (
     slug character varying(255),
     description text,
     ancestry text,
-    ancestry_depth integer DEFAULT 0 NOT NULL,
-    team_email_address text
+    ancestry_depth integer DEFAULT 0 NOT NULL
 );
 
 

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -607,3 +607,5 @@ INSERT INTO schema_migrations (version) VALUES ('20150212153220');
 INSERT INTO schema_migrations (version) VALUES ('20150213103214');
 
 INSERT INTO schema_migrations (version) VALUES ('20150217105036');
+
+INSERT INTO schema_migrations (version) VALUES ('20150219154520');

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,14 +7,12 @@ FactoryGirl.define do
     initialize_with do
       Peoplefinder::Group.where(ancestry_depth: 0).first_or_create(name: 'Ministry of Justice')
     end
-    team_email_address { generate(:email) }
   end
 
   factory :group, class: 'Peoplefinder::Group' do
     sequence :name do |n|
       'Group-%04d' % n
     end
-    team_email_address { generate(:email) }
     association :parent, factory: :department
   end
 

--- a/spec/features/audit_trail_spec.rb
+++ b/spec/features/audit_trail_spec.rb
@@ -76,7 +76,6 @@ feature 'Audit trail' do
     with_versioning do
       visit new_group_path
       fill_in 'Team name', with: 'Jon'
-      fill_in 'Team email address', with: 'something@example.com'
       click_button 'Save'
 
       visit '/audit_trail'

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -13,7 +13,6 @@ feature 'Group maintenance' do
 
     fill_in 'Team name', with: name
     fill_in 'Team description', with: 'about my team'
-    add_team_email_address
     click_button 'Save'
 
     expect(page).to have_content('Created Ministry of Justice')
@@ -33,7 +32,6 @@ feature 'Group maintenance' do
 
     name = 'CSG'
     fill_in 'Team name', with: name
-    add_team_email_address
     click_button 'Save'
 
     expect(page).to have_content('Created CSG')
@@ -52,7 +50,6 @@ feature 'Group maintenance' do
 
     name = 'Digital Services'
     fill_in 'Team name', with: name
-    add_team_email_address
     click_button 'Save'
 
     expect(page).to have_content('Created Digital Services')
@@ -70,7 +67,6 @@ feature 'Group maintenance' do
 
     fill_in 'Team name', with: 'Digital Services'
     click_on_subteam_in_org_browser 'Corporate Services'
-    add_team_email_address
     click_button 'Save'
 
     within('.breadcrumbs ol') do
@@ -154,7 +150,6 @@ feature 'Group maintenance' do
     expect(page).to have_text('You are currently editing this profile')
 
     fill_in 'Team name', with: 'Digital'
-    add_team_email_address
     click_button 'Save'
     expect(page).to have_selector('.search-box')
     expect(page).not_to have_text('You are currently editing this profile')
@@ -180,9 +175,5 @@ feature 'Group maintenance' do
 
     visit edit_group_path(dept)
     expect(page).not_to have_selector('.org-browser')
-  end
-
-  def add_team_email_address
-    fill_in 'Team email address', with: 'something@example'
   end
 end

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -285,7 +285,7 @@ feature 'Person maintenance' do
     fill_in 'Additional details', with: 'Some stuff'
     expect { click_button 'Submit' }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
-    expect(last_email.to).to include(group.team_email_address)
+    expect(last_email.to).to include(Rails.configuration.support_email)
     expect(last_email.subject).to eql('A People Finder profile has been reported')
     expect(last_email.body.encoded).to have_text('Reason for reporting: Duplicate profile')
     expect(last_email.body.encoded).to have_text('Additional details: Some stuff')

--- a/spec/models/peoplefinder/group_spec.rb
+++ b/spec/models/peoplefinder/group_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Peoplefinder::Group, type: :model do
   it { should have_many(:leaders) }
-  it { should validate_presence_of(:team_email_address) }
 
   it "gives first orphaned groups as department" do
     parent = create(:department)

--- a/spec/models/peoplefinder/person_spec.rb
+++ b/spec/models/peoplefinder/person_spec.rb
@@ -128,27 +128,6 @@ RSpec.describe Peoplefinder::Person, type: :model do
     end
   end
 
-  describe '.support_email' do
-    let(:person) { create(:person) }
-    subject { person.support_email }
-
-    context 'when the the person is a member of a group' do
-      before do
-        person.groups << create(:group, team_email_address: '123@example.com')
-      end
-
-      it 'uses the group email address' do
-        expect(subject).to eql('123@example.com')
-      end
-    end
-
-    context 'when the person is not in a group' do
-      it 'sets the application-wide support email' do
-        expect(subject).to eql(Rails.configuration.support_email)
-      end
-    end
-  end
-
   describe '#tag_list' do
     before do
       create(:person, tags: 'Ruby,Perl,Python')


### PR DESCRIPTION
* it removes the `team_email_address` field from `Group`
* all reported profiles e-mails are sent to the defined support e-mail address