### PR TITLE
Make health check database details flexible

### DIFF
--- a/app/models/health_check/database.rb
+++ b/app/models/health_check/database.rb
@@ -29,15 +29,14 @@ module HealthCheck
     end
 
     def log_error
-      @errors = [
-        'Database Error: could not connect to %s using %s' % [
-          config.url, config.adapter
-        ]
-      ]
+      @errors = ["Database Error: could not connect with #{config}"]
     end
 
     def config
-      OpenStruct.new(Rails.configuration.database_configuration[Rails.env])
+      full_config = Rails.configuration.database_configuration[Rails.env]
+      permitted_keys = %w[ url database host adapter ]
+      filtered_config = full_config.slice(*permitted_keys)
+      filtered_config.sort.map { |k, v| "#{k}='#{v}'" }.join(' ')
     end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ default: &default
 
 development:
   <<: *default
-  url: 'postgresql://localhost/peoplefinder_development'
+  database: peoplefinder_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -57,7 +57,11 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  url: <%= ENV.fetch('DB_TEST_URL','postgresql://localhost/peoplefinder_test') %>
+<% if ENV.key?('DB_TEST_URL') %>
+  url: <%= ENV.fetch('DB_TEST_URL') %>
+<% else %>
+  database: peoplefinder_test
+<% end %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/models/health_check/database_spec.rb
+++ b/spec/models/health_check/database_spec.rb
@@ -32,7 +32,7 @@ describe HealthCheck::Database do
       allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
       subject.available?
 
-      expect(subject.errors.first).to match(/could not connect to \S+_test/)
+      expect(subject.errors.first).to match(/could not connect with .*?_test/)
     end
 
     it 'returns an error an backtrace for errors not specific to a component' do


### PR DESCRIPTION
The motivation for this is that #154 broke my ability to run the test suite without tweaking the database configuration each time.

The configuration is now reported by the health check regardless of whether host/database or URL configuration is used, i.e. it works with any configuration supported by Rails. This means that the test configuration no longer has to be a URL.

If `DB_TEST_URL` is defined, it will still be used in the `test` environment; if not, the previous configuration of `database: peoplefinder_test` is used: this works with PostgreSQL peer authentication.