### PR TITLE
Databasify domain validation 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ defined on a per environment basis.
 
 `config.support_email` e.g. 'peoplefinder-support@example.com'
 
-`config.valid_login_domains` Restrict login to email addresses from domains that match the string or regular expresson. e.g. `[/(.*)\.gov\.uk\Z/, 'example.com']`
-
 ## Authentication
 
 Authentication requires two environment variables. You can obtain these by

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -58,7 +58,7 @@ private
   end
 
   def default_valid_login_domains
-    Rails.configuration.try(:valid_login_domains) || []
+    PermittedDomain.pluck(:domain)
   end
 
   def capitalise(word)

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,22 +57,6 @@ module Peoplefinder
 
     config.action_mailer.asset_host = ENV['ACTION_MAILER_DEFAULT_URL']
 
-    config.valid_login_domains = %w[
-      cjs.gsi.gov.uk
-      digital.cabinet-office.gov.uk
-      digital.justice.gov.uk
-      hmcourts-service.gsi.gov.uk
-      hmcts.gsi.gov.uk
-      hmps.gsi.gov.uk
-      homeoffice.gsi.gov.uk
-      ips.gsi.gov.uk
-      justice.gsi.gov.uk
-      legalaid.gsi.gov.uk
-      noms.gsi.gov.uk
-      publicguardian.gsi.gov.uk
-      yjb.gsi.gov.uk
-    ]
-
     # The following values are required by the phase banner
     config.phase = 'beta'
     config.feedback_url = 'https://docs.google.com/a/digital.justice.gov.uk/forms/d/1dJ9xQ66QFvk8K7raf60W4ZXfK4yTQ1U3EeO4OLLlq88/viewform'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,15 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-Dir[Rails.root.join('db', 'seeds', '*.rb')].each do |seed|
-  require seed
-end
+# HEY YOU! YES YOU. This comment is important. Expect `rake db:seed` to be run
+# in all environments at random. Along with being run as part of `rake
+# db:setup`, it might be run on server restart, on building an environment,
+# whenever Jupiter is in aphelion, when the wolf lies with the lamb, etc.
+#
+# This means anything it runs should be idempotent (i.e. running `rake db:seed`
+# multiple times should have the same end result as running it once). See
+# `permitted_domains.rb` for an example of this.
+
+$:.unshift(Rails.root.join('db', 'seeds'))
+
+require 'permitted_domains'

--- a/docker/rails/unicorn.service
+++ b/docker/rails/unicorn.service
@@ -10,16 +10,16 @@ if [ -z "$APP_MASTER_SERVER" -o "$APPHOST" == "$APP_MASTER_SERVER" ]; then
         echo "running db:reset"     >>/rails/log/unicorn.log
         bundle exec rake db:reset >>/rails/log/unicorn.log 2>&1
         ;;
-    seed)
-        echo "running db:seed"     >>/rails/log/unicorn.log
-        bundle exec rake db:seed >>/rails/log/unicorn.log 2>&1
     esac
+
+    echo "running migrate"        >>/rails/log/unicorn.log
+    bundle exec rake db:migrate   >>/rails/log/unicorn.log 2>&1
+
+    echo "running db:seed"     >>/rails/log/unicorn.log
+    bundle exec rake db:seed >>/rails/log/unicorn.log 2>&1
 else
     echo "Slave server: skipping DB and cron configuration"   >>/rails/log/unicorn.log
 fi
-
-echo "running migrate"        >>/rails/log/unicorn.log
-bundle exec rake db:migrate   >>/rails/log/unicorn.log 2>&1
 
 rm /tmp/db.lock
 # Increment restart metric

--- a/spec/controllers/api/people_controller_spec.rb
+++ b/spec/controllers/api/people_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Api::PeopleController, type: :controller do
+  include PermittedDomainHelper
+
   # This should return the minimal set of attributes required to create a valid
   # Person. As you add validations to Person, be sure to
   # adjust the attributes here as well.

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -19,6 +19,8 @@ require 'rails_helper'
 # that an instance is receiving a specific message.
 
 RSpec.describe GroupsController, type: :controller do
+  include PermittedDomainHelper
+
   before do
     mock_logged_in_user
   end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
+  include PermittedDomainHelper
+
   before do
     mock_logged_in_user
   end

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe MembershipsController, type: :controller do
+  include PermittedDomainHelper
+
   before do
     mock_logged_in_user
   end

--- a/spec/controllers/metrics/profiles_controller_spec.rb
+++ b/spec/controllers/metrics/profiles_controller_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 RSpec.describe Metrics::ProfilesController, type: :controller do
+  include PermittedDomainHelper
+
   let(:parsed_body) { JSON.parse(response.body) }
 
   describe 'GET index' do

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PeopleController, type: :controller do
+  include PermittedDomainHelper
+
   before do
     mock_logged_in_user
   end

--- a/spec/controllers/person_image_controller_spec.rb
+++ b/spec/controllers/person_image_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PersonImageController, type: :controller do
+  include PermittedDomainHelper
+
   before do
     mock_logged_in_user
   end

--- a/spec/controllers/suggestions_controller_spec.rb
+++ b/spec/controllers/suggestions_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SuggestionsController, type: :controller do
+  include PermittedDomainHelper
+
   before do
     mock_logged_in_user
   end

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe VersionsController, type: :controller do
+  include PermittedDomainHelper
   before do
     mock_logged_in_user
   end

--- a/spec/features/audit_trail_spec.rb
+++ b/spec/features/audit_trail_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Audit trail' do
+  include PermittedDomainHelper
+
   before do
     omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
   end

--- a/spec/features/group_audit_spec.rb
+++ b/spec/features/group_audit_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 feature 'View group audit' do
+  include PermittedDomainHelper
   let(:super_admin_email)  { 'test.user@digital.justice.gov.uk' }
   let!(:super_admin)  { create(:super_admin, email: super_admin_email) }
 

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Group browsing' do
+  include PermittedDomainHelper
+
   let!(:department) { create(:department) }
   let!(:team) { create(:group, name: 'A Team', parent: department) }
   let!(:subteam) { create(:group, name: 'A Subteam', parent: team) }

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 feature 'Group maintenance' do
+  include PermittedDomainHelper
   include ActiveJobHelper
 
   before do

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Home page' do
+  include PermittedDomainHelper
+
   before do
     create(:department)
     omni_auth_log_in_as 'test.user@digital.justice.gov.uk'

--- a/spec/features/login_flow_spec.rb
+++ b/spec/features/login_flow_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Login flow' do
+  include PermittedDomainHelper
+
   let(:email) { 'test.user@digital.justice.gov.uk' }
   let!(:department) { create(:department) }
   let(:current_time) { Time.now }

--- a/spec/features/omni_auth_authentication_spec.rb
+++ b/spec/features/omni_auth_authentication_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'OmniAuth Authentication' do
+  include PermittedDomainHelper
+
   let(:login_page) { Pages::Login.new }
 
   before do

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'View person audit' do
+  include PermittedDomainHelper
+
   let(:super_admin_email)  { 'test.user@digital.justice.gov.uk' }
   let!(:super_admin)  { create(:super_admin, email: super_admin_email) }
 

--- a/spec/features/person_browsing_spec.rb
+++ b/spec/features/person_browsing_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Person browsing' do
+  include PermittedDomainHelper
+
   before do
     omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
   end

--- a/spec/features/person_communities_spec.rb
+++ b/spec/features/person_communities_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 feature "Communities" do
   extend FeatureFlagSpecHelper
+  include PermittedDomainHelper
+
   enable_feature :communities
 
   before do

--- a/spec/features/person_edit_notifications_spec.rb
+++ b/spec/features/person_edit_notifications_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Person edit notifications' do
   include ActiveJobHelper
+  include PermittedDomainHelper
 
   let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
   before do

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 feature 'Person maintenance' do
+  include PermittedDomainHelper
 
   let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
   before do

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature "Person maintenance" do
+  include PermittedDomainHelper
+
   before do
     omni_auth_log_in_as 'test.user@digital.justice.gov.uk'
   end

--- a/spec/features/regression_spec.rb
+++ b/spec/features/regression_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Regression' do
+  include PermittedDomainHelper
+
   let(:login_page) { Pages::Login.new }
 
   before do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 feature 'Search for people', elastic: true do
   extend FeatureFlagSpecHelper
+  include PermittedDomainHelper
+
   enable_feature :communities
 
   describe 'with elasticsearch' do

--- a/spec/features/suggestion_spec.rb
+++ b/spec/features/suggestion_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Make a suggestion about a profile', js: true do
   include ActiveJobHelper
+  include PermittedDomainHelper
 
   let(:me) { create(:person) }
   let(:leader) { create(:person) }

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -7,6 +7,7 @@ end
 
 feature 'Token Authentication' do
   include ActiveJobHelper
+  include PermittedDomainHelper
 
   let(:login_page) { Pages::Login.new }
 

--- a/spec/mailers/group_update_mailer_spec.rb
+++ b/spec/mailers/group_update_mailer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe GroupUpdateMailer do
+  include PermittedDomainHelper
+
   let(:recipient) { create(:person, email: 'test.user@digital.justice.gov.uk') }
   let(:person_responsible) { create(:person) }
   let(:group) { create(:person) }

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ReminderMailer do
+  include PermittedDomainHelper
+
   describe '.inadequate_profile' do
     let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
     let(:mail) { described_class.inadequate_profile(person).deliver_now }

--- a/spec/mailers/suggestion_mailer_spec.rb
+++ b/spec/mailers/suggestion_mailer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SuggestionMailer do
+  include PermittedDomainHelper
+
   let(:suggester) { create(:person, email: 'suggester@digital.justice.gov.uk') }
   let(:person)    { create(:person, email: 'person@digital.justice.gov.uk') }
   let(:admin)     { create(:person,  email: 'admin@digital.justice.gov.uk') }

--- a/spec/mailers/user_update_mailer_spec.rb
+++ b/spec/mailers/user_update_mailer_spec.rb
@@ -16,6 +16,8 @@ RSpec.shared_examples "observe token_auth feature flag" do
 end
 
 RSpec.describe UserUpdateMailer do
+  include PermittedDomainHelper
+
   let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
 
   describe ".new_profile_email" do

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Community, type: :model do
+  include PermittedDomainHelper
+
   let(:person) { create(:person) }
   let(:community) { create(:community) }
   let(:reloaded_person) { Person.find(person.id) }

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
+  include PermittedDomainHelper
 
   context '#completion score' do
     it 'returns 0 if all fields are empty' do

--- a/spec/models/concerns/work_days_spec.rb
+++ b/spec/models/concerns/work_days_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Concerns::WorkDays do
+  include PermittedDomainHelper
 
   describe '.works_weekends?' do
     let(:weekday_person) { create(:person) }

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do
+  include PermittedDomainHelper
+
   it { should have_many(:leaders) }
   it { should validate_length_of(:description).is_at_most(1000) }
 

--- a/spec/models/person_search_spec.rb
+++ b/spec/models/person_search_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Person, elastic: true do
+  include PermittedDomainHelper
+
   after(:all) do
     clean_up_indexes_and_tables
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Person, type: :model do
+  include PermittedDomainHelper
+
   let(:person) { build(:person) }
   it { should validate_presence_of(:given_name).on(:update) }
   it { should validate_presence_of(:surname) }

--- a/spec/models/tokens_spec.rb
+++ b/spec/models/tokens_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Token, type: :model do
+  include PermittedDomainHelper
+
   it 'generates a token' do
     token = create(:token)
     expect(token.value).to match(/\A[a-z0-9\-]{36}\z/)

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Version, type: :model do
+  include PermittedDomainHelper
+
   context 'whodunnit' do
     let(:author) { create(:person) }
 

--- a/spec/services/csv_people_importer_spec.rb
+++ b/spec/services/csv_people_importer_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CsvPeopleImporter, type: :service do
 
   before do
-    allow(Rails.configuration).to receive(:valid_login_domains).and_return(['valid.gov.uk'])
+    allow(PermittedDomain).to receive(:pluck).with(:domain).and_return(['valid.gov.uk'])
   end
 
   subject(:importer) { described_class.new(csv) }

--- a/spec/services/find_create_person_spec.rb
+++ b/spec/services/find_create_person_spec.rb
@@ -21,6 +21,8 @@ shared_examples 'new person created' do
 end
 
 RSpec.describe FindCreatePerson, type: :service do
+  include PermittedDomainHelper
+
   let(:valid_auth_hash) do
     {
       'info' => {

--- a/spec/services/group_update_service_spec.rb
+++ b/spec/services/group_update_service_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe GroupUpdateService, type: :service do
+  include PermittedDomainHelper
+
   let(:group) { build(:group) }
   let(:person_responsible) { build(:person) }
   subject { described_class.new(group: group, person_responsible: person_responsible) }

--- a/spec/services/login_spec.rb
+++ b/spec/services/login_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Login, type: :service do
+  include PermittedDomainHelper
 
   let(:session) { {} }
   let(:person) { create(:person) }

--- a/spec/services/random_generator_spec.rb
+++ b/spec/services/random_generator_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe RandomGenerator do
+  include PermittedDomainHelper
+
   let(:group) { create(:group) }
   subject { described_class.new(group) }
 

--- a/spec/support/permitted_domain_helper.rb
+++ b/spec/support/permitted_domain_helper.rb
@@ -1,0 +1,9 @@
+module PermittedDomainHelper
+  extend ActiveSupport::Concern
+
+  included do
+    before do
+      PermittedDomain.find_or_create_by(domain: 'digital.justice.gov.uk')
+    end
+  end
+end

--- a/spec/uploaders/peoplefinder/image_uploader_spec.rb
+++ b/spec/uploaders/peoplefinder/image_uploader_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ImageUploader, type: :uploader do
   include CarrierWave::Test::Matchers
+  include PermittedDomainHelper
+
   let(:person) { create(:person, image: File.open(sample_image)) }
 
   before do

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EmailValidator do
   end
 
   before do
-    allow(Rails.configuration).to receive(:valid_login_domains).and_return(['valid.gov.uk'])
+    allow(PermittedDomain).to receive(:pluck).with(:domain).and_return(['valid.gov.uk'])
   end
 
   subject { TestModel.new(email: email) }


### PR DESCRIPTION
Card on trello: https://trello.com/c/evh4Vq08

This changeset contains modifications to:

*  `db/seeds.rb` [that make it more likely a developer will see the note about making all seeds idempotent](https://github.com/ministryofjustice/peoplefinder/blob/databasify-domain-validation-2/db/seeds.rb) (as discussed with @threedaymonk).
*  `docker/rails/unicorn-service.sh` [that make the ops magic run migrations/seeds on unicorn restart](https://github.com/ministryofjustice/peoplefinder/blob/databasify-domain-validation-2/docker/rails/unicorn.service) (specifically only once on multi-server depoys), (as discussed with @koikonom).
* `app/models/email_address.rb` [that makes it use the permitted_domains table to validate email addresses](https://github.com/ministryofjustice/peoplefinder/blob/databasify-domain-validation-2/app/models/email_address.rb#L61).

In theory that means merging these changes won't in fact break the site, which would be nice! Any comments/feedback appreciated.