### PR TITLE
Use Bombshelter to prevent image size DoS attack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'will_paginate', '~> 3.0'
 gem 'carrierwave',
   git: 'https://github.com/carrierwaveuploader/carrierwave.git',
   tag: 'cc39842e44edcb6187b2d379a606ec48a6b5e4a8'
+gem 'carrierwave-bombshelter'
 gem 'omniauth-gplus',
   git: 'https://github.com/ministryofjustice/omniauth-gplus.git'
 
@@ -71,4 +72,8 @@ end
 
 group :development, :test, :assets do
   gem 'dotenv-rails'
+end
+
+group :test do
+  gem 'fuubar'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    carrierwave-bombshelter (0.1.0.2)
+      activesupport (>= 3.2.0)
+      carrierwave
+      fastimage
     cliver (0.3.2)
     coderay (1.1.0)
     coercible (1.0.0)
@@ -136,6 +140,8 @@ GEM
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
+    fastimage (1.7.0)
+      addressable (~> 2.3, >= 2.3.5)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     fog (1.29.0)
@@ -233,6 +239,9 @@ GEM
     formatador (0.2.5)
     friendly_id (5.0.5)
       activerecord (>= 4.0.0)
+    fuubar (2.0.0)
+      rspec (~> 3.0)
+      ruby-progressbar (~> 1.4)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     govspeak (3.3.0)
@@ -396,6 +405,10 @@ GEM
       mail
     ref (1.0.5)
     request_store (1.1.0)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
     rspec-core (3.2.2)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.0)
@@ -511,6 +524,7 @@ DEPENDENCIES
   brakeman
   capybara
   carrierwave!
+  carrierwave-bombshelter
   delayed_job_active_record
   dotenv-rails
   elasticsearch-model (~> 0.1.4)
@@ -520,6 +534,7 @@ DEPENDENCIES
   fog
   foreman
   friendly_id (~> 5.0.0)
+  fuubar
   govspeak
   govuk_frontend_toolkit
   govuk_template

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,6 +2,8 @@
 class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   include CarrierWave::DirHelpers
+  include CarrierWave::BombShelter
+
 
   # Storage location is configured per-environment in
   # config/initializers/carrierwave.rb


### PR DESCRIPTION
https://github.com/DarthSim/carrierwave-bombshelter was one of the
CarrierWave recommended solutions to the problem of image bombs. After a
quick review of it and the supporting FastImage gem, I decided that
using it was more sensible than trying to roll the same thing from
scratch.

This commit also include the fast-failing rspec formatter Fuubar and an
update to rspec.