### PR TITLE
Run Brakeman as part of default CI task

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -73,7 +73,8 @@ private
 
   # Use callbacks to share common setup or constraints between actions.
   def set_group
-    @group = collection.friendly.includes(:people).find(params[:id])
+    group = collection.friendly.find(params[:id])
+    @group = Group.includes(:people).find(group.id)
   end
 
   def set_org_structure

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -63,7 +63,7 @@ class GroupsController < ApplicationController
 
   # DELETE /groups/1
   def destroy
-    next_page = @group.parent ? @group.parent : groups_url
+    next_page = @group.parent ? group_path(@group.parent) : groups_path
     @group.destroy
     notice :group_deleted, group: @group
     redirect_to next_page

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,10 +1,11 @@
-namespace :brakeman do
+task :brakeman do
+  sh <<END
+(brakeman --no-progress --quiet --output tmp/brakeman.out --exit-on-warn && \
+echo "No warnings or errors") || \
+(cat tmp/brakeman.out; exit 1)
+END
+end
 
-  desc "Run Brakeman"
-  task :run, :output_files do |t, args|
-    require 'brakeman'
-
-    files = args[:output_files].split(' ') if args[:output_files]
-    Brakeman.run :app_path => ".", :output_files => files, :print_report => true
-  end
+if %w[development test].include? Rails.env
+  task(:default).prerequisites << task(:brakeman)
 end


### PR DESCRIPTION
Although Brakeman is not perfect – it won't identify every vulnerability, and not everything it complains about is necessarily a problem – having no warnings is a reasonable goal. Although we already had Brakeman in the Gemfile, it wasn't necessarily being used.

This changeset, therefore:

1. Adds Brakeman to the standard Rake task, and makes the build fail if Brakeman identifies any potential vulnerabilities.
2. Addresses things that Brakeman complains about, so that the build will still pass.