### PR TITLE
Fix weird wrapping at 100% complete

### DIFF
--- a/app/assets/stylesheets/peoplefinder/people.css.scss
+++ b/app/assets/stylesheets/peoplefinder/people.css.scss
@@ -120,7 +120,7 @@ img.preview {
 
 .complete-your-profile {
   background-color: $grey-bg;
-  width: 285px;
+  width: 300px;
   margin-top: 5px;
   padding: 15px 0 1px 15px;
   font-weight: bold;


### PR DESCRIPTION
Because '100%' is wider than '99%', the text didn't fit properly once we started showing the box at 100% to congratulate people.

Making the box the same width as the profile photo above looks more consistent and fixes the wrapping.

![screenshot-2015-05-07t09 50 39z](https://cloud.githubusercontent.com/assets/17347/7512759/04f81250-f4a7-11e4-9c63-ad94e96acca1.png)