### PR TITLE
Fix photo uploads

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,8 +10,8 @@ Rails.application.config.assets.precompile += %w[
   peoplefinder/peoplefinder-lt-ie9.css
   peoplefinder/peoplefinder-ie7.css
   gov-static/gov-ie.js
-  jquery.Jcrop.min.css
-  jquery.Jcrop.min.js
+  Jcrop/css/jquery.Jcrop.min.css
+  Jcrop/css/jquery.Jcrop.min.js
 ]
 
 unless Rails.env.production?


### PR DESCRIPTION
The precompilation path for Jcrop was incorrect. This broke the photo cropping interstitial page, but in a way which is not caught in the test environment.