### PR TITLE
Stop generating errors on invalid search input

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,11 +1,20 @@
 class SearchController < ApplicationController
   def index
-    @people = PersonSearch.new.fuzzy_search(params[:query]).records.limit(100)
+    @query = query
+    @people = PersonSearch.new.fuzzy_search(@query)
   end
 
 private
 
   def can_add_person_here?
     true
+  end
+
+  def query
+    input = params[:query]
+    input.encode(Encoding::UTF_32LE)
+    input
+  rescue Encoding::InvalidByteSequenceError
+    ''
   end
 end

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -1,7 +1,7 @@
 class PersonSearch
-  def fuzzy_search(query)
+  def fuzzy_search(query, max = 100)
     Person.search(
-      size: 100,
+      size: max,
       query: {
         fuzzy_like_this: {
           fields: [
@@ -11,6 +11,6 @@ class PersonSearch
           like_text: query, prefix_length: 3, ignore_tf: true
         }
       }
-    )
+    ).records.limit(max)
   end
 end

--- a/app/views/shared/_search.html.haml
+++ b/app/views/shared/_search.html.haml
@@ -1,5 +1,5 @@
 = form_tag '/search', method: :get, class: 'search-box' do
   %h2.search= t('home.search_heading')
   %label.visuallyhidden{ for: :query }= t('shared.search.label')
-  = text_field_tag :query, params[:query], placeholder: t('shared.search.placeholder'), class: 'form-control'
+  = text_field_tag :query, @query, placeholder: t('shared.search.placeholder'), class: 'form-control'
   = submit_tag 'Submit search', class: 'submit-button'

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe SearchController, type: :controller do
+  include PermittedDomainHelper
+
+  let(:search) {
+    double(PersonSearch, fuzzy_search: search_result)
+  }
+
+  let(:search_result) {
+    double('Elasticsearch result')
+  }
+
+  before do
+    mock_logged_in_user
+    allow(PersonSearch).to receive(:new).and_return(search)
+  end
+
+  context 'with valid UTF-8' do
+    let(:query) { 'válïd ☺' }
+
+    it 'searches for the query' do
+      expect(search).to receive(:fuzzy_search).with(query).
+        and_return(search_result)
+      get :index, query: query
+    end
+
+    it 'assigns the search result to @people' do
+      get :index, query: query
+      expect(assigns(:people)).to eq(search_result)
+    end
+
+    it 'assigns the query to @query' do
+      get :index, query: query
+      expect(assigns(:query)).to eq(query)
+    end
+  end
+
+  context 'with invalid UTF-8' do
+    let(:query) { "\x99" }
+
+    it 'searches for an empty string' do
+      expect(search).to receive(:fuzzy_search).with('').
+        and_return(search_result)
+      get :index, query: query
+    end
+
+    it 'assigns the search result to @people' do
+      get :index, query: query
+      expect(assigns(:people)).to eq(search_result)
+    end
+
+    it 'assigns an empty string to @query' do
+      get :index, query: query
+      expect(assigns(:query)).to eq('')
+    end
+  end
+end

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -63,6 +63,6 @@ RSpec.describe PersonSearch, elastic: true do
   end
 
   def search_for(query)
-    described_class.new.fuzzy_search(query).records
+    described_class.new.fuzzy_search(query)
   end
 end


### PR DESCRIPTION
When percent-encoded invalid UTF-8 was passed via the query parameter, an exception was raised, and a 500 status resulted.

This happened because, although the invalid UTF-8 was safe at rest, as soon as it was used to generate the JSON to be sent to Elasticsearch, an encoding error was raised. This masked a secondary problem where the parameter was interpolated into the view, which would also have caused
an encoding error.

Instead, we now validate the encoding in the controller (by attempting to convert the UTF-8 to UTF-32LE) and replace it with an empty string if it's not valid. The valid query or empty string is assigned to an instance variable for use in the view.