### PR TITLE
A more helpful login prompt

### DIFF
--- a/app/assets/stylesheets/peoplefinder/application.scss
+++ b/app/assets/stylesheets/peoplefinder/application.scss
@@ -327,6 +327,13 @@ form input[readonly] {
   padding: 7px 30px;
 }
 
+.login-email-info {
+  background: #ededed image-url('icon_info.png') scroll no-repeat 15px 20px;
+  padding: 15px 15px 20px 90px;
+  margin-top: 15px;
+  font-size: 1.2em;
+}
+
 @media screen and (max-width: 640px) {
  .form-hint{
    width: 50%;

--- a/app/views/tokens/create.html.haml
+++ b/app/views/tokens/create.html.haml
@@ -1,2 +1,5 @@
-%h1.h3.no-line= t('tokens.create.title')
-%p= t('tokens.create.body')
+%h1.no-line= t('tokens.create.title')
+%div.login-email-info.grid-2-3
+  %p= t('tokens.create.body_intro')
+  %p= t('tokens.create.body_informative_html')
+  %p= t('tokens.create.body_dont_panic')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,8 +38,10 @@ en:
     show:
       token_auth_disabled: "Sorry, that login link is invalid. Please login using your Google account."
     create:
-      title: Please check your emails
-      body: We are sending you a link to log in to People Finder.
+      title: Link sent — check your email
+      body_intro: We're just emailing you a link to access People Finder. This can take up to 5 minutes.
+      body_informative_html: Please check your inbox for this email from <a href="mailto:people-finder-support@digital.justice.gov.uk">people-finder-support@digital.justice.gov.uk</a>.
+      body_dont_panic: If you can't find it, check your junk folder and add our address to your safe list.
       token_auth_disabled: "Sorry, the alternate login method is not availabe. Please login using your Google account."
   controllers:
     groups:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,9 +39,9 @@ en:
       token_auth_disabled: "Sorry, that login link is invalid. Please login using your Google account."
     create:
       title: Link sent — check your email
-      body_intro: We're just emailing you a link to access People Finder. This can take up to 5 minutes.
+      body_intro: We’re just emailing you a link to access People Finder. This can take up to 5 minutes.
       body_informative_html: Please check your inbox for this email from <a href="mailto:people-finder-support@digital.justice.gov.uk">people-finder-support@digital.justice.gov.uk</a>.
-      body_dont_panic: If you can't find it, check your junk folder and add our address to your safe list.
+      body_dont_panic: If you can’t find it, check your junk folder and add our address to your safe list.
       token_auth_disabled: "Sorry, the alternate login method is not availabe. Please login using your Google account."
   controllers:
     groups:
@@ -61,7 +61,7 @@ en:
       expired_token: |
         The authentication token has expired and is more than %{time} hours old.
         Request a new link to log in.
-      invalid_token: "The authentication token doesn't exist and so isn't valid"
+      invalid_token: "The authentication token doesn’t exist and so isn’t valid"
     admin/person_uploads:
         upload_succeeded: "Successfully uploaded %{count} people"
         upload_failed: "Upload failed"
@@ -98,7 +98,7 @@ en:
   people:
     form:
       notes:
-        email: "Note: You can't change this email address. If it's changed, you must delete this profile and create a new one."
+        email: "Note: You can’t change this email address. If it’s changed, you must delete this profile and create a new one."
     day_names:
       works_monday: "Monday"
       works_tuesday: "Tuesday"
@@ -184,7 +184,7 @@ en:
       token:
         invalid_address: "Email address is not formatted correctly"
         invalid_domain: "Email address is not valid"
-        token_throttle_limit: "You've reached the limit of %{limit} tokens requested within an hour"
+        token_throttle_limit: "You’ve reached the limit of %{limit} tokens requested within an hour"
       group:
         attributes:
           base:

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -31,7 +31,7 @@ feature 'Token Authentication' do
     visit '/'
     fill_in 'token_user_email', with: 'james.darling@digital.justice.gov.uk'
     expect { click_button 'Request link' }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    expect(page).to have_text('We\'re just emailing you a link to access People Finder')
+    expect(page).to have_text('We’re just emailing you a link to access People Finder')
 
     expect(last_email.to).to eql(['james.darling@digital.justice.gov.uk'])
     expect(last_email.body.encoded).to have_text(token_url(Token.last))
@@ -41,7 +41,7 @@ feature 'Token Authentication' do
     visit '/'
     fill_in 'token_user_email', with: ' correct@digital.justice.gov.uk '
     click_button 'Request link'
-    expect(page).to have_text('We\'re just emailing you a link to access People Finder')
+    expect(page).to have_text('We’re just emailing you a link to access People Finder')
 
     expect(last_email.to).to include('correct@digital.justice.gov.uk')
   end
@@ -63,7 +63,7 @@ feature 'Token Authentication' do
     expect(page).to_not have_text('Signed in as')
     expect(page).to_not have_text('Start building your profile now')
 
-    expect(page).to have_text("The authentication token doesn't exist and so isn't valid")
+    expect(page).to have_text("The authentication token doesn’t exist and so isn’t valid")
   end
 
   scenario "logging in with a token that's more than 3 hours old" do
@@ -82,11 +82,11 @@ feature 'Token Authentication' do
       fill_in 'token_user_email', with: ' tony.stark@digital.justice.gov.uk '
       click_button 'Request link'
       if count < 9
-        expect(page).to have_text('We\'re just emailing you a link to access People Finder')
-        expect(page).to_not have_text("You've reached the limit of 8 tokens requested within an hour")
+        expect(page).to have_text('We’re just emailing you a link to access People Finder')
+        expect(page).to_not have_text("You’ve reached the limit of 8 tokens requested within an hour")
       else
-        expect(page).not_to have_text('We\'re just emailing you a link to access People Finder')
-        expect(page).to have_text("You've reached the limit of 8 tokens requested within an hour")
+        expect(page).not_to have_text('We’re just emailing you a link to access People Finder')
+        expect(page).to have_text("You’ve reached the limit of 8 tokens requested within an hour")
       end
     end
   end

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -31,7 +31,7 @@ feature 'Token Authentication' do
     visit '/'
     fill_in 'token_user_email', with: 'james.darling@digital.justice.gov.uk'
     expect { click_button 'Request link' }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    expect(page).to have_text('We are sending you a link to log in')
+    expect(page).to have_text('We\'re just emailing you a link to access People Finder')
 
     expect(last_email.to).to eql(['james.darling@digital.justice.gov.uk'])
     expect(last_email.body.encoded).to have_text(token_url(Token.last))
@@ -41,7 +41,7 @@ feature 'Token Authentication' do
     visit '/'
     fill_in 'token_user_email', with: ' correct@digital.justice.gov.uk '
     click_button 'Request link'
-    expect(page).to have_text('We are sending you a link to log in')
+    expect(page).to have_text('We\'re just emailing you a link to access People Finder')
 
     expect(last_email.to).to include('correct@digital.justice.gov.uk')
   end
@@ -82,10 +82,10 @@ feature 'Token Authentication' do
       fill_in 'token_user_email', with: ' tony.stark@digital.justice.gov.uk '
       click_button 'Request link'
       if count < 9
-        expect(page).to have_text('We are sending you a link to log in')
+        expect(page).to have_text('We\'re just emailing you a link to access People Finder')
         expect(page).to_not have_text("You've reached the limit of 8 tokens requested within an hour")
       else
-        expect(page).to_not have_text('We are sending you a link to log in')
+        expect(page).not_to have_text('We\'re just emailing you a link to access People Finder')
         expect(page).to have_text("You've reached the limit of 8 tokens requested within an hour")
       end
     end


### PR DESCRIPTION
After the user enters their email address, a login token is generated and sent
to the user via email. The next page has a bit of informative text prompting the
user to check their emails for a login token.

This page used to look like an error message or a broken page rather than an
important piece of information. We've styled the page and changed the copy to
make it more appealing and hopefully it will be ignored less.