### PR TITLE
'Stop' people downloading photos

### DIFF
--- a/app/assets/stylesheets/peoplefinder/groups.css.scss
+++ b/app/assets/stylesheets/peoplefinder/groups.css.scss
@@ -1,14 +1,11 @@
+@import 'maginot';
 $focus-color: #FFBF47;
 
 .group-leader {
   .image-background {
     height: 300px;
   }
-  img {
-    width: 300px;
-    clip: rect(0px, 300px, 300px, 0px);
-    max-width: 100%;
-  }
+  @include maginot(300px, 300px);
 }
 
 .group-title {
@@ -29,11 +26,7 @@ $focus-color: #FFBF47;
   .image-background {
     height: 217px;
   }
-  img {
-    width: 217px;
-    max-width: 100%;
-    clip: rect(0px, 217px, 217px, 0px);
-  }
+  @include maginot(217px, 217px);
   .role {
     font-size: 16px;
     width: 212px;

--- a/app/assets/stylesheets/peoplefinder/maginot.scss
+++ b/app/assets/stylesheets/peoplefinder/maginot.scss
@@ -1,0 +1,17 @@
+@mixin maginot($width, $height) {
+  .maginot {
+    position: relative;
+    width: $width;
+    .barrier, img {
+      position: absolute;
+      width: $width;
+      height: $height;
+      top: 0;
+      left: 0;
+    }
+    img {
+      clip: rect(0px, $width, $height, 0px);
+      max-width: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/peoplefinder/people.css.scss
+++ b/app/assets/stylesheets/peoplefinder/people.css.scss
@@ -1,3 +1,4 @@
+@import 'maginot';
 ul.working_days {
   clear: both;
   list-style: none;
@@ -25,11 +26,7 @@ ul.working_days {
   .image-background {
     height: 300px;
   }
-  img {
-    width: 300px;
-    clip: rect(0px, 300px, 300px, 0px);
-    max-width: 100%;
-  }
+  @include maginot(300px, 300px);
   dl {
     margin-bottom: 15px;
   }
@@ -88,12 +85,7 @@ img.preview {
           height: 125px;
         }
       }
-
-      img {
-        width: 125px;
-        clip: rect(0px, 125px, 125px, 0px);
-        float: left;
-      }
+      @include maginot(125px, 125px);
       .details {
         @media screen and (max-width: 320px) {
           float: none;

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -8,7 +8,10 @@ module PeopleHelper
   end
 
   def profile_image_tag(person, source, options = {})
-    image_tag(source, options.merge(alt: "Current photo of #{ person }"))
+    content_tag(:div, class: 'maginot') {
+      image_tag(source, options.merge(alt: "Current photo of #{ person }")) +
+      content_tag(:div, class: 'barrier') {}
+    }
   end
 
   # Why do we need to go to this trouble to repeat new_person/edit_person? you


### PR DESCRIPTION
[Story 337](https://trello.com/c/X5doZMQ7/337)

This puts in front of all profile images a div of the same width and height, preventing the most unskilled users from saving the image via a right click or by dragging it out of the browser.

This is, of course, ultimately futile: even six-year-olds know how to get around this, and print screen will still work.