### PR TITLE
Make CSV parsing (for bulk upload) more liberal

### DIFF
--- a/app/models/person_upload.rb
+++ b/app/models/person_upload.rb
@@ -20,7 +20,7 @@ class PersonUpload
     return nil unless valid?
 
     groups = Group.where(id: group_id)
-    importer = CsvPeopleImporter.new(file.read, groups: groups)
+    importer = PersonCsvImporter.new(file.read, groups: groups)
     @import_count = importer.import || 0
     @csv_errors = importer.errors
     @import_count > 0

--- a/app/services/email_extractor.rb
+++ b/app/services/email_extractor.rb
@@ -1,0 +1,33 @@
+require 'mail'
+
+class EmailExtractor
+  def extract(source)
+    return nil unless source
+    candidates = [:full, :angled, :parenthesized].flat_map { |method|
+      send(method, source)
+    }.map(&:strip)
+    candidates.find { |c| valid?(c) } || source
+  end
+
+private
+
+  def full(str)
+    str
+  end
+
+  def angled(str)
+    str.scan(/<([^>]+)>/).map(&:first)
+  end
+
+  def parenthesized(str)
+    str.scan(/\(([^\)]+)\)/).map(&:first)
+  end
+
+  def valid?(addr)
+    return false unless addr
+    mail_address = Mail::Address.new(addr)
+    mail_address.domain && addr == mail_address.address
+  rescue Mail::Field::ParseError
+    false
+  end
+end

--- a/app/services/person_csv_importer.rb
+++ b/app/services/person_csv_importer.rb
@@ -1,6 +1,6 @@
 require 'csv'
 
-class CsvPeopleImporter
+class PersonCsvImporter
   COLUMNS = %w[given_name surname email]
 
   ErrorRow = Struct.new(:line_number, :raw, :messages) do

--- a/app/services/person_csv_parser.rb
+++ b/app/services/person_csv_parser.rb
@@ -1,0 +1,42 @@
+require 'csv'
+
+class PersonCsvParser
+  Header = Struct.new(:columns, :original) do
+    def line_number
+      1
+    end
+  end
+
+  Record = Struct.new(:line_number, :fields, :original)
+
+  def initialize(serialized)
+    @rows = CSV.new(serialized).to_a
+  end
+
+  def header
+    columns = @rows.first.map { |s| infer_header(s) }.compact
+    Header.new(columns, @rows.first.to_csv.chomp)
+  end
+
+  def records
+    @rows.drop(1).map.with_index do |row, i|
+      fields = Hash[header.columns.zip(row)]
+      Record.new(i + 2, fields, row.to_csv.chomp)
+    end
+  end
+
+private
+
+  def infer_header(str)
+    case str
+    when /given|first/i
+      :given_name
+    when /surname|last|family/i
+      :surname
+    when /email|e-mail/i
+      :email
+    else
+      nil
+    end
+  end
+end

--- a/lib/tasks/peoplefinder/import.rake
+++ b/lib/tasks/peoplefinder/import.rake
@@ -3,7 +3,7 @@ namespace :peoplefinder do
     desc 'Check validity of CSV file before import'
     task :csv_check, [:path] => :environment do |_, args|
       if File.exist?(args[:path])
-        importer = CsvPeopleImporter.new(File.new(args[:path]))
+        importer = PersonCsvImporter.new(File.new(args[:path]))
         if importer.valid?
           puts 'The given file is valid'
         else
@@ -20,7 +20,7 @@ namespace :peoplefinder do
     desc 'Import valid CSV file'
     task :csv_import, [:path] => :environment do |_, args|
       if File.exist?(args[:path])
-        importer = CsvPeopleImporter.new(File.new(args[:path]))
+        importer = PersonCsvImporter.new(File.new(args[:path]))
         result = importer.import
 
         if result.nil?

--- a/spec/models/person_upload_spec.rb
+++ b/spec/models/person_upload_spec.rb
@@ -7,29 +7,29 @@ RSpec.describe PersonUpload, type: :model do
 
   before do
     allow(Group).to receive(:where).with(id: group.id).and_return([group])
-    allow(CsvPeopleImporter).to receive(:new).with('contents', groups: [group])
+    allow(PersonCsvImporter).to receive(:new).with('contents', groups: [group])
   end
 
   context 'with a valid upload' do
     describe 'save' do
-      it 'initialises a CsvPeopleImporter with the file contents and groups' do
-        importer = double(CsvPeopleImporter, import: 1, errors: [])
-        expect(CsvPeopleImporter).to receive(:new).
+      it 'initialises a PersonCsvImporter with the file contents and groups' do
+        importer = double(PersonCsvImporter, import: 1, errors: [])
+        expect(PersonCsvImporter).to receive(:new).
           with('contents', groups: [group]).
           and_return(importer)
         subject.save
       end
 
       it 'returns falsy if upload failed' do
-        importer = double(CsvPeopleImporter, import: nil, errors: [])
-        allow(CsvPeopleImporter).to receive(:new).and_return(importer)
+        importer = double(PersonCsvImporter, import: nil, errors: [])
+        allow(PersonCsvImporter).to receive(:new).and_return(importer)
 
         expect(subject.save).to be_falsy
       end
 
       it 'returns truthy if upload succeeded' do
-        importer = double(CsvPeopleImporter, import: 1, errors: [])
-        allow(CsvPeopleImporter).to receive(:new).and_return(importer)
+        importer = double(PersonCsvImporter, import: 1, errors: [])
+        allow(PersonCsvImporter).to receive(:new).and_return(importer)
 
         expect(subject.save).to be_truthy
       end
@@ -37,16 +37,16 @@ RSpec.describe PersonUpload, type: :model do
 
     describe 'import_count' do
       it 'returns the number of items uploaded after save' do
-        importer = double(CsvPeopleImporter, import: 1, errors: [])
-        allow(CsvPeopleImporter).to receive(:new).and_return(importer)
+        importer = double(PersonCsvImporter, import: 1, errors: [])
+        allow(PersonCsvImporter).to receive(:new).and_return(importer)
 
         subject.save
         expect(subject.import_count).to eq(1)
       end
 
       it 'returns 0 if no items were uploaded' do
-        importer = double(CsvPeopleImporter, import: nil, errors: [])
-        allow(CsvPeopleImporter).to receive(:new).and_return(importer)
+        importer = double(PersonCsvImporter, import: nil, errors: [])
+        allow(PersonCsvImporter).to receive(:new).and_return(importer)
 
         subject.save
         expect(subject.import_count).to eq(0)
@@ -55,8 +55,8 @@ RSpec.describe PersonUpload, type: :model do
 
     describe 'csv_errors' do
       it 'is empty after save' do
-        importer = double(CsvPeopleImporter, import: 1, errors: [])
-        allow(CsvPeopleImporter).to receive(:new).and_return(importer)
+        importer = double(PersonCsvImporter, import: 1, errors: [])
+        allow(PersonCsvImporter).to receive(:new).and_return(importer)
 
         subject.save
         expect(subject.csv_errors).to eq([])
@@ -64,8 +64,8 @@ RSpec.describe PersonUpload, type: :model do
 
       it 'returns the errors found during save' do
         error = double('error')
-        importer = double(CsvPeopleImporter, import: nil, errors: [error])
-        allow(CsvPeopleImporter).to receive(:new).and_return(importer)
+        importer = double(PersonCsvImporter, import: nil, errors: [error])
+        allow(PersonCsvImporter).to receive(:new).and_return(importer)
 
         subject.save
         expect(subject.csv_errors).to eq([error])

--- a/spec/services/csv_people_importer_spec.rb
+++ b/spec/services/csv_people_importer_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe CsvPeopleImporter, type: :service do
     context 'when csv has valid format' do
       context 'when all people have surname and email' do
         let(:csv) do
-          <<CSV
-email,given_name,surname
-peter.bly@valid.gov.uk,Peter,Bly
-jon.o.carey@valid.gov.uk,Jon,O'Carey
-CSV
+          <<-CSV.strip_heredoc
+            email,given_name,surname
+            peter.bly@valid.gov.uk,Peter,Bly
+            jon.o.carey@valid.gov.uk,Jon,O'Carey
+          CSV
         end
 
         it { is_expected.to be true }
@@ -32,12 +32,12 @@ CSV
 
       context 'when some people have incorrect details' do
         let(:csv) do
-          <<CSV
-email,given_name,surname
-peter.bly@valid.gov.uk,Peter,Bly
-jon.o. carey@valid.gov.uk,Jon,O'Carey
-jack@invalid.gov.uk,Jack,
-CSV
+          <<-CSV.strip_heredoc
+            email,given_name,surname
+            peter.bly@valid.gov.uk,Peter,Bly
+            jon.o. carey@valid.gov.uk,Jon,O'Carey
+            jack@invalid.gov.uk,Jack,
+          CSV
         end
 
         it { is_expected.to be false }
@@ -62,10 +62,10 @@ CSV
 
     context 'when the csv has missing columns' do
       let(:csv) do
-        <<CSV
-email
-peter.bly@valid.gov.uk
-CSV
+        <<-CSV.strip_heredoc
+          email
+          peter.bly@valid.gov.uk
+        CSV
       end
 
       it { is_expected.to be false }
@@ -86,11 +86,11 @@ CSV
   describe '#import' do
     context 'for a valid csv' do
       let(:csv) {
-        <<CSV
-email,given_name,surname
-peter.bly@valid.gov.uk,Peter,Bly
-jon.con@valid.gov.uk,Jon,Con
-CSV
+        <<-CSV.strip_heredoc
+          email,given_name,surname
+          peter.bly@valid.gov.uk,Peter,Bly
+          jon.con@valid.gov.uk,Jon,Con
+        CSV
       }
 
       it 'creates new records' do
@@ -124,11 +124,11 @@ CSV
 
     context 'for an invalid csv (including duplicates)' do
       let(:csv) {
-        <<CSV
-email,given_name,surname
-peter.bly@valid.gov.uk,,Bly
-jon.o.carey@valid.gov.uk,Jon,O'Carey
-CSV
+        <<-CSV.strip_heredoc
+          email,given_name,surname
+          peter.bly@valid.gov.uk,,Bly
+          jon.o.carey@valid.gov.uk,Jon,O'Carey
+        CSV
       }
 
       before do

--- a/spec/services/email_extractor_spec.rb
+++ b/spec/services/email_extractor_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'email_extractor'
+
+RSpec.describe EmailExtractor, type: :service do
+  subject {
+    described_class.new
+  }
+
+  it 'returns the original email when supplied with a valid email address' do
+    expect(subject.extract("user.o'postrophe@example.com")).
+      to eq("user.o'postrophe@example.com")
+  end
+
+  it 'returns an email address in <>' do
+    expect(subject.extract("John <user.o'postrophe@example.com>")).
+      to eq("user.o'postrophe@example.com")
+  end
+
+  it 'returns an email address in ()' do
+    expect(subject.extract("John (user.o'postrophe@example.com)")).
+      to eq("user.o'postrophe@example.com")
+  end
+
+  it 'returns nil if email is nil' do
+    expect(subject.extract(nil)).to be_nil
+  end
+
+  it 'returns the original content if no email address is found' do
+    expect(subject.extract('rubbish')).to eq('rubbish')
+  end
+
+  it 'finds the best email address amongst multiple sets of parentheses' do
+    expect(subject.extract("(102 PF) (user.o'postrophe@example.com)")).
+      to eq("user.o'postrophe@example.com")
+  end
+
+  it 'strips space around the email address' do
+    expect(subject.extract("  user.o'postrophe@example.com  ")).
+      to eq("user.o'postrophe@example.com")
+  end
+end

--- a/spec/services/person_csv_importer_spec.rb
+++ b/spec/services/person_csv_importer_spec.rb
@@ -141,6 +141,32 @@ RSpec.describe PersonCsvImporter, type: :service do
     end
   end
 
+  describe '#import' do
+    context 'for a CSV exported by Estates' do
+      let(:csv) {
+        <<-CSV.strip_heredoc
+          First Name,Last Name,E-mail Display Name
+          Reinhold,Denesik,"Denesik, Reinhold (Reinhold.Denesik@valid.gov.uk)"
+          Lelah,Jerde,"Jerde, Lelah (Lelah.Jerde@valid.gov.uk)"
+        CSV
+      }
+
+      it 'creates records' do
+        subject.import
+        expect(Person.where(
+          given_name: 'Reinhold',
+          surname: 'Denesik',
+          email: 'reinhold.denesik@valid.gov.uk'
+        ).count).to eq(1)
+        expect(Person.where(
+          given_name: 'Lelah',
+          surname: 'Jerde',
+          email: 'lelah.jerde@valid.gov.uk'
+        ).count).to eq(1)
+      end
+    end
+  end
+
   it 'renders errors as strings' do
     error_row = PersonCsvImporter::ErrorRow.new(
       4, "jack@invalid.gov.uk,Jack,", ['Something', 'Something else']

--- a/spec/services/person_csv_importer_spec.rb
+++ b/spec/services/person_csv_importer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CsvPeopleImporter, type: :service do
+RSpec.describe PersonCsvImporter, type: :service do
 
   before do
     allow(PermittedDomain).to receive(:pluck).with(:domain).and_return(['valid.gov.uk'])
@@ -44,11 +44,11 @@ RSpec.describe CsvPeopleImporter, type: :service do
 
         it 'errors contain missing columns' do
           expect(importer.errors).to match_array([
-            CsvPeopleImporter::ErrorRow.new(
+            PersonCsvImporter::ErrorRow.new(
               3, "jon.o. carey@valid.gov.uk,Jon,O'Carey",
               ['Main email isn’t valid']
             ),
-            CsvPeopleImporter::ErrorRow.new(
+            PersonCsvImporter::ErrorRow.new(
               4, "jack@invalid.gov.uk,Jack,",
               [
                 'Surname is required',
@@ -72,10 +72,10 @@ RSpec.describe CsvPeopleImporter, type: :service do
 
       it 'errors contain missing columns' do
         expect(importer.errors).to match_array([
-          CsvPeopleImporter::ErrorRow.new(
+          PersonCsvImporter::ErrorRow.new(
             1, "email", ['given_name column is missing']
           ),
-          CsvPeopleImporter::ErrorRow.new(
+          PersonCsvImporter::ErrorRow.new(
             1, "email", ['surname column is missing']
           )
         ])
@@ -142,7 +142,7 @@ RSpec.describe CsvPeopleImporter, type: :service do
   end
 
   it 'renders errors as strings' do
-    error_row = CsvPeopleImporter::ErrorRow.new(
+    error_row = PersonCsvImporter::ErrorRow.new(
       4, "jack@invalid.gov.uk,Jack,", ['Something', 'Something else']
     )
     expect(error_row.to_s).to eq('line 4 "jack@invalid.gov.uk,Jack,": Something, Something else')

--- a/spec/services/person_csv_parser_spec.rb
+++ b/spec/services/person_csv_parser_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+require 'person_csv_parser'
+require 'active_support/core_ext/string/strip'
+
+RSpec.describe PersonCsvParser, type: :service do
+
+  subject {
+    described_class.new(csv)
+  }
+
+  context 'with a clean CSV' do
+    let(:csv) {
+      <<-END.strip_heredoc
+        email,given_name,surname
+        peter.bly@valid.gov.uk,Peter,Bly
+        jon.o.carey@valid.gov.uk,Jon,O'Carey
+      END
+    }
+
+    subject {
+      described_class.new(csv)
+    }
+
+    it 'returns the line number of the header' do
+      expect(subject.header.line_number).to eq(1)
+    end
+
+    it 'returns the line number of each row' do
+      expect(subject.records.map(&:line_number)).to eq([2, 3])
+    end
+
+    it 'returns the original content of the header' do
+      expect(subject.header.original).to eq('email,given_name,surname')
+    end
+
+    it 'returns the original content of each row' do
+      expect(subject.records.map(&:original)).to eq(
+        [
+          'peter.bly@valid.gov.uk,Peter,Bly',
+          'jon.o.carey@valid.gov.uk,Jon,O\'Carey'
+        ]
+      )
+    end
+
+    it 'returns a hash of fields' do
+      expect(subject.records.map(&:fields)).to eq(
+        [
+          { given_name: 'Peter', surname: 'Bly', email: 'peter.bly@valid.gov.uk' },
+          { given_name: 'Jon', surname: 'O\'Carey', email: 'jon.o.carey@valid.gov.uk' }
+        ]
+      )
+    end
+  end
+
+  context 'with dodgy headers' do
+    let(:csv) {
+      <<-END.strip_heredoc
+        First Name,Last Name,E-mail Display Name
+        Peter,Bly,peter.bly@valid.gov.uk
+        Jon,O'Carey,jon.o.carey@valid.gov.uk
+      END
+    }
+
+    it 'returns a hash of fields with cleaned keys' do
+      expect(subject.records.map(&:fields)).to eq(
+        [
+          { given_name: 'Peter', surname: 'Bly', email: 'peter.bly@valid.gov.uk' },
+          { given_name: 'Jon', surname: 'O\'Carey', email: 'jon.o.carey@valid.gov.uk' }
+        ]
+      )
+    end
+  end
+
+  context 'with unidentifiable headers' do
+    let(:csv) {
+      <<-END.strip_heredoc
+        Foo,bar,BAZ
+        Peter,Bly,peter.bly@valid.gov.uk
+        Jon,O'Carey,jon.o.carey@valid.gov.uk
+      END
+    }
+
+    it 'returns an empty hash for the fields' do
+      expect(subject.records.map(&:fields)).to eq([{}, {}])
+    end
+  end
+end


### PR DESCRIPTION
[Story 330](https://trello.com/c/j94heRWK/330-s-take-outlook-output-contact-list-in-format-surname-name-name-surname-domain-com-and-rationalise)

The CSV files generated from the Global Address List look something like:

```
First Name,Last Name,E-mail Display Name
Reinhold,Denesik,"Denesik, Reinhold (Reinhold.Denesik@valid.gov.uk)"
Lelah,Jerde,"Jerde, Lelah (Lelah.Jerde@valid.gov.uk)"
```

… which doesn't conform to our stated schema, but is still systematic enough that we could parse it.

First, we change CSV parsing to treat column names more liberally. Specifically, case is ignored, and:

* The column for `given_name` can be called anything containing 'first' or 'given';
* The column for `surname` can be anything containing 'surname', 'family', or 'last';
* The column for `email` can be anything containing 'email' or 'e-mail'.

Second, we extract bracketed email addresses from the email field and remove any surrounding whitespace so that all of the following are equivalent:

* `foo@example.com`
* `Foo <foo@example.com`
* `Foo (foo@example.com)`
* `Foo ( foo@example.com )`
* `(Foo) (foo@example.com)`

This enables us to process a wider range of data sources without a manual data-munging stage beforehand.