### PR TITLE
Don't show team label if team is top level

### DIFF
--- a/app/views/peoplefinder/people/show.html.haml
+++ b/app/views/peoplefinder/people/show.html.haml
@@ -21,9 +21,10 @@
     .inner-block
       - @person.memberships.each do |membership|
         %h3= membership.role
-        %dl.inline-labels.role-and-location
-          %dt Team
-          %dd.breadcrumbs= breadcrumbs(membership.path.drop(1))
+        - if membership.path.length > 1
+          %dl.inline-labels.role-and-location
+            %dt Team
+            %dd.breadcrumbs= breadcrumbs(membership.path.drop(1))
 
       %dl.inline-labels
         - if feature_enabled?(:communities)


### PR DESCRIPTION
Fixes the layout for the Permanent Secretary.