### PR TITLE
Fix unreliable specs

### DIFF
--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -4,7 +4,7 @@ feature 'Report a problem', js: true do
   include ActiveJobHelper
   include PermittedDomainHelper
 
-  let(:current_time) { Time.at(1_410_298_077) }
+  let(:current_time) { Time.at(1_410_298_020) }
 
   around do |example|
     Timecop.travel(current_time)


### PR DESCRIPTION
The particular time chosen for these specs happens to be 57 seconds past the minute, which gives the spec three seconds to run before the minute matched in the assertion fails.

This is not usually a problem, but Travis CI sometimes runs very slowly indeed. Changing the start time to the top of the minute gives us a whole 60 seconds of oxygen.

Freezing time for the duration of the spec would be a simpler solution, but, alas, "Capybara does not work with libraries which freeze time".