### PR TITLE
Specify S3 region explicitly

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -4,7 +4,8 @@ CarrierWave.configure do |config|
     config.fog_credentials = {
       provider: 'AWS',
       aws_access_key_id: ENV['S3_KEY'],
-      aws_secret_access_key: ENV['S3_SECRET']
+      aws_secret_access_key: ENV['S3_SECRET'],
+      region: ENV['S3_REGION']
     }
     config.fog_directory  = ENV['S3_BUCKET_NAME']
   elsif Rails.env.test?


### PR DESCRIPTION
Fog changed to using AWS V4, and can't guess the correct region any more. This leads to error messages from S3 like:

> The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-west-1'

As a fix, we will specify the region explicitly via the S3_REGION environment variable.

See https://github.com/fog/fog/issues/3275