### PR TITLE
:cop: Throttle generation of auth tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ GPLUS_CLIENT_ID=your_gplus_client_id
 GPLUS_CLIENT_SECRET=your_gplus_client_secret
 SSL_ON=false
 GA_TRACKING_ID=UA-XXXXX-X
+MAX_TOKENS_PER_HOUR=8

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -3,6 +3,8 @@ class TokensController < ApplicationController
   before_action :set_desired_path, only: [:show]
   before_action :ensure_token_auth_enabled!
 
+  rescue_from Token::MaxNumberOfTokensError, with: :throttle_limit_error
+
   def create
     @token = Token.new(token_params)
     if @token.save
@@ -57,5 +59,10 @@ private
     minutes = Token.ttl.div(60)
     hours = minutes.div(60)
     hours
+  end
+
+  def throttle_limit_error
+    error :token_throttle_limit, limit: Token.max_tokens_per_hour
+    render action: :new
   end
 end

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -4,7 +4,7 @@ class TokensController < ApplicationController
   before_action :ensure_token_auth_enabled!
 
   def create
-    @token = Token.create(token_params)
+    @token = Token.new(token_params)
     if @token.save
       send_token_and_render(@token)
     else

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -4,10 +4,8 @@ class TokensController < ApplicationController
   before_action :ensure_token_auth_enabled!
 
   def create
-    @token = generate_token(token_params)
-    if @token.nil?
-      show_throttle_limit_error
-    elsif @token.valid?
+    @token = Token.create(token_params)
+    if @token.save
       send_token_and_render(@token)
     else
       render action: :new
@@ -59,20 +57,9 @@ private
     render
   end
 
-  def show_throttle_limit_error
-    error :token_throttle_limit, limit: Token.max_tokens_per_hour
-    render action: :new
-  end
-
   def ttl_seconds_in_hours
     minutes = Token.ttl.div(60)
     hours = minutes.div(60)
     hours
-  end
-
-  def generate_token(token_params)
-    @token = Token.create(token_params)
-  rescue Token::MaxNumberOfTokensError
-    nil
   end
 end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -70,6 +70,6 @@ private
   end
 
   def tokens_in_the_last_hour
-    Token.where(['user_email = ? and created_at between ? and ?', user_email, 1.hour.ago, Time.now])
+    Token.where(user_email: user_email, created_at: 1.hour.ago..Time.now)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,8 @@ module Peoplefinder
 
     config.rack_timeout = (ENV['RACK_TIMEOUT'] || 14)
 
+    config.max_tokens_per_hour = ENV['MAX_TOKENS_PER_HOUR']
+
     config.action_mailer.default_url_options = {
       host: ENV['ACTION_MAILER_DEFAULT_URL'],
       protocol: (ENV['SSL_ON'] != 'false' ? 'https' : 'http')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,6 @@ en:
     tokens:
       expired_token: "The authentication token has expired and is more than %{time} hours old"
       invalid_token: "The authentication token doesn't exist and so isn't valid"
-      token_throttle_limit: "You've reached the limit of %{limit} tokens requested within an hour"
     admin/person_uploads:
         upload_succeeded: "Successfully uploaded %{count} people"
         upload_failed: "Upload failed"
@@ -180,6 +179,7 @@ en:
       token:
         invalid_address: "Email address is not formatted correctly"
         invalid_domain: "Email address is not valid"
+        token_throttle_limit: "You've reached the limit of %{limit} tokens requested within an hour"
       group:
         attributes:
           base:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
     tokens:
       expired_token: "The authentication token has expired and is more than %{time} hours old"
       invalid_token: "The authentication token doesn't exist and so isn't valid"
+      token_throttle_limit: "You've reached the limit of %{limit} tokens requested within an hour"
     admin/person_uploads:
         upload_succeeded: "Successfully uploaded %{count} people"
         upload_failed: "Upload failed"

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -76,6 +76,21 @@ feature 'Token Authentication' do
     expect(page).to have_text("The authentication token has expired and is more than 3 hours old")
   end
 
+  scenario "requesting more than 8 tokens per hour isn't permitted" do
+    1.upto(9) do |count|
+      visit '/'
+      fill_in 'token_user_email', with: ' tony.stark@digital.justice.gov.uk '
+      click_button 'Use email'
+      if count < 9
+        expect(page).to have_text('We are sending you a link to log in')
+        expect(page).to_not have_text("You've reached the limit of 8 tokens requested within an hour")
+      else
+        expect(page).to_not have_text('We are sending you a link to log in')
+        expect(page).to have_text("You've reached the limit of 8 tokens requested within an hour")
+      end
+    end
+  end
+
   scenario 'logging in and displaying a link to my profile' do
     person = create(:person, given_name: 'Bob', surname: 'Smith', email: 'test.user@digital.justice.gov.uk')
     token = Token.for_person(person)

--- a/spec/models/tokens_spec.rb
+++ b/spec/models/tokens_spec.rb
@@ -93,4 +93,20 @@ RSpec.describe Token, type: :model do
       end
     end
   end
+
+  context 'throttling token generation' do
+    let(:person) { create(:person, email: 'text.user@digital.justice.gov.uk') }
+
+    describe '#save or #create of a new token' do
+      it 'throws and error if more than 8 tokens have been generated in the past hour for the same person' do
+        1.upto(9) do |count|
+          if count < 9
+            expect { described_class.for_person(person) }.to_not raise_error
+          else
+            expect { described_class.for_person(person) }.to raise_error
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/tokens_spec.rb
+++ b/spec/models/tokens_spec.rb
@@ -95,14 +95,14 @@ RSpec.describe Token, type: :model do
   end
 
   context 'throttling token generation' do
-    let(:person) { create(:person, email: 'text.user@digital.justice.gov.uk') }
+    let(:person) { create(:person, email: 'text.user1@digital.justice.gov.uk') }
 
     describe '#save or #create of a new token' do
       it 'throws and error if more than 8 tokens have been generated in the past hour for the same person' do
         8.times do
-          expect { described_class.for_person(person) }.to_not raise_error
+          expect(described_class.for_person(person)).to be_valid
         end
-        expect { described_class.for_person(person) }.to raise_error
+        expect { described_class.for_person(person) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end

--- a/spec/models/tokens_spec.rb
+++ b/spec/models/tokens_spec.rb
@@ -99,13 +99,10 @@ RSpec.describe Token, type: :model do
 
     describe '#save or #create of a new token' do
       it 'throws and error if more than 8 tokens have been generated in the past hour for the same person' do
-        1.upto(9) do |count|
-          if count < 9
-            expect { described_class.for_person(person) }.to_not raise_error
-          else
-            expect { described_class.for_person(person) }.to raise_error
-          end
+        8.times do
+          expect { described_class.for_person(person) }.to_not raise_error
         end
+        expect { described_class.for_person(person) }.to raise_error
       end
     end
   end


### PR DESCRIPTION
Chances of collisions via token entropy attacks are extremely small just because of how they're generated. Still, in order to discourage this kind of attack and any DDOS by side effect, a limit is now set on how many tokens can be generated within an hourly period per person.

The default limit is 8 and can be increased/decreased by setting the env variable MAX_TOKENS_PER_HOUR on the server.