### PR TITLE
Show default placeholder for team description

### DIFF
--- a/app/models/peoplefinder/concerns/placeholder.rb
+++ b/app/models/peoplefinder/concerns/placeholder.rb
@@ -1,0 +1,14 @@
+require 'peoplefinder'
+
+module Peoplefinder::Concerns::Placeholder
+  extend ActiveSupport::Concern
+
+  def placeholder(field)
+    I18n.t(field, scope: "placeholders.#{self.class.model_name.i18n_key}")
+  end
+
+  def with_placeholder_default(field)
+    value = send(field)
+    value.blank? ? placeholder(field) : value
+  end
+end

--- a/app/models/peoplefinder/group.rb
+++ b/app/models/peoplefinder/group.rb
@@ -4,6 +4,7 @@ class Peoplefinder::Group < ActiveRecord::Base
   self.table_name = 'groups'
 
   include Peoplefinder::Concerns::Hierarchical
+  include Peoplefinder::Concerns::Placeholder
 
   MAX_DESCRIPTION = 1000
 

--- a/app/views/peoplefinder/groups/_detail.html.haml
+++ b/app/views/peoplefinder/groups/_detail.html.haml
@@ -10,5 +10,5 @@
   %div.grid.grid-2-3
     %div.inner-block.about.text
       %h3 About the team
-      = govspeak(@group.description)
+      = govspeak(@group.with_placeholder_default(:description))
 

--- a/app/views/peoplefinder/groups/_form.html.haml
+++ b/app/views/peoplefinder/groups/_form.html.haml
@@ -20,7 +20,7 @@
       Team description
       %p.form-hint= info_text('hint_team_description')
     - text_limit = Peoplefinder::Group::MAX_DESCRIPTION # to be replaced with a variable
-    = f.text_area :description, class: 'form-control', "data-limit" => text_limit
+    = f.text_area :description, class: 'form-control', placeholder: f.object.placeholder(:description), "data-limit" => text_limit
 
   - if @group.editable_parent?
     .form-group.group-parent.editable-container

--- a/app/views/peoplefinder/groups/_subgroup.html.haml
+++ b/app/views/peoplefinder/groups/_subgroup.html.haml
@@ -2,4 +2,4 @@
   %a.subgroup-link-block.inner-block{ href: url_for(subgroup) }
     %h3= subgroup
     %div.about-subgroup
-      = govspeak(truncate(subgroup.description, length: 350))
+      = govspeak(truncate(subgroup.with_placeholder_default(:description), length: 350))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,6 +186,10 @@ en:
         skills_and_expertise_hint_html: "You can add tags to your profile to allow people to find you based on<br/>your specific skills or expertise. Add them using the field below and<br/>remove them at any time with the ‘X’."
         team_deletable: "Note that team deletion cannot be undone."
         team_not_deletable: "Team deletion is only possible if there are no people associated with it."
+  placeholders:
+    peoplefinder/group:
+      description: |
+        Discover what this team is responsible for, who is in it and how you can get in touch with them.
   activerecord:
     errors:
       messages:

--- a/spec/models/peoplefinder/concerns/placeholder_spec.rb
+++ b/spec/models/peoplefinder/concerns/placeholder_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Peoplefinder::Concerns::Placeholder do
+
+  class TestModel
+    extend ActiveModel::Naming
+    include Peoplefinder::Concerns::Placeholder
+    attr_accessor :field
+  end
+
+  subject { TestModel.new }
+
+  describe '#placeholder' do
+    it 'looks up placeholder text via I18n' do
+      expect(subject.placeholder(:field)).
+        to eq('translation missing: en.placeholders.test_model.field')
+    end
+  end
+
+  describe '#with_placeholder_default' do
+    it 'returns the value of a field if present' do
+      subject.field = 'EXAMPLE TEXT'
+      expect(subject.with_placeholder_default(:field)).
+        to eq('EXAMPLE TEXT')
+    end
+
+    it 'returns the placeholder text if field is blank' do
+      subject.field = ''
+      expect(subject.with_placeholder_default(:field)).
+        to eq('translation missing: en.placeholders.test_model.field')
+    end
+  end
+end


### PR DESCRIPTION
* When editing, the placeholder text is displayed in an empty textarea via the placeholder HTML attribute.
* When viewing, the placeholder is shown instead of the description if the description is blank.