### PR TITLE
Add a cookie message and policy

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,2 @@
-//= require peoplefinder/application.js
+//= require peoplefinder/application
+//= require cookie-message

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,7 @@
+class PagesController < ApplicationController
+  skip_before_action :ensure_user
+
+  def show
+    @page_name = params[:id]
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,6 +23,8 @@
           = yield :report_link
         #last_update
           = last_update
+- content_for :cookie_message do
+  %p= t('shared.cookie_message_html')
 = render partial: "shared/feedback_form"
 = render 'layouts/script'
 = render template: "layouts/peoplefinder"

--- a/app/views/pages/show.html.haml
+++ b/app/views/pages/show.html.haml
@@ -1,0 +1,4 @@
+%h1= t(:title, scope: [:pages, @page_name])
+
+.formatted-text
+  = govspeak(t(:body, scope: [:pages, @page_name]))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,9 @@ en:
     search:
       label: Enter the name of a person or role
       placeholder: 'Enter name, job title, team name or location'
+    cookie_message_html:
+      People Finder uses cookies to make the site simpler.
+      <a href="/cookies">Find out more about cookies</a>
   home:
     heading: Welcome to People Finder
     explanation: |

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -1,0 +1,66 @@
+en:
+  pages:
+    cookies:
+      title: Cookies
+      body: |
+        People Finder stores small pieces of data (known as ‘cookies’) on your
+        computer in order to operate and to collect information about how you
+        browse the site.
+
+        Cookies are used to:
+
+        * keep you logged into the website
+        * measure how you use the website so it can be updated and improved
+          based on your needs
+        * remember the notifications you’ve seen so that we don’t show them to
+          you again
+
+        Third party cookies on People Finder aren’t used to identify you
+        personally.
+
+        Find out more about [how to manage cookies][manage-cookies].
+
+        # How cookies are used on People Finder
+
+        ## Measuring website usage (Google Analytics)
+
+        We use Google Analytics software to collect information about how you
+        use People Finder.
+        We do this to help make sure the site is meeting the needs of its users
+        and to [help us make improvements][improvements].
+
+        Google Analytics stores information about:
+
+        * the pages you visit on People Finder
+        * how long you spend on each People Finder page 
+        * how you got to the site  
+        * what you click on while you’re visiting the site
+
+        We don’t collect or store your personal information (eg your name or
+        address) so this information can’t be used to identify who you are.
+
+        We don’t allow Google to use or share our analytics data.
+
+        You can [opt out of Google Analytics cookies][google-optout].
+
+        ## Our introductory message
+
+        You may see a pop-up welcome message when you first visit People
+        Finder.
+        We’ll store a cookie so that your computer knows you’ve seen it and
+        knows not to show it again.
+
+        ## Sessions
+
+        People Finder will store a cookie when you log into the site to open a
+        session.
+        This cookie is stored so that you don’t need to log in every time you
+        visit the site.
+        If you are working on a government machine, you may find that your
+        cookies are cleared automatically every time you turn off or log out of
+        your machine.
+        This will mean you need to log into People Finder again.
+
+        [manage-cookies]: http://www.aboutcookies.org/
+        [improvements]: https://insidegovuk.blog.gov.uk/2014/10/29/info-pages-publishing-data-about-user-needs-and-metrics/
+        [google-optout]: https://tools.google.com/dlpage/gaoptout

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,4 +45,6 @@ Rails.application.routes.draw do
       resources :person_uploads, only: [:new, :create]
     end
   end
+
+  get '/cookies', to: 'pages#show', id: 'cookies', as: :cookies
 end

--- a/spec/features/cookie_message_spec.rb
+++ b/spec/features/cookie_message_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+feature 'Cookie message', js: true do
+  let(:message_text) { 'People Finder uses cookies' }
+
+  scenario 'first visit' do
+    visit '/'
+    expect(page).to have_text(message_text)
+
+    click_link 'Find out more about cookies'
+    expect(page).to have_content('How cookies are used on People Finder')
+  end
+
+  scenario 'subsequent visits' do
+    visit '/'
+    visit '/'
+    expect(page).not_to have_text(message_text)
+  end
+end


### PR DESCRIPTION
This uses the existing cookie banner from the template: on first visit, a banner is shown, with a link to the policy. On subsequent visits, the banner is not shown.