### PR TITLE
Restrict admin to known IP addresses

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,9 @@ Rails.application.routes.draw do
     resources :profiles, only: [:index]
   end
 
-  namespace :admin do
-    resources :person_uploads, only: [:new, :create]
+  constraints ip: /81\.134\.202\.29|127\.0\.0\.1/ do
+    namespace :admin do
+      resources :person_uploads, only: [:new, :create]
+    end
   end
 end


### PR DESCRIPTION
We'd rather do this at the server level, so this is a temporary fix until server configuration is changed.