### PR TITLE
Expose a simple API so we can show overall completion on Geckoboard

### DIFF
--- a/app/controllers/peoplefinder/metrics/completions_controller.rb
+++ b/app/controllers/peoplefinder/metrics/completions_controller.rb
@@ -1,0 +1,15 @@
+module Peoplefinder
+  module Metrics
+    class CompletionsController < ApplicationController
+      skip_before_action :ensure_user
+
+      def index
+        render json: {
+          'item' => Peoplefinder::Person.overall_completion,
+          'min' => { 'value' => 0 },
+          'max' => { 'value' => 100 }
+        }
+      end
+    end
+  end
+end

--- a/app/models/peoplefinder/concerns/completion.rb
+++ b/app/models/peoplefinder/concerns/completion.rb
@@ -3,25 +3,24 @@ require 'peoplefinder'
 module Peoplefinder::Concerns::Completion
   extend ActiveSupport::Concern
 
+  ADEQUATE_FIELDS = [
+    :image, :location_in_building, :building, :city, :primary_phone_number
+  ]
+
+  COMPLETION_FIELDS = [
+    :given_name, :surname, :email, :location_in_building, :building, :city,
+    :primary_phone_number, :description, :groups, :image
+  ]
+
   included do
-    def completion_score_fields
-      [
-        :given_name, :surname, :email, :location_in_building, :building, :city,
-        :primary_phone_number, :description, :groups, :image
-      ]
-    end
-
     def self.inadequate_profiles
-      fields = [:image, :location_in_building, :building, :city,
-                :primary_phone_number]
-      criteria = fields.map { |f| "COALESCE(#{f}, '') = ''" }.join(' OR ')
-
+      criteria = ADEQUATE_FIELDS.map { |f| "COALESCE(#{f}, '') = ''" }.join(' OR ')
       where(criteria).order(:email)
     end
 
     def completion_score
-      completed = completion_score_fields.map { |f| send(f).present? }
-      (100 * completed.select { |f| f }.length) / completion_score_fields.length
+      completed = COMPLETION_FIELDS.map { |f| send(f).present? }
+      (100 * completed.select { |f| f }.length) / COMPLETION_FIELDS.length
     end
 
     def incomplete?

--- a/app/models/peoplefinder/concerns/completion.rb
+++ b/app/models/peoplefinder/concerns/completion.rb
@@ -18,6 +18,36 @@ module Peoplefinder::Concerns::Completion
       where(criteria).order(:email)
     end
 
+    def self.overall_completion
+      #
+      # Calculate a total completion score. This is the total number of
+      # COMPLETION_FIELDS present across all people in the database.
+      #
+      # Note the oddity with groups: the presence of a group is actually a
+      # question of whether there are one or more memberships associated with
+      # the person. As all the other fields are text, we translate this into
+      # 'Y' or '' to work with the generic CASE + coalesce sum expression
+      # generated from COMPLETION_FIELDS.
+      #
+      sum_expression = COMPLETION_FIELDS.map { |f|
+        "CASE WHEN coalesce(#{f}, '') = '' THEN 0 ELSE 1 END"
+      }.join(' + ')
+      completed_fields = connection.execute(%{
+        SELECT sum(#{sum_expression}) AS completed FROM (
+          SELECT people.*,
+            CASE WHEN count(memberships.id) > 0 THEN 'Y' ELSE '' END AS groups
+          FROM people LEFT OUTER JOIN memberships
+          ON memberships.person_id = people.id
+          GROUP BY people.id) AS subquery
+      })[0]['completed'].to_f
+
+      # Turn it into a percentage. The denominator is the total number of
+      # completed fields possible, i.e. the number of people multiplied by the
+      # number of items in COMPLETION_FIELDS.
+      #
+      (completed_fields * 100.0) / (count * COMPLETION_FIELDS.length)
+    end
+
     def completion_score
       completed = COMPLETION_FIELDS.map { |f| send(f).present? }
       (100 * completed.select { |f| f }.length) / COMPLETION_FIELDS.length

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,8 @@ Peoplefinder::Engine.routes.draw do
   get '/groups/:id', to: redirect('/teams/%{id}')
   get '/groups/:id/edit', to: redirect('/teams/%{id}/edit')
   get '/groups/:id/people', to: redirect('/teams/%{id}/people')
+
+  namespace :metrics do
+    resources :completions, only: [:index]
+  end
 end

--- a/spec/controllers/peoplefinder/metrics/completions_controller_spec.rb
+++ b/spec/controllers/peoplefinder/metrics/completions_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+RSpec.describe Peoplefinder::Metrics::CompletionsController, type: :controller do
+  routes { Peoplefinder::Engine.routes }
+
+  let(:parsed_body) { JSON.parse(response.body) }
+
+  describe 'GET index' do
+    it 'returns JSON for the overall completion score' do
+      allow(Peoplefinder::Person).to receive(:overall_completion).and_return(37)
+      expected = {
+        'item' => 37,
+        'min' => { 'value' => 0 },
+        'max' => { 'value' => 100 }
+      }
+      get :index
+      expect(parsed_body).to eq(expected)
+    end
+
+    it 'returns 200 OK' do
+      get :index
+      expect(response).to be_ok
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,10 @@
 FactoryGirl.define do
-  sequence :email do |n|
-    'example.user.%d@digital.justice.gov.uk' % n
-  end
+  sequence(:email) { |n| 'example.user.%d@digital.justice.gov.uk' % n }
+  sequence(:given_name) { |n| 'First name-%04d' % n }
+  sequence(:surname) { |n| 'Surname-%04d' % n }
+  sequence(:building) { |n| '%d High Street' % n }
+  sequence(:city) { |n| 'Megacity %d' % n }
+  sequence(:phone_number) { |n| '07700 %06d' % (900_000 + n) }
 
   factory :department, class: 'Peoplefinder::Group' do
     initialize_with do
@@ -17,13 +20,9 @@ FactoryGirl.define do
   end
 
   factory :person, class: 'Peoplefinder::Person' do
-    sequence :given_name do |n|
-      'First name-%04d' % n
-    end
-    sequence :surname do |n|
-      'Surname-%04d' % n
-    end
-    email { generate(:email) }
+    given_name
+    surname
+    email
 
     factory :person_with_multiple_logins do
       login_count 10


### PR DESCRIPTION
This calculates the overall completion score across all profiles and exposes it via a Geckoboard-compatible endpoint at `/metrics/completions`.