### PR TITLE
Never expose DB password in healthcheck

### DIFF
--- a/app/models/health_check/database.rb
+++ b/app/models/health_check/database.rb
@@ -34,9 +34,7 @@ module HealthCheck
 
     def config
       full_config = Rails.configuration.database_configuration[Rails.env]
-      permitted_keys = %w[ url database host adapter ]
-      filtered_config = full_config.slice(*permitted_keys)
-      filtered_config.sort.map { |k, v| "#{k}='#{v}'" }.join(' ')
+      DatabaseConfiguration.new(full_config).to_s
     end
   end
 end

--- a/app/models/health_check/database_configuration.rb
+++ b/app/models/health_check/database_configuration.rb
@@ -1,0 +1,34 @@
+require 'uri'
+
+module HealthCheck
+  class DatabaseConfiguration
+    SAFE = %w[ adapter database host port ]
+
+    def initialize(hash)
+      if hash.key?('url')
+        @hash = parse_out_uri(hash)
+      else
+        @hash = hash
+      end
+    end
+
+    def to_s
+      @hash.
+        sort.
+        select { |k, v| SAFE.include?(k.to_s) && v }.
+        map { |k, v| "#{k}=#{v}" }.
+        join(' ')
+    end
+
+  private
+
+    def parse_out_uri(hash)
+      uri = URI.parse(hash['url'])
+      hash.merge(
+        'database' => uri.path[1..-1],
+        'host' => uri.hostname,
+        'port' => uri.port
+      )
+    end
+  end
+end

--- a/spec/models/health_check/database_configuration_spec.rb
+++ b/spec/models/health_check/database_configuration_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+require 'health_check/database_configuration'
+
+describe HealthCheck::DatabaseConfiguration do
+  subject { described_class.new(config_hash) }
+
+  describe 'to_s' do
+    context 'with all safe fields' do
+      let(:config_hash) {
+        {
+          'adapter' => 'postgresql',
+          'database' => 'foo_test',
+          'host' => 'db.example.com',
+          'port' => 1337
+        }
+      }
+
+      it 'lists all fields in alphabetical order' do
+        expect(subject.to_s).
+          to eq('adapter=postgresql database=foo_test host=db.example.com port=1337')
+      end
+    end
+
+    context 'with unsafe fields' do
+      let(:config_hash) {
+        {
+          'adapter' => 'postgresql',
+          'pool' => 5,
+          'database' => 'foo_test',
+          'host' => 'db.example.com',
+          'port' => 1337,
+          'username' => 'aoluser',
+          'password' => 'SuperSecret'
+        }
+      }
+
+      it 'excludes password' do
+        expect(subject.to_s).not_to match(/password|SuperSecret/)
+      end
+
+      it 'excludes username' do
+        expect(subject.to_s).not_to match(/username|aoluser/)
+      end
+    end
+
+    context 'with a comprehensive url' do
+      let(:config_hash) {
+        {
+          'adapter' => 'postgresql',
+          'url' => 'postgresql://aoluser:SuperSecret@db.example.com:1337/foo_test'
+        }
+      }
+
+      it 'preserves non-url parameters' do
+        expect(subject.to_s).to match(/adapter=postgresql/)
+      end
+
+      it 'extracts database' do
+        expect(subject.to_s).to match(/database=foo_test/)
+      end
+
+      it 'extracts host' do
+        expect(subject.to_s).to match(/host=db\.example\.com/)
+      end
+
+      it 'extracts port' do
+        expect(subject.to_s).to match(/port=1337/)
+      end
+
+      it 'excludes password' do
+        expect(subject.to_s).not_to match(/SuperSecret/)
+      end
+
+      it 'excludes username' do
+        expect(subject.to_s).not_to match(/aoluser/)
+      end
+    end
+
+    context 'with a url without all fields' do
+      let(:config_hash) {
+        {
+          'adapter' => 'postgresql',
+          'url' => 'postgresql://localhost/foo_test'
+        }
+      }
+
+      it 'excludes port' do
+        expect(subject.to_s).not_to match(/port/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
A database URL can (and, where it matters, usually will) contain the database password. We should never expose this in the healthcheck.

Instead, we now extract fields from the configuration hash and, optionally, the url field in the hash, and return only whitelisted parameters