### PR TITLE
Make legacy profile images continue to work

### DIFF
--- a/app/assets/javascripts/peoplefinder/photo_upload.js
+++ b/app/assets/javascripts/peoplefinder/photo_upload.js
@@ -122,12 +122,9 @@ var PhotoUpload = (function (){
       var els = PhotoUpload.findElements(event.target);
       var cropData = els.$preview.data('new-crop-data');
       var previewBoxWidth  = els.$preview.closest('.preview-box').width();
-      var previewBoxHeight = els.$preview.closest('.preview-box').height();
       var naturalWidth  = els.$preview.naturalWidth();
-      var naturalHeight = els.$preview.naturalHeight();
 
       var xaspect = previewBoxWidth  / naturalWidth;
-      var yaspect = previewBoxHeight / naturalHeight;
 
       els.$crop_x.val(cropData.x);
       els.$crop_y.val(cropData.y);

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -97,10 +97,6 @@ private
     ]
   end
 
-  def successful_redirect_path
-    @person
-  end
-
   def set_org_structure
     @org_structure = Group.arrange.to_h
   end
@@ -119,7 +115,7 @@ private
       creator = PersonCreator.new(@person, current_user)
       creator.create!
       notice :profile_created, person: @person
-      redirect_to successful_redirect_path
+      redirect_to @person
     end
   end
 
@@ -132,7 +128,7 @@ private
 
       type = @person == current_user ? :mine : :other
       notice :profile_updated, type, person: @person
-      redirect_to successful_redirect_path
+      redirect_to @person
     end
   end
 

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -8,7 +8,7 @@ module PeopleHelper
   end
 
   def profile_image_tag(person, options = {})
-    source = person.image.try(:medium) || 'medium_no_photo.png'
+    source = person.profile_image.try(:medium) || 'medium_no_photo.png'
     content_tag(:div, class: 'maginot') {
       image_tag(source, options.merge(alt: "Current photo of #{ person }")) +
       content_tag(:div, class: 'barrier') {}

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,9 +40,13 @@ class Person < ActiveRecord::Base
     profile_photo.crop crop_x, crop_y, crop_w, crop_h if crop_x.present?
   end
 
+  mount_uploader :legacy_image, ImageUploader, mount_on: :image, mount_as: :image
+
   def profile_image
     if profile_photo
       profile_photo.image
+    elsif attributes['image']
+      legacy_image
     else
       nil
     end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,7 +40,13 @@ class Person < ActiveRecord::Base
     profile_photo.crop crop_x, crop_y, crop_w, crop_h if crop_x.present?
   end
 
-  delegate :image, to: :profile_photo, allow_nil: true
+  def profile_image
+    if profile_photo
+      profile_photo.image
+    else
+      nil
+    end
+  end
 
   validates :given_name, presence: true, on: :update
   validates :surname, presence: true

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -12,7 +12,7 @@ class ImageUploader < CarrierWave::Uploader::Base
     '%suploads/peoplefinder/%s/%s/%s' % [
       base_upload_dir,
       model.class.to_s.underscore,
-      mounted_as,
+      mounted_as_without_legacy_prefix,
       model.id
     ]
   end
@@ -40,6 +40,10 @@ class ImageUploader < CarrierWave::Uploader::Base
         img
       end
     end
+  end
+
+  def mounted_as_without_legacy_prefix
+    mounted_as.to_s.sub(/^legacy_/, '')
   end
 
   # Add a white list of extensions which are allowed to be uploaded.

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -27,9 +27,7 @@ class ImageUploader < CarrierWave::Uploader::Base
     process quality: 60
   end
 
-  version :croppable do
-    # process resize_to_limit: [1024, 1024]
-  end
+  version :croppable
 
   def crop
     if model.crop_x.present?

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -203,4 +203,28 @@ RSpec.describe Person, type: :model do
       end
     end
   end
+
+  describe 'profile_image' do
+    context 'when there is a profile photo' do
+      it 'delegates to the profile photo' do
+        profile_photo = create(:profile_photo)
+        person.profile_photo = profile_photo
+        expect(person.profile_image).to eq(profile_photo.image)
+      end
+    end
+
+    context 'when there is a legacy image but no profile photo' do
+      it 'returns the mounted uploader' do
+        person.assign_attributes image: 'cats.gif'
+        expect(person.profile_image).to be_kind_of(ImageUploader)
+      end
+    end
+
+    context 'when there is no image' do
+      it 'returns nil' do
+        person.assign_attributes image: nil
+        expect(person.profile_image).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/profile_photo_spec.rb
+++ b/spec/models/profile_photo_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProfilePhoto, type: :model do
     create(:profile_photo)
   }
 
-  it 'should crop the image' do
+  it 'crops the image' do
     expect(subject.image).to receive(:recreate_versions!)
     subject.crop(1, 2, 3, 4)
     expect(subject.crop_x).to eq(1)

--- a/spec/support/profile.rb
+++ b/spec/support/profile.rb
@@ -10,7 +10,7 @@ module SpecSupport
         location_in_building: '10.999',
         building: '102 Petty France',
         city: 'London',
-        description: 'Lorem ipsum dolor sit amet...',
+        description: 'Lorem ipsum dolor sit amet...'
       }
     end
 

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -4,34 +4,46 @@ RSpec.describe ImageUploader, type: :uploader do
   include CarrierWave::Test::Matchers
   include PermittedDomainHelper
 
-  let(:profile_photo) { create(:profile_photo, image: File.open(sample_image)) }
-  subject { profile_photo.image }
-
   before do
     described_class.enable_processing = true
   end
 
-  it 'creates default image sizes' do
-    expect(subject.croppable).to be_no_larger_than(1024, 1024)
-    expect(subject.medium).to be_no_larger_than(512, 512)
-  end
-
-  it 'crops the medium image and leaves the croppable version intact' do
-    profile_photo.assign_attributes(crop_x: 10, crop_y: 10, crop_w: 20, crop_h: 20)
-    subject.recreate_versions!
-
-    expect(subject.croppable).to be_no_larger_than(1024, 1024)
-    expect(subject.medium).to have_dimensions(20, 20)
-  end
-
-  it 'has a consistent path' do
-    # If you change this, you must also consider what to do with legacy image
-    # uploads.
-    expect(subject.store_dir).
-      to eq("uploads/peoplefinder/profile_photo/image/#{profile_photo.id}")
-  end
-
   after do
     described_class.enable_processing = false
+  end
+
+  context 'with a profile photo object' do
+    let(:profile_photo) { create(:profile_photo, image: File.open(sample_image)) }
+    subject { profile_photo.image }
+
+    it 'creates default image sizes' do
+      expect(subject.croppable).to be_no_larger_than(1024, 1024)
+      expect(subject.medium).to be_no_larger_than(512, 512)
+    end
+
+    it 'crops the medium image and leaves the croppable version intact' do
+      profile_photo.assign_attributes(crop_x: 10, crop_y: 10, crop_w: 20, crop_h: 20)
+      subject.recreate_versions!
+
+      expect(subject.croppable).to be_no_larger_than(1024, 1024)
+      expect(subject.medium).to have_dimensions(20, 20)
+    end
+
+    it 'has a consistent path' do
+      # If you change this, you must also consider what to do with legacy image
+      # uploads.
+      expect(subject.store_dir).
+        to eq("uploads/peoplefinder/profile_photo/image/#{profile_photo.id}")
+    end
+  end
+
+  context 'with a person object' do
+    let(:person) { create(:person, image: File.open(sample_image)) }
+    subject { person.legacy_image }
+
+    it 'has a consistent path' do
+      expect(subject.store_dir).
+        to eq("uploads/peoplefinder/person/image/#{person.id}")
+    end
   end
 end


### PR DESCRIPTION
With the merge of #139, profile photos are now stored against a separate object. This poses a problem for all the existing photos, because the path is dynamically generated by CarrierWave based on class and ID. It's not trivial to move all the objects in S3, nor to change CarrierWave to a more (how shall we say?) forward-thinking path strategy.

Instead, we'll continue to mount the image uploader on the Person as before, and return it for `profile_image` only if there is not an associated profile photo object.
