### PR TITLE
Removes a token after use

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -32,6 +32,7 @@ protected
     if token.active?
       person = FindCreatePerson.from_token(token)
       login_person(person)
+      token.destroy!
     else
       error :expired_token, time: ttl_seconds_in_hours
       redirect_to new_sessions_path

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -19,6 +19,15 @@ describe TokensController, type: :controller do
         end
       end
     end
+
+    context 'token usage' do
+      before { PermittedDomain.find_or_create_by(domain: 'digital.justice.gov.uk') }
+      let!(:token) { create(:token) }
+
+      it 'token gets removed after use' do
+        expect { get :show, id: token.value; }.to change{ Token.count }.by(-1)
+      end
+    end
   end
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,11 @@
 require "codeclimate-test-reporter"
+require 'simplecov-rcov'
 CodeClimate::TestReporter.start
+SimpleCov.start 'rails' do
+  add_filter '/gem/'
+  add_filter '.bundle'
+end
+SimpleCov.minimum_coverage 100
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,8 @@ end
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 3
 
+require 'site_prism'
+require 'pry-byebug'
 Dir[File.expand_path('../../{lib,app/*}', __FILE__)].each do |path|
   $LOAD_PATH.unshift(path) unless $LOAD_PATH.include?(path)
 end


### PR DESCRIPTION
The pentest recommended token expiry after use.  On review, it seemed more sensible to remove expired tokens.  I haven't made an exhaustive code review.  However, the token_controller creates a new one each time a login is requested and the old ones are never reused for token login.

The remedy for the cryptographic timing attack required a find_batch on all tokens.  Removing tokens as they are used keeps us from having to scope that find_batch to active tokens, setting up a cron job to remove expired tokens later, or just waiting for that find_batch to slow down due to the ever growing number of records.