### PR TITLE
Fix vulnerability to cryptographic timing attacks

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,3 +1,4 @@
+require 'secure'
 class TokensController < ApplicationController
   skip_before_action :ensure_user
   before_action :set_desired_path, only: [:show]
@@ -13,7 +14,7 @@ class TokensController < ApplicationController
   end
 
   def show
-    token = Token.where(value: params[:id]).first
+    token = find_token_securly(params[:id])
     if token
       verify_active_token(token)
     else
@@ -51,6 +52,12 @@ protected
   end
 
 private
+
+  def find_token_securly(token)
+    Token.find_each do |t|
+      return t if Secure.compare(t.value, token)
+    end
+  end
 
   def send_token_and_render(token)
     TokenMailer.new_token_email(token).deliver_later

--- a/lib/secure.rb
+++ b/lib/secure.rb
@@ -1,0 +1,12 @@
+class Secure
+
+  def self.compare(a, b)
+    return false if a.blank? || b.blank? || a.bytesize != b.bytesize
+    l = a.unpack "C#{a.bytesize}"
+
+    res = 0
+    b.each_byte { |byte| res |= byte ^ l.shift }
+    res == 0
+  end
+
+end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe TokensController, type: :controller do
+  describe 'GET show' do
+    context 'securly verifies that a token is valid and active' do
+      describe 'avoiding a method with differning repsonse times for valid and invalid tokens' do
+        it 'does not use Token.where(value: param[:id]).first' do
+          expect(Token).not_to receive(:where)
+          get :show, id: 'some token value'
+        end
+      end
+
+      describe 'using a method that takes a constant time regardless of the validity of the token' do
+        it 'loops over a block of tokens and finds the first match using Secure.compare' do
+          expect(Token).to receive(:find_each).and_yield(double('token', value: 'some token value'))
+          expect(Secure).to receive(:compare).with('some token value', 'some token value').and_return(true)
+          expect(controller).to receive(:verify_active_token).and_return(double.as_null_object)
+          expect{ get :show, id: 'some token value' }.to raise_error{ ActionView::MissingTemplate }
+        end
+      end
+    end
+  end
+end
+

--- a/spec/lib/secure_spec.rb
+++ b/spec/lib/secure_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'secure'
+
+describe Secure do
+
+  it 'complains when comparing empty or different sized passes' do
+    [nil, ""].each do |empty|
+      expect(described_class.compare(empty, "something")).to be_falsey
+      expect(described_class.compare("something", empty)).to be_falsey
+      expect(described_class.compare(empty, empty)).to be_falsey
+    end
+    expect(described_class.compare("size_1", "size_four")).to be_falsey
+  end
+
+  it 'passes when things match' do
+    expect(described_class.compare("some token", "some token")).to be_truthy
+  end
+end


### PR DESCRIPTION
Ideally, this would have been implemented using Devise.secure_compare.
However, peoplefinder does not use Devise, so I decided to port the
logic and tests of that method into the app directly.  I also added a
controller spec for the the tokens_controller to ensure that it was
working end-to-end.

I am not entirely happy with my use of Token.find_each to locate the
correct token.  That said, it appeared to be cleanest way to implement
the lookup from a conceptual standpoint. I considered sorting the tokens
and then starting the find_each at the appropriate point in the recored
set. However, doing so seemed like premature optimisation at this
point.