### PR TITLE
Allow a buffer of time/retries between the DNS based maintenance page being switched off and the smoke tests testing the site

### DIFF
--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -7,7 +7,7 @@
     <meta content="Login request for MOJ People Finder" property="og:title"/>
     <title>Ministry of Justice - People Finder Login Token</title>
     <style type="text/css">
-      
+
       @media only screen and (max-device-width: 600px) {
           table[class="body"] {
               width: 100% !important;
@@ -75,7 +75,7 @@
                     • do not reply to it or click any links
                     <br/>
                     • forward it to
-                    <a href="mailto:phishing@digital.justice.gov.uk" style="color:#097FC9;" target="_blank">phishing@justice.gsi.gov.uk</a>
+                    <a href="mailto:phishing@digital.justice.gov.uk" style="color:#097FC9;" target="_blank">phishing@digital.justice.gov.uk</a>
                   </td>
                   <td style="min-width:10px;border-collapse:collapse;" width="20"></td>
                 </tr>

--- a/smoke_test
+++ b/smoke_test
@@ -60,7 +60,8 @@ class SmokeTest
   def run
     step 'Request token' do
       # 300 secs is the TTL for the DNS based maintenance page
-      with_retries(initial_delay: 15, max_delay: 120) { request_token }
+      with_retries(initial_delay: 15, max_delay: 60) { request_token }
+      # request_token
     end
 
     signin_path = nil
@@ -125,9 +126,9 @@ private
   end
 
   def request_token
+    visit '/'
     page_loaded = page.has_text?('Request link to access People Finder')
     if page_loaded
-      visit '/'
       fill_in 'Email address', with: email_address
       click_button 'Request link'
     end

--- a/smoke_test
+++ b/smoke_test
@@ -59,12 +59,13 @@ class SmokeTest
   # rubocop:disable MethodLength
   def run
     step 'Request token' do
-      request_token
+      # 300 secs is the TTL for the DNS based maintenance page
+      with_retries(initial_delay: 15, max_delay: 120) { request_token }
     end
 
     signin_path = nil
     step 'Fetch token email' do
-      token_mail = with_retries { fetch_token_mail }
+      token_mail = with_retries(initial_delay: 5, max_delay: 120) { fetch_token_mail }
       fail "couldn't find token email" unless token_mail
 
       text_part = token_mail.text_part.decoded
@@ -124,9 +125,13 @@ private
   end
 
   def request_token
-    visit '/'
-    fill_in 'Email address', with: email_address
-    click_button 'Request link'
+    page_loaded = page.has_text?('Request link to access People Finder')
+    if page_loaded
+      visit '/'
+      fill_in 'Email address', with: email_address
+      click_button 'Request link'
+    end
+    page_loaded
   end
 
   def fetch_token_mail


### PR DESCRIPTION
Tweaking the retries for both Token request and Fetch email token