### PR TITLE
Adds default permitted domains on rake db:seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,7 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+Dir[Rails.root.join('db', 'seeds', '*.rb')].each do |seed|
+  require seed
+end

--- a/db/seeds/data/permitted_domains.yml
+++ b/db/seeds/data/permitted_domains.yml
@@ -1,0 +1,13 @@
+- cjs.gsi.gov.uk
+- digital.cabinet-office.gov.uk
+- digital.justice.gov.uk
+- hmcourts-service.gsi.gov.uk
+- hmcts.gsi.gov.uk
+- hmps.gsi.gov.uk
+- homeoffice.gsi.gov.uk
+- ips.gsi.gov.uk
+- justice.gsi.gov.uk
+- legalaid.gsi.gov.uk
+- noms.gsi.gov.uk
+- publicguardian.gsi.gov.uk
+- yjb.gsi.gov.uk

--- a/db/seeds/permitted_domains.rb
+++ b/db/seeds/permitted_domains.rb
@@ -1,0 +1,10 @@
+require 'yaml'
+
+data_file = Rails.root.join('db', 'seeds', 'data', 'permitted_domains.yml')
+domains   = YAML.load_file(data_file)
+
+domains.each do |domain|
+  PermittedDomain.find_or_create_by(domain: domain)
+end
+
+


### PR DESCRIPTION
Hi @threedaymonk, this adds the domains we're currently using to validate email addresses to the database when you run `rake db:seed` as discussed.

I need to merge this and get Kyriakos to run `rake db:seed` on production before we can actually add the code that checks against these rather than read the domains out of config.