### PR TITLE
 Add email field to feedback form

### DIFF
--- a/app/assets/stylesheets/peoplefinder/feedback.scss
+++ b/app/assets/stylesheets/peoplefinder/feedback.scss
@@ -14,7 +14,7 @@
       display: block;
     }
     textarea{
-      width:100%;
+      height: 3em;
     }
   }
 }

--- a/app/controllers/problem_reports_controller.rb
+++ b/app/controllers/problem_reports_controller.rb
@@ -11,7 +11,7 @@ private
 
   def problem_report_params
     params.require(:problem_report).
-      permit(:goal, :problem, :browser).
+      permit(:goal, :problem, :browser, :person_email).
       merge(current_user_params).
       merge(ip_address: request.remote_ip)
   end

--- a/app/views/shared/_feedback_form.html.haml
+++ b/app/views/shared/_feedback_form.html.haml
@@ -3,14 +3,15 @@
     %a{href: '#feedback', id: 'feedbackToggle'}
       Report a problem
     = form_for ProblemReport.new, id: 'feedback' do |f|
-      = f.label :goal do
-        What were you trying to do?
-      = f.text_area :goal
+      .form-group
+        = f.label :goal do
+          What were you trying to do?
+        = f.text_area :goal, class: 'form-control'
 
-      = f.label :problem do
-        What went wrong?
-      = f.text_area :problem
+        = f.label :problem do
+          What went wrong?
+        = f.text_area :problem, class: 'form-control'
 
-      = f.hidden_field :browser
+        = f.hidden_field :browser
 
       = f.submit class: 'button'

--- a/app/views/shared/_feedback_form.html.haml
+++ b/app/views/shared/_feedback_form.html.haml
@@ -12,6 +12,11 @@
           What went wrong?
         = f.text_area :problem, class: 'form-control'
 
+        - unless current_user
+          = f.label :person_email do
+            Your email
+          = f.text_field :person_email, class: 'form-control'
+
         = f.hidden_field :browser
 
       = f.submit class: 'button'

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -48,6 +48,7 @@ feature 'Report a problem', js: true do
       visit new_sessions_path
 
       find('a', text: 'Report a problem').trigger('click')
+      fill_in 'Your email', with: 'test@example.com'
       fill_in 'What were you trying to do?', with: 'Rhubarb'
       fill_in 'What went wrong?', with: 'Custard'
       click_button 'Report'
@@ -60,7 +61,7 @@ feature 'Report a problem', js: true do
       expect(body).to have_text('Rhubarb')
       expect(body).to have_text('Custard')
       expect(body).to match(/Browser: .*?PhantomJS/)
-      expect(body).to have_text('Email: unknown')
+      expect(body).to have_text('Email: test@example.com')
       expect(body).to have_text('Person ID: unknown')
       expect(body).to match(/Reported: 2014-09-09T21:27:..Z/)
     end


### PR DESCRIPTION
Add email field to feedback form when user logged out. Otherwise the user's email is unknown, and it is not possible to reply to the user.