### PR TITLE
Prevent orphaned memberships

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -19,7 +19,9 @@ class Group < ActiveRecord::Base
     name_changed?
   end
 
-  has_many :memberships, -> { includes(:person).order('people.surname')  }
+  has_many :memberships,
+    -> { includes(:person).order('people.surname')  },
+    dependent: :destroy
   has_many :people, through: :memberships
   has_many :leaderships, -> { where(leader: true) }, class_name: 'Membership'
   has_many :non_leaderships,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -41,7 +41,9 @@ class Person < ActiveRecord::Base
     presence: true, uniqueness: { case_sensitive: false }, email: true
   validates :secondary_email, email: true, allow_blank: true
 
-  has_many :memberships, -> { includes(:group).order('groups.name') }, dependent: :destroy
+  has_many :memberships,
+    -> { includes(:group).order('groups.name') },
+    dependent: :destroy
   has_many :groups, through: :memberships
   belongs_to :community
 

--- a/db/migrate/20150604110007_remove_invalid_relationships.rb
+++ b/db/migrate/20150604110007_remove_invalid_relationships.rb
@@ -1,0 +1,11 @@
+class RemoveInvalidRelationships < ActiveRecord::Migration
+  def up
+    execute <<-SQL.strip_heredoc
+      DELETE FROM memberships
+      WHERE person_id IS NULL
+      OR person_id NOT IN (SELECT id FROM people)
+      OR group_id IS NULL
+      OR group_id NOT IN (SELECT id FROM groups);
+    SQL
+  end
+end

--- a/db/migrate/20150604110654_enforce_membership_integrity.rb
+++ b/db/migrate/20150604110654_enforce_membership_integrity.rb
@@ -1,0 +1,8 @@
+class EnforceMembershipIntegrity < ActiveRecord::Migration
+  def change
+    change_column_null :memberships, :person_id, false
+    change_column_null :memberships, :group_id, false
+    add_foreign_key :memberships, :people
+    add_foreign_key :memberships, :groups
+  end
+end

--- a/db/seeds/permitted_domains.rb
+++ b/db/seeds/permitted_domains.rb
@@ -6,5 +6,3 @@ domains   = YAML.load_file(data_file)
 domains.each do |domain|
   PermittedDomain.find_or_create_by(domain: domain)
 end
-
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -155,8 +155,8 @@ ALTER SEQUENCE groups_id_seq OWNED BY groups.id;
 
 CREATE TABLE memberships (
     id integer NOT NULL,
-    group_id integer,
-    person_id integer,
+    group_id integer NOT NULL,
+    person_id integer NOT NULL,
     role text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -532,6 +532,22 @@ CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (v
 
 
 --
+-- Name: fk_rails_092b9b8356; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY memberships
+    ADD CONSTRAINT fk_rails_092b9b8356 FOREIGN KEY (person_id) REFERENCES people(id);
+
+
+--
+-- Name: fk_rails_aaf389f138; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY memberships
+    ADD CONSTRAINT fk_rails_aaf389f138 FOREIGN KEY (group_id) REFERENCES groups(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -584,3 +600,7 @@ INSERT INTO schema_migrations (version) VALUES ('20150407101222');
 INSERT INTO schema_migrations (version) VALUES ('20150413101844');
 
 INSERT INTO schema_migrations (version) VALUES ('20150417141735');
+
+INSERT INTO schema_migrations (version) VALUES ('20150604110007');
+
+INSERT INTO schema_migrations (version) VALUES ('20150604110654');


### PR DESCRIPTION
It should not be the case that a `Membership` exists separately from either a `Person` or a `Group`. Nonetheless, this was the case on staging after penetration testing. This situation manifested as a 500 error; the real problem was that a `nil` `Group` was not expected. The `Membership` referred to a `Group` that had been deleted, but nothing cascaded the deletion to the `Membership`, and there was no database-level enforcement of consistency.

The fix is in three parts:

1. Delete any orphaned `memberships` from the database.
2. Add `NOT NULL` and foreign key constraints to ensure that orphaned memberships cannot exist in future.
3. Add the missing `dependent: :destroy` on `Membership` to ensure that deleting a group will delete its membership.