### PR TITLE
ENV value no longer errors out when String

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -45,7 +45,7 @@ class Token < ActiveRecord::Base
   end
 
   def self.max_tokens_per_hour
-    Rails.configuration.try(:max_tokens_per_hour) || DEFAULT_MAX_TOKENS_PER_HOUR
+    Integer(Rails.configuration.try(:max_tokens_per_hour) || DEFAULT_MAX_TOKENS_PER_HOUR)
   end
 
   def max_tokens_per_hour


### PR DESCRIPTION
When using Heroku we noticed that as 'max_tokens_per_hour' was being defined as a String, a type error was thrown.

Here I cast the type to an integer at first point of reference.