### PR TITLE
Prevent info leakage about invalid domains

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -3,13 +3,16 @@ class TokensController < ApplicationController
   skip_before_action :ensure_user
   before_action :set_desired_path, only: [:show]
   before_action :ensure_token_auth_enabled!
+  REPORT_EMAIL_ERROR_REGEXP = %r{(not formatted correctly|reached the limit)}
 
   def create
     @token = Token.new(token_params)
     if @token.save
       send_token_and_render(@token)
-    else
+    elsif @token.errors[:user_email].first[REPORT_EMAIL_ERROR_REGEXP]
       render action: :new
+    else
+      render action: :create
     end
   end
 

--- a/spec/features/token_user_email_shared.rb
+++ b/spec/features/token_user_email_shared.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.shared_examples "it received a valid request from" do
+  it "and sends the email" do
+    delivery_count = sent_to.blank? ? 0 : 1
+    visit '/'
+    fill_in 'token_user_email', with: email
+    expect { click_button 'Request link' }.to change { ActionMailer::Base.deliveries.count }.by(delivery_count)
+    expect(page).to have_text('We’re just emailing you a link to access People Finder')
+
+    unless sent_to.blank?
+      expect(last_email.to).to eql([sent_to])
+      expect(last_email.body.encoded).to have_text(token_url(Token.last))
+    end
+  end
+end


### PR DESCRIPTION
The original pentest flagged a possible vulnerability regarding an
attacker brute-forcing the token authentication to ennumerate all of the
valid emails in the department.  It turns out this is not possible as
the token generator only checks for valid emails and valid domains.  It
is also rate-limited to 8 requests per hour. Nevertheless, after
discussions with our pentesters, I have disabled warnings regarding
invalid domains.