### PR TITLE
Enables codeclimate coverage tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,5 @@ end
 
 group :test do
   gem 'fuubar'
+  gem 'codeclimate-test-reporter', require: nil
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       carrierwave
       fastimage
     cliver (0.3.2)
+    codeclimate-test-reporter (0.4.8)
+      simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -525,6 +527,7 @@ DEPENDENCIES
   capybara
   carrierwave!
   carrierwave-bombshelter
+  codeclimate-test-reporter
   delayed_job_active_record
   dotenv-rails
   elasticsearch-model (~> 0.1.4)


### PR DESCRIPTION
With the CODECLIMATE_REPO_TOKEN set.  I've already set this in circleci,
so it should just work.