### PR TITLE
removing tags from profile view

### DIFF
--- a/app/views/people/_show_tags.html.haml
+++ b/app/views/people/_show_tags.html.haml
@@ -1,6 +1,0 @@
-- if @person.tags.present?
-  .spacer-25
-  %ul.tags
-    %h4 Skills and expertise
-    - @person.tags.split(',').each do |tag|
-      %li= link_to tag, search_path(query: tag)

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -51,8 +51,6 @@
         %h5 Extra information:
         %p= @person.description
 
-      - if feature_enabled?(:profile_tags)
-        = render partial: "show_tags"
 
 - if @person.email.present?
   - if current_user.email == @person.email


### PR DESCRIPTION
Removed tags from the profile view & deleted the partial.

As far as I can see we shouldn't need to do anything else. Can't see anyway to enter tags on the form