### PR TITLE
Mobile actions

### DIFF
--- a/app/helpers/peoplefinder/application_helper.rb
+++ b/app/helpers/peoplefinder/application_helper.rb
@@ -50,6 +50,12 @@ module Peoplefinder
       ).compact.join(' - ')
     end
 
+    def call_to(telno)
+      return nil unless telno
+      digits = telno.gsub(/[^0-9+#*,]+/, '')
+      content_tag(:a, href: "tel:#{digits}") { telno }
+    end
+
   private
 
     def updated_at(obj)

--- a/app/models/peoplefinder/person.rb
+++ b/app/models/peoplefinder/person.rb
@@ -71,8 +71,7 @@ class Peoplefinder::Person < ActiveRecord::Base
   end
 
   def phone
-    return primary_phone_number if primary_phone_number.present?
-    return secondary_phone_number if secondary_phone_number.present?
+    [primary_phone_number, secondary_phone_number].find(&:present?)
   end
 
   def community_name

--- a/app/views/layouts/peoplefinder/_shared.html.haml
+++ b/app/views/layouts/peoplefinder/_shared.html.haml
@@ -3,3 +3,4 @@
 - content_for :head do
   = stylesheet_link_tag "application"
   = csrf_meta_tag
+  %meta{name: "format-detection", content: "telephone=no"}

--- a/app/views/peoplefinder/people/_person.html.haml
+++ b/app/views/peoplefinder/people/_person.html.haml
@@ -16,7 +16,7 @@
 
           - if feature_enabled?("communities") && person.community.present?
             .meta.community= link_to person.community, search_path(query: person.community.name)
-          .meta= person.phone
+          .meta= call_to(person.phone)
           .meta= mail_to(person.email)
 
     - if edit_link

--- a/app/views/peoplefinder/people/show.html.haml
+++ b/app/views/peoplefinder/people/show.html.haml
@@ -40,11 +40,11 @@
 
         - if @person.primary_phone_number.present?
           %dt.visuallyhidden Primary phone number
-          %dd= @person.primary_phone_number
+          %dd= call_to(@person.primary_phone_number)
 
         - if @person.secondary_phone_number.present?
           %dt.visuallyhidden Other phone number
-          %dd= @person.secondary_phone_number
+          %dd= call_to(@person.secondary_phone_number)
 
       - if @person.description.present?
         %dl

--- a/spec/helpers/peoplefinder/application_helper_spec.rb
+++ b/spec/helpers/peoplefinder/application_helper_spec.rb
@@ -49,4 +49,28 @@ RSpec.describe Peoplefinder::ApplicationHelper, type: :helper do
       expect(fragment).to have_selector('a[href="/teams/digital-services"]', text: 'Digital Services')
     end
   end
+
+  context '#call_to' do
+    it 'returns an a with a tel: href' do
+      generated = call_to('07700900123')
+      fragment = Capybara::Node::Simple.new(generated)
+      expect(fragment).to have_selector('a[href="tel:07700900123"]', text: '07700900123')
+    end
+
+    it 'strips extraneous characters from href' do
+      generated = call_to('07700 900 123')
+      fragment = Capybara::Node::Simple.new(generated)
+      expect(fragment).to have_selector('a[href="tel:07700900123"]')
+    end
+
+    it 'preserves significant non-numeric characters in href' do
+      generated = call_to('+447700900123,,1234#*')
+      fragment = Capybara::Node::Simple.new(generated)
+      expect(fragment).to have_selector('a[href="tel:+447700900123,,1234#*"]')
+    end
+
+    it 'returns nil if telephone number is nil' do
+      expect(call_to(nil)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Mark up telephone numbers with `<a href="tel:…">…</a>` so that you can touch to dial on mobile devices (or anything else that supports the `tel:` scheme).