### PR TITLE
Style lists only within a container

### DIFF
--- a/app/assets/stylesheets/peoplefinder/application.scss
+++ b/app/assets/stylesheets/peoplefinder/application.scss
@@ -392,14 +392,16 @@ textarea.form-control {
   }
 }
 
-ul li {
-  list-style-type: disc;
-  margin-left: 20px;
-}
+.formatted-text {
+  ul li {
+    list-style-type: disc;
+    margin-left: 20px;
+  }
 
-ol li {
-  list-style-type: decimal;
-  margin-left: 25px;
+  ol li {
+    list-style-type: decimal;
+    margin-left: 25px;
+  }
 }
 
 @import 'retinal_images';

--- a/app/views/peoplefinder/groups/_detail.html.haml
+++ b/app/views/peoplefinder/groups/_detail.html.haml
@@ -10,5 +10,6 @@
   %div.grid.grid-2-3
     %div.inner-block.about.text
       %h3 About the team
-      = govspeak(@group.with_placeholder_default(:description))
+      .formatted-text
+        = govspeak(@group.with_placeholder_default(:description))
 

--- a/app/views/peoplefinder/groups/_subgroup.html.haml
+++ b/app/views/peoplefinder/groups/_subgroup.html.haml
@@ -2,4 +2,5 @@
   %a.subgroup-link-block.inner-block{ href: url_for(subgroup) }
     %h3= subgroup
     %div.about-subgroup
-      = govspeak(truncate(subgroup.with_placeholder_default(:description), length: 350))
+      .formatted-text
+        = govspeak(truncate(subgroup.with_placeholder_default(:description), length: 350))


### PR DESCRIPTION
The navigation bar was made weird by the additional indentation. We only need the styling within formatted text that's being generated via Markdown, so we'll wrap it in a formatted-text class and apply the style only within that.