### PR TITLE
Make group selector database-efficient

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -47,11 +47,6 @@ class Group < ActiveRecord::Base
     name
   end
 
-  def name_with_path
-    return name if ancestors.empty?
-    "#{name} [#{ancestors.join ' > '}]"
-  end
-
   def deletable?
     leaf_node? && memberships.reject(&:new_record?).empty?
   end

--- a/app/services/group_lister.rb
+++ b/app/services/group_lister.rb
@@ -1,0 +1,53 @@
+class GroupLister
+  class ListedGroup
+    attr_reader :id, :parent_id, :name
+
+    def initialize(index, group)
+      @index = index
+      @id = group.id
+      @parent_id = group.ancestor_ids.last
+      @name = group.name
+    end
+
+    def parent
+      parent_id && @index[parent_id]
+    end
+
+    def path
+      parent ? parent.path + [self] : [self]
+    end
+
+    def ancestors
+      path[0..-2]
+    end
+
+    def to_s
+      name
+    end
+
+    def name_with_path
+      return name if ancestors.empty?
+      "#{name} [#{ancestors.join(' > ')}]"
+    end
+  end
+
+  def initialize(max_depth = nil)
+    @scope = scope_with_maximum_depth(max_depth)
+  end
+
+  def list
+    index = {}
+    @scope.all.each do |group|
+      index[group.id] = ListedGroup.new(index, group)
+    end
+    index.values
+  end
+
+private
+
+  def scope_with_maximum_depth(max_depth)
+    return Group unless max_depth
+    tbl = Group.arel_table
+    Group.where(tbl[:ancestry_depth].lt(max_depth))
+  end
+end

--- a/app/views/people/_membership_fields.html.haml
+++ b/app/views/people/_membership_fields.html.haml
@@ -8,7 +8,7 @@
     = membership_f.label :group_id, 'Team', class: 'form-label-bold'
     %p.form-hint= info_text('hint_add_person_to_team')
     = membership_f.collection_select :group_id,
-      Group.all.sort_by { |g| g.path.map(&:to_s) },
+      GroupLister.new.list.sort_by { |g| g.path.map(&:to_s) },
       :id, :name_with_path, {}, class: 'form-control select-autocomplete team-select'
 
   .form-group

--- a/spec/services/group_lister_spec.rb
+++ b/spec/services/group_lister_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe GroupLister, type: :service do
+  let!(:department) { create(:department, name: 'A Department') }
+  let!(:team) { create(:group, name: 'A Team', parent: department) }
+  let!(:subteam) { create(:group, name: 'A Subteam', parent: team) }
+  let!(:leaf_node) { create(:group, name: 'A Leaf Node', parent: subteam) }
+
+  context 'with no maximum depth' do
+    subject { described_class.new }
+
+    let(:list) { subject.list }
+
+    it 'returns an array of group-like objects' do
+      expect(list.length).to eq(4)
+      expect(list.first).to be_kind_of(described_class::ListedGroup)
+    end
+  end
+
+  context 'with maximum depth' do
+    subject { described_class.new(2) }
+
+    let(:list) { subject.list }
+
+    it 'returns objects only to specified depth' do
+      ids = list.map(&:id).sort
+      expect(ids).to eq([department.id, team.id])
+    end
+  end
+
+  context 'a node with a hierarchy' do
+    subject { described_class.new.list.sort_by(&:id).last }
+
+    it 'has the name of the group' do
+      expect(subject.name).to eq(leaf_node.name)
+    end
+
+    it 'has a parent id' do
+      expect(subject.parent_id).to eql(subteam.id)
+    end
+
+    it 'has a parent' do
+      expect(subject.parent).to be_kind_of(described_class::ListedGroup)
+      expect(subject.parent.id).to eq(subteam.id)
+    end
+
+    it 'returns the name with path of each object' do
+      expect(subject.name_with_path).
+        to eq("A Leaf Node [A Department > A Team > A Subteam]")
+    end
+
+    it 'returns the ancestors of each node' do
+      expect(subject.ancestors.map(&:id)).
+        to eq([department.id, team.id, subteam.id])
+      expect(subject.ancestors.first).
+        to be_kind_of(described_class::ListedGroup)
+    end
+
+    it 'returns the path of each node' do
+      expect(subject.path.map(&:id)).
+        to eq([department.id, team.id, subteam.id, leaf_node.id])
+      expect(subject.path.first).
+        to be_kind_of(described_class::ListedGroup)
+    end
+  end
+
+  context 'a top-level node' do
+    subject { described_class.new.list.sort_by(&:id).first }
+
+    it 'has nil parent id' do
+      expect(subject.parent_id).to be_nil
+    end
+
+    it 'has nil parent' do
+      expect(subject.parent).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes #109 by building an array of lightweight objects from a single query.