### PR TITLE
Enqueue all data needed to email deleted user

### DIFF
--- a/app/mailers/user_update_mailer.rb
+++ b/app/mailers/user_update_mailer.rb
@@ -16,10 +16,10 @@ class UserUpdateMailer < ActionMailer::Base
     mail to: @person.email
   end
 
-  def deleted_profile_email(person, by_email = nil)
-    @person = person
+  def deleted_profile_email(recipient_email, recipient_name, by_email = nil)
     @by_email = by_email
-    mail to: @person.email
+    @name = recipient_name
+    mail to: recipient_email
   end
 
 private

--- a/app/services/person_destroyer.rb
+++ b/app/services/person_destroyer.rb
@@ -26,7 +26,7 @@ private
   def send_destroy_email!
     if @person.notify_of_change?(@current_user)
       UserUpdateMailer.deleted_profile_email(
-        @person, @current_user.email
+        @person.email, @person.given_name, @current_user.email
       ).deliver_later
     end
   end

--- a/app/views/user_update_mailer/deleted_profile_email.html.erb
+++ b/app/views/user_update_mailer/deleted_profile_email.html.erb
@@ -10,7 +10,7 @@
         </tr>
         <tr>
           <td width="560" align="left" valign="top" style="font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:30px;color:#434343;padding-bottom:20px;border-collapse:collapse;">
-            Hello <%= @person.given_name %>,
+            Hello <%= @name %>,
           </td>
         </tr>
         <tr>

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature 'Person maintenance' do
   include PermittedDomainHelper
+  include ActiveJobHelper
 
   let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
   before do
@@ -274,9 +275,16 @@ feature 'Person maintenance' do
   context 'Deleting a person' do
     scenario 'Deleting a person' do
       person = create(:person)
+      email_address = person.email
+      given_name = person.given_name
+
       visit edit_person_path(person)
       click_link('Delete this profile')
       expect { Person.find(person.id) }.to raise_error(ActiveRecord::RecordNotFound)
+
+      expect(last_email.to).to include(email_address)
+      expect(last_email.subject).to eq('Your profile on MOJ People Finder has been deleted')
+      expect(last_email.body.encoded).to match("Hello #{given_name}")
     end
 
     scenario 'Allow deletion of a person even when there are memberships' do

--- a/spec/services/person_destroyer_spec.rb
+++ b/spec/services/person_destroyer_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe PersonDestroyer, type: :service do
       'Person',
       destroy!: true,
       new_record?: false,
-      notify_of_change?: false
+      notify_of_change?: false,
+      email: 'user@example.com',
+      given_name: 'Rupert'
     )
   }
   let(:current_user) { double('Current User', email: 'user@example.com') }
@@ -53,7 +55,7 @@ RSpec.describe PersonDestroyer, type: :service do
       mailing = double('mailing')
       expect(class_double('UserUpdateMailer').as_stubbed_const).
         to receive(:deleted_profile_email).
-        with(person, current_user.email).
+        with(person.email, person.given_name, current_user.email).
         and_return(mailing)
       expect(mailing).to receive(:deliver_later)
       subject.destroy!


### PR DESCRIPTION
Previously, we pushed the user ID to the queue. Within the transaction of the test environment, this works. In the wild, the queue is consumed in a different context, in which the user no longer exists.

We can delete the defective queue entries after deploying this.