### PR TITLE
Give Elasticsearch time to index

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,12 @@ AllCops:
     - 'spec/dummy/db/**/*'
   RunRailsCops: true
 
+# You can't use let in a before block, which we need to give Elasticsearch
+# time to index.
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/models/peoplefinder/concerns/searchable_spec.rb'
+
 # private/protected/public
 Style/AccessModifierIndentation:
   EnforcedStyle: outdent

--- a/peoplefinder.gemspec
+++ b/peoplefinder.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'teaspoon'
   s.add_development_dependency 'capybara'
+  s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'minitest'

--- a/spec/models/peoplefinder/concerns/searchable_spec.rb
+++ b/spec/models/peoplefinder/concerns/searchable_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Searchable', elastic: true do # rubocop:disable RSpec/DescribeCl
       @bob.memberships.create(group: digital_services, role: 'Cleaner')
       Peoplefinder::Person.import
       Peoplefinder::Person.__elasticsearch__.client.indices.refresh
-      sleep 1
+      sleep 2
     end
 
     after(:all) do

--- a/spec/models/peoplefinder/concerns/searchable_spec.rb
+++ b/spec/models/peoplefinder/concerns/searchable_spec.rb
@@ -5,22 +5,30 @@ RSpec.describe 'Searchable', elastic: true do # rubocop:disable RSpec/DescribeCl
     clean_up_indexes_and_tables
   end
 
-  let!(:alice) {
-    create(:person, given_name: 'Alice', surname: 'Andrews', community: community)
-  }
-  let!(:bob) {
-    create(:person, given_name: 'Bob', surname: 'Browning',
-           location_in_building: '10th floor', building: '102 Petty France',
-           city: 'London', description: 'weekends only')
-  }
-  let!(:digital_services) { create(:group, name: 'Digital Services') }
-  let!(:membership) { bob.memberships.create(group: digital_services, role: 'Cleaner') }
-  let(:community) { create(:community, name: "Poetry") }
-
   context 'with some people' do
-    before do
+    let(:alice) { @alice }
+    let(:bob) { @bob }
+    let(:community) { @community }
+
+    before(:all) do
+      @community = create(:community, name: "Poetry")
+      @alice = create(:person,
+        given_name: 'Alice', surname: 'Andrews', community: @community
+      )
+      @bob = create(:person,
+        given_name: 'Bob', surname: 'Browning',
+        location_in_building: '10th floor', building: '102 Petty France',
+        city: 'London', description: 'weekends only'
+      )
+      digital_services = create(:group, name: 'Digital Services')
+      @bob.memberships.create(group: digital_services, role: 'Cleaner')
       Peoplefinder::Person.import
       Peoplefinder::Person.__elasticsearch__.client.indices.refresh
+      sleep 1
+    end
+
+    after(:all) do
+      DatabaseCleaner.clean
     end
 
     it 'searches by surname' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,9 @@ Capybara.default_wait_time = 3
 
 require 'site_prism'
 
+require 'database_cleaner'
+DatabaseCleaner.strategy = :truncation
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
The tests, when run via Travis CI, were failing intermittently due to the race between Elasticsearch indexing and the tests running.

As a fix, we'll load up the fixtures for all the tests first, pause for a second (the standard commit time in ES), then run all the specs.