### PR TITLE
Use the same upload path as in the engine era

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -9,7 +9,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    '%suploads/%s/%s/%s' % [
+    '%suploads/peoplefinder/%s/%s/%s' % [
       base_upload_dir,
       model.class.to_s.underscore,
       mounted_as,


### PR DESCRIPTION
Because we've changed the model namespace (from `Peoplefinder::Person` to `Person`), the implicitly-computed upload paths have changed and all the old pictures don't work.

I'd rather have the directory set explicitly for each model, rather than relying on the class name, but this is a quick fix for the immediate problem.