### PR TITLE
Removes the fadeout at the bottom of Subgroups whilst tabbing through

### DIFF
--- a/app/assets/stylesheets/peoplefinder/groups.css.scss
+++ b/app/assets/stylesheets/peoplefinder/groups.css.scss
@@ -59,6 +59,7 @@
      color: $link-hover-colour;
     }
 
+    // fadeout at the bottom
     &:before {
       position: absolute;
       bottom: 0;
@@ -75,6 +76,10 @@
       filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=0 ); /* IE6-8 */
     }
 
+    // removes the fadeout when tabbing along
+    &:focus:before {
+      display: none;
+    }
   }
 
   h3 {

--- a/app/assets/stylesheets/peoplefinder/groups.css.scss
+++ b/app/assets/stylesheets/peoplefinder/groups.css.scss
@@ -59,6 +59,16 @@
      color: $link-hover-colour;
     }
 
+    @mixin vertical-gradient($top-color, $bottom-color) {
+      background: -moz-linear-gradient(top,  $top-color 0%, $bottom-color 70%); /* FF3.6+ */
+      background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,$top-color), color-stop(70%,$bottom-color)); /* Chrome,Safari4+ */
+      background: -webkit-linear-gradient(top, $top-color 0%, $bottom-color 70%); /* Chrome10+,Safari5.1+ */
+      background: -o-linear-gradient(top, $top-color 0%, $bottom-color 70%); /* Opera 11.10+ */
+      background: -ms-linear-gradient(top, $top-color 0%, $bottom-color 70%); /* IE10+ */
+      background: linear-gradient(to bottom,  $top-color 0%, $bottom-color 70%); /* W3C */
+      filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{$top-color}', endColorstr='#{$bottom-color}', GradientType=0); /* IE6-8 */
+    }
+
     // fadeout at the bottom
     &:before {
       position: absolute;
@@ -67,13 +77,7 @@
       right: 0;
       height: 40px;
       content: '';
-      background: -moz-linear-gradient(top,  rgba(255,255,255,0) 0%, rgba(255,255,255,1) 70%); /* FF3.6+ */
-      background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0)), color-stop(70%,rgba(255,255,255,1))); /* Chrome,Safari4+ */
-      background: -webkit-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* Chrome10+,Safari5.1+ */
-      background: -o-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* Opera 11.10+ */
-      background: -ms-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* IE10+ */
-      background: linear-gradient(to bottom,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 70%); /* W3C */
-      filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=0 ); /* IE6-8 */
+      @include vertical-gradient(rgba($white, 0), $white);
     }
 
     // removes the fadeout when tabbing along

--- a/app/assets/stylesheets/peoplefinder/groups.css.scss
+++ b/app/assets/stylesheets/peoplefinder/groups.css.scss
@@ -1,3 +1,5 @@
+$focus-color: #FFBF47;
+
 .group-leader {
   .image-background {
     height: 300px;
@@ -80,9 +82,9 @@
       @include vertical-gradient(rgba($white, 0), $white);
     }
 
-    // removes the fadeout when tabbing along
+    // change colour of fadeout when tabbing along
     &:focus:before {
-      display: none;
+      @include vertical-gradient(rgba($focus-color, 0), $focus-color);
     }
   }
 


### PR DESCRIPTION
![fadeout-before-after](https://cloud.githubusercontent.com/assets/9111/6348517/4fadcfaa-bc18-11e4-80bf-7f6084904823.png)
