### PR TITLE
Truncate subteam description on index page

### DIFF
--- a/app/views/peoplefinder/groups/_subgroup.html.haml
+++ b/app/views/peoplefinder/groups/_subgroup.html.haml
@@ -2,4 +2,4 @@
   %a.subgroup-link-block.inner-block{ href: url_for(subgroup) }
     %h3= subgroup
     %div.about-subgroup
-      = govspeak(subgroup.description)
+      = govspeak(truncate(subgroup.description, length: 350))


### PR DESCRIPTION
The description is visually truncated, but we don't want to send an excessive amount of text that no one will see. The solution chosen is to truncate the description at a reasonable point that is nonetheless longer than will be displayed. After experimentation, 350 characters seems to work well.