### PR TITLE
Strip spaces around email when logging in

### DIFF
--- a/app/models/peoplefinder/token.rb
+++ b/app/models/peoplefinder/token.rb
@@ -1,15 +1,14 @@
 require 'peoplefinder'
 
 class Peoplefinder::Token < ActiveRecord::Base
+  include Peoplefinder::Concerns::Sanitisable
+  sanitise_fields :user_email
+
   self.table_name = 'tokens'
 
   after_initialize :generate_value
 
   validate :valid_email_address
-
-  def user_email=(s)
-    super(s && s.strip)
-  end
 
   def to_param
     value

--- a/app/models/peoplefinder/token.rb
+++ b/app/models/peoplefinder/token.rb
@@ -7,6 +7,10 @@ class Peoplefinder::Token < ActiveRecord::Base
 
   validate :valid_email_address
 
+  def user_email=(s)
+    super(s && s.strip)
+  end
+
   def to_param
     value
   end

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -40,6 +40,15 @@ feature 'Token Authentication' do
     expect(last_email.body.encoded).to have_text(token_url(Peoplefinder::Token.last))
   end
 
+  scenario 'copy-pasting an email with extraneous spaces' do
+    visit '/'
+    fill_in 'token_user_email', with: ' correct@digital.justice.gov.uk '
+    click_button 'Use email'
+    expect(page).to have_text('We are sending you a link to log in')
+
+    expect(last_email.to).to include('correct@digital.justice.gov.uk')
+  end
+
   scenario 'following valid link from email and getting prompted to complete my profile' do
     token = create(:token)
     visit token_path(token)

--- a/spec/models/peoplefinder/tokens_spec.rb
+++ b/spec/models/peoplefinder/tokens_spec.rb
@@ -29,11 +29,6 @@ RSpec.describe Peoplefinder::Token, type: :model do
     expect(token).not_to be_valid
   end
 
-  it 'removes whitespace around the email address' do
-    token = build(:token, user_email: '  text.user@digital.justice.gov.uk  ')
-    expect(token.user_email).to eq('text.user@digital.justice.gov.uk')
-  end
-
   describe '#for_person' do
     let(:person) { create(:person, email: 'text.user@digital.justice.gov.uk') }
     let(:token) { described_class.for_person(person) }

--- a/spec/models/peoplefinder/tokens_spec.rb
+++ b/spec/models/peoplefinder/tokens_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe Peoplefinder::Token, type: :model do
     expect(token).not_to be_valid
   end
 
+  it 'removes whitespace around the email address' do
+    token = build(:token, user_email: '  text.user@digital.justice.gov.uk  ')
+    expect(token.user_email).to eq('text.user@digital.justice.gov.uk')
+  end
+
   describe '#for_person' do
     let(:person) { create(:person, email: 'text.user@digital.justice.gov.uk') }
     let(:token) { described_class.for_person(person) }


### PR DESCRIPTION
Some users add spaces to their emails when trying to log in, for reasons unknown (possibly copy and paste). This lets them log in instead of hectoring them with unhelpful error messages.