### PR TITLE
Team subscriptions

### DIFF
--- a/app/controllers/peoplefinder/groups_controller.rb
+++ b/app/controllers/peoplefinder/groups_controller.rb
@@ -50,7 +50,10 @@ module Peoplefinder
 
     # PATCH/PUT /groups/1
     def update
-      if @group.update(group_params)
+      group_update_service = Peoplefinder::GroupUpdateService.new(
+        group: @group, person_responsible: current_user
+      )
+      if group_update_service.update(group_params)
         notice :group_updated, group: @group
         redirect_to @group
       else

--- a/app/controllers/peoplefinder/people_controller.rb
+++ b/app/controllers/peoplefinder/people_controller.rb
@@ -92,7 +92,7 @@ module Peoplefinder
         :primary_phone_number, :secondary_phone_number, :email, :image,
         :image_cache, :description, :tags, :community_id,
         *Person::DAYS_WORKED,
-        memberships_attributes: [:id, :role, :group_id, :leader]
+        memberships_attributes: [:id, :role, :group_id, :leader, :subscribed]
       ]
     end
 

--- a/app/helpers/peoplefinder/application_helper.rb
+++ b/app/helpers/peoplefinder/application_helper.rb
@@ -56,6 +56,17 @@ module Peoplefinder
       content_tag(:a, href: "tel:#{digits}") { telno }
     end
 
+    def role_translate(subject, key, options = {})
+      if subject == current_user
+        subkey = 'mine'
+        user = subject
+      else
+        subkey = 'other'
+        user = current_user
+      end
+      I18n.t([key, subkey].join('.'), options.merge(name: user))
+    end
+
   private
 
     def updated_at(obj)

--- a/app/mailers/peoplefinder/group_update_mailer.rb
+++ b/app/mailers/peoplefinder/group_update_mailer.rb
@@ -1,0 +1,11 @@
+module Peoplefinder
+  class GroupUpdateMailer < ActionMailer::Base
+    def inform_subscriber(recipient, group, person_responsible)
+      @group = group
+      @person_responsible = person_responsible
+      @group_url = group_url(group)
+
+      mail to: recipient.email
+    end
+  end
+end

--- a/app/models/peoplefinder/group.rb
+++ b/app/models/peoplefinder/group.rb
@@ -62,6 +62,10 @@ class Peoplefinder::Group < ActiveRecord::Base
     new_record? || parent.present? || children.empty?
   end
 
+  def subscribers
+    memberships.subscribing.joins(:person).map(&:person)
+  end
+
 private
 
   def name_and_sequence

--- a/app/models/peoplefinder/membership.rb
+++ b/app/models/peoplefinder/membership.rb
@@ -18,4 +18,6 @@ class Peoplefinder::Membership < ActiveRecord::Base
 
   include Peoplefinder::Concerns::ConcatenatedFields
   concatenated_field :to_s, :group_name, :role, join_with: ', '
+
+  scope :subscribing, -> { where(subscribed: true) }
 end

--- a/app/services/peoplefinder/group_update_service.rb
+++ b/app/services/peoplefinder/group_update_service.rb
@@ -8,7 +8,17 @@ module Peoplefinder
     end
 
     def update(params)
-      @group.update(params)
+      @group.update(params).tap { |ok| inform_subscribers if ok }
+    end
+
+  private
+
+    def inform_subscribers
+      @group.subscribers.each do |subscriber|
+        GroupUpdateMailer.
+          inform_subscriber(subscriber, @group, @person_responsible).
+          deliver_later
+      end
     end
   end
 end

--- a/app/services/peoplefinder/group_update_service.rb
+++ b/app/services/peoplefinder/group_update_service.rb
@@ -1,0 +1,14 @@
+require 'peoplefinder'
+
+module Peoplefinder
+  class GroupUpdateService
+    def initialize(group:, person_responsible:)
+      @group = group
+      @person_responsible = person_responsible
+    end
+
+    def update(params)
+      @group.update(params)
+    end
+  end
+end

--- a/app/views/peoplefinder/group_update_mailer/inform_subscriber.erb
+++ b/app/views/peoplefinder/group_update_mailer/inform_subscriber.erb
@@ -1,0 +1,5 @@
+Hi,
+
+The <%= @group %> page on People Finder has been edited by <%= @person_responsible %>.
+
+To see the updated page, visit <%= @group_url %>.

--- a/app/views/peoplefinder/people/_membership_fields.html.haml
+++ b/app/views/peoplefinder/people/_membership_fields.html.haml
@@ -35,6 +35,10 @@
       = membership_f.check_box :leader
       %span.hint This person leads the team above. (More than one person can be selected as team leader.)
 
+      = membership_f.label :subscribed, 'Team updates', class: 'form-label-bold'
+      = membership_f.check_box :subscribed
+      %span.hint Tick this box to alert this person by email whenever anyone edits team details.
+
       .remove-link
         - if membership.new_record?
           = link_to 'Delete', '#', class: 'remove-new-membership'

--- a/app/views/peoplefinder/people/_membership_fields.html.haml
+++ b/app/views/peoplefinder/people/_membership_fields.html.haml
@@ -36,7 +36,7 @@
       %span.hint= role_translate(membership.person, 'peoplefinder.memberships.leader')
 
       = membership_f.label :subscribed, 'Team updates', class: 'form-label-bold'
-      = membership_f.check_box :subscribed
+      = membership_f.check_box :subscribed, class: 'membership-subscribed-check-box'
       %span.hint= role_translate(membership.person, 'peoplefinder.memberships.subscribed')
 
       .remove-link

--- a/app/views/peoplefinder/people/_membership_fields.html.haml
+++ b/app/views/peoplefinder/people/_membership_fields.html.haml
@@ -33,11 +33,11 @@
     .form-group
       = membership_f.label :leader, 'Team leader?', class: 'form-label-bold'
       = membership_f.check_box :leader
-      %span.hint This person leads the team above. (More than one person can be selected as team leader.)
+      %span.hint= role_translate(membership.person, 'peoplefinder.memberships.leader')
 
       = membership_f.label :subscribed, 'Team updates', class: 'form-label-bold'
       = membership_f.check_box :subscribed
-      %span.hint Tick this box to alert this person by email whenever anyone edits team details.
+      %span.hint= role_translate(membership.person, 'peoplefinder.memberships.subscribed')
 
       .remove-link
         - if membership.new_record?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,21 @@ en:
         update_error: "There was an error updating the image"
       reported_profiles:
         message_sent: "Your message has been sent"
+    memberships:
+      leader:
+        mine: |
+          Tick this box if you lead the team above.
+          (More than one person can be selected as team leader.)
+        other: |
+          This person leads the team above.
+          (More than one person can be selected as team leader.)
+      subscribed:
+        mine: |
+          Tick this box if you want to be alerted by email whenever anyone
+          edits team details.
+        other: |
+          Tick this box to alert this person by email whenever anyone edits
+          team details.
     people:
       form:
         notes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,9 @@ en:
         subject: "This email address has been removed from a profile on MOJ People Finder"
       updated_address_to_email:
         subject: "This email address has been added to a profile on MOJ People Finder"
+    group_update_mailer:
+      inform_subscriber:
+        subject: "People Finder team updated"
     errors:
       information_request:
         message_required: "You must enter a message to be sent to the person"

--- a/db/migrate/20150304110649_add_subscribed_to_membership.rb
+++ b/db/migrate/20150304110649_add_subscribed_to_membership.rb
@@ -1,0 +1,5 @@
+class AddSubscribedToMembership < ActiveRecord::Migration
+  def change
+    add_column :memberships, :subscribed, :boolean, default: true, null: false
+  end
+end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -138,7 +138,8 @@ CREATE TABLE memberships (
     role text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    leader boolean DEFAULT false
+    leader boolean DEFAULT false,
+    subscribed boolean DEFAULT true NOT NULL
 );
 
 
@@ -609,3 +610,5 @@ INSERT INTO schema_migrations (version) VALUES ('20150213103214');
 INSERT INTO schema_migrations (version) VALUES ('20150217105036');
 
 INSERT INTO schema_migrations (version) VALUES ('20150219154520');
+
+INSERT INTO schema_migrations (version) VALUES ('20150304110649');

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -96,6 +96,8 @@ feature 'Group maintenance' do
     dept = create(:department)
     org = create(:group, name: 'CSG', parent: dept)
     group = create(:group, name: 'Digital Services', parent: org)
+    subscriber = create(:person)
+    create :membership, person: subscriber, group: group, subscribed: true
 
     javascript_log_in
     visit group_path(group)
@@ -118,6 +120,11 @@ feature 'Group maintenance' do
     group.reload
     expect(group.name).to eql(new_name)
     expect(group.parent).to eql(dept)
+
+    expect(last_email.to).to include(subscriber.email)
+    expect(last_email.subject).to eq('People Finder team updated')
+    expect(page).to have_text(new_name)
+    expect(last_email.body.encoded).to match(group_url(group))
   end
 
   scenario 'Not responding to the selection of impossible parent nodes', js: true do

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -21,6 +21,7 @@ feature "Peoplefinder::Person maintenance" do
     expect(membership.role).to eql('Head Honcho')
     expect(membership.group).to eql(group)
     expect(membership.leader?).to be true
+    expect(membership).to be_subscribed
   end
 
   scenario 'Editing a job title', js: true do
@@ -54,6 +55,21 @@ feature "Peoplefinder::Person maintenance" do
 
     click_button 'Save'
     expect(Peoplefinder::Person.last.memberships.length).to eql(2)
+  end
+
+  scenario 'Unsubscribing from notifications', js: true do
+    person = create_person_in_digital_justice
+
+    javascript_log_in
+    visit edit_person_path(person)
+    click_link 'Edit'
+
+    fill_in 'Job title', with: 'Head Honcho'
+    uncheck 'Team updates'
+    click_button 'Save'
+
+    membership = Peoplefinder::Person.last.memberships.last
+    expect(membership).not_to be_subscribed
   end
 
   scenario 'Clicking the add another role link', js: true do

--- a/spec/helpers/peoplefinder/application_helper_spec.rb
+++ b/spec/helpers/peoplefinder/application_helper_spec.rb
@@ -73,4 +73,22 @@ RSpec.describe Peoplefinder::ApplicationHelper, type: :helper do
       expect(call_to(nil)).to be_nil
     end
   end
+
+  context '#role_translate' do
+    let(:current_user) { build(:person) }
+
+    it 'uses the "mine" translation when the user is the current user' do
+      expect(I18n).to receive(:t).
+        with('foo.bar.mine', hash_including(name: current_user)).
+        and_return('translation')
+      expect(role_translate(current_user, 'foo.bar')).to eq('translation')
+    end
+
+    it 'uses the "other" translation when the user is not the current user' do
+      expect(I18n).to receive(:t).
+        with('foo.bar.other', hash_including(name: current_user)).
+        and_return('translation')
+      expect(role_translate(build(:person), 'foo.bar')).to eq('translation')
+    end
+  end
 end

--- a/spec/mailers/peoplefinder/group_update_mailer_spec.rb
+++ b/spec/mailers/peoplefinder/group_update_mailer_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.configure do |c|
+  c.include Peoplefinder::Engine.routes.url_helpers
+end
+
+RSpec.describe Peoplefinder::GroupUpdateMailer do
+  let(:recipient) { create(:person, email: 'test.user@digital.justice.gov.uk') }
+  let(:person_responsible) { create(:person) }
+  let(:group) { create(:person) }
+
+  describe '.inform_subscriber' do
+    let(:mail) {
+      described_class.inform_subscriber(recipient, group, person_responsible).
+        deliver_now
+    }
+
+    it 'includes the name of the group changed' do
+      expect(mail.body).to have_text(group.name)
+    end
+
+    it 'includes a link to the group changed' do
+      expect(mail.body).to have_text(group_url(group))
+    end
+
+    it 'includes the name of the person who changed the group' do
+      expect(mail.body).to have_text(person_responsible.name)
+    end
+
+    it 'is sent to the recipient' do
+      expect(mail.to).to include(recipient.email)
+    end
+  end
+end

--- a/spec/models/peoplefinder/group_spec.rb
+++ b/spec/models/peoplefinder/group_spec.rb
@@ -186,4 +186,19 @@ RSpec.describe Peoplefinder::Group, type: :model do
       end
     end
   end
+
+  describe '#subscribers' do
+    it 'returns all members with the subscribed flag set' do
+      group = create(:group)
+      subscriber_a = create(:person)
+      subscriber_b = create(:person)
+      non_subscriber = create(:person)
+      _non_member = create(:person)
+      create :membership, person: subscriber_a, group: group, subscribed: true
+      create :membership, person: subscriber_b, group: group, subscribed: true
+      create :membership, person: non_subscriber, group: group, subscribed: false
+
+      expect(group.subscribers).to match_array([subscriber_a, subscriber_b])
+    end
+  end
 end

--- a/spec/models/peoplefinder/membership_spec.rb
+++ b/spec/models/peoplefinder/membership_spec.rb
@@ -4,9 +4,13 @@ RSpec.describe Peoplefinder::Membership, type: :model do
   it { should validate_presence_of(:person).on(:update) }
   it { should validate_presence_of(:group).on(:update) }
 
-  let!(:membership) { create(:membership) }
+  subject { described_class.new }
 
-  it 'is not be a leader by default' do
-    expect(membership.leader?).to be false
+  it 'is not a leader by default' do
+    expect(subject).not_to be_leader
+  end
+
+  it 'is suscribed by default' do
+    expect(subject).to be_subscribed
   end
 end

--- a/spec/services/peoplefinder/group_update_service_spec.rb
+++ b/spec/services/peoplefinder/group_update_service_spec.rb
@@ -11,4 +11,24 @@ RSpec.describe Peoplefinder::GroupUpdateService, type: :service do
     expect(group).to receive(:update).and_return(result)
     expect(subject.update(params)).to eq(result)
   end
+
+  it 'sends an email to each subscriber to the group' do
+    subscribers = create_list(:person, 2)
+    allow(group).to receive(:subscribers).and_return(subscribers)
+    email_1 = double(Mail::Message)
+    email_2 = double(Mail::Message)
+
+    expect(Peoplefinder::GroupUpdateMailer).
+      to receive(:inform_subscriber).
+      with(subscribers[0], group, person_responsible).
+      and_return(email_1)
+    expect(Peoplefinder::GroupUpdateMailer).
+      to receive(:inform_subscriber).
+      with(subscribers[1], group, person_responsible).
+      and_return(email_2)
+    expect(email_1).to receive(:deliver_later)
+    expect(email_2).to receive(:deliver_later)
+
+    subject.update({})
+  end
 end

--- a/spec/services/peoplefinder/group_update_service_spec.rb
+++ b/spec/services/peoplefinder/group_update_service_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Peoplefinder::GroupUpdateService, type: :service do
+  let(:group) { build(:group) }
+  let(:person_responsible) { build(:person) }
+  subject { described_class.new(group: group, person_responsible: person_responsible) }
+
+  it 'updates the group with the supplied parameters and returns the result' do
+    params = double(Hash)
+    result = Object.new
+    expect(group).to receive(:update).and_return(result)
+    expect(subject.update(params)).to eq(result)
+  end
+end


### PR DESCRIPTION
Adds a checkbox on the profile edit page, when editing the team, to (un)subscribe the person to/from email notifications when the team changes.

Email copy is just a placeholder, and yet to be confirmed.