### PR TITLE
Acquisition and activation metrics

### DIFF
--- a/app/controllers/metrics/activations_controller.rb
+++ b/app/controllers/metrics/activations_controller.rb
@@ -1,0 +1,60 @@
+module Metrics
+  class ActivationsController < ApplicationController
+    skip_before_action :ensure_user
+
+    def index
+      date = params[:cohort_split_date]
+      date = Date.parse(date).to_s
+
+      bullet_graph = {
+        orientation: "horizontal",
+        item: [
+          aquisition_bullet_graph(date),
+          activation_bullet_graph(date)
+        ]
+      }
+
+      render json: bullet_graph.to_json
+    end
+
+    private
+
+    def aquisition_bullet_graph date
+      acquired_percentage = Person.acquired_percentage(from: date)
+
+      bullet_graph label: "#{acquired_percentage}% logged in at least once",
+        sublabel: "users created from #{date}",
+        current_end: acquired_percentage,
+        comparative_point: Person.acquired_percentage(before: date)
+    end
+
+    def activation_bullet_graph date
+      activated_percentage = Person.activated_percentage(from: date)
+
+      bullet_graph label: "#{activated_percentage}% of acquired users completed > 80%",
+        sublabel: "users created from #{date}",
+        current_end: activated_percentage,
+        comparative_point: Person.activated_percentage(before: date)
+    end
+
+    def bullet_graph label:, sublabel:, current_end:, comparative_point:
+      {
+        label: label,
+        sublabel: sublabel,
+        axis: {
+          point: [0, 20, 40, 60, 80, 100]
+        },
+        range: {
+          red:   { start:  0, end:  20 },
+          amber: { start: 21, end:  80 },
+          green: { start: 81, end: 100 }
+        },
+        measure: {
+          current:   { start: 0, end: current_end },
+          projected: { start: 0, end: 0 }
+        },
+        comparative: { point: comparative_point }
+      }
+    end
+  end
+end

--- a/app/models/concerns/acquisition.rb
+++ b/app/models/concerns/acquisition.rb
@@ -3,14 +3,20 @@ module Concerns::Acquisition
 
   included do
     # % of people who have logged in at least once
-    def self.acquired_percentage
+    def self.acquired_percentage from: nil, before: nil
       people_count = Person.count
       if people_count == 0
         0.0
       else
-        acquired_count = Person.where("people.login_count > 0").count
-        (acquired_count.to_f / people_count * 100).round(0)
+        (acquired_count(from: from, before: before).to_f / people_count * 100).round(0)
       end
+    end
+
+    def self.acquired_count from: nil, before: nil
+      acquired = Person.where("people.login_count > 0")
+      acquired = acquired.where("created_at >= ?", from) if from
+      acquired = acquired.where("created_at < ?", before) if before
+      acquired.count
     end
 
   end

--- a/app/models/concerns/acquisition.rb
+++ b/app/models/concerns/acquisition.rb
@@ -1,0 +1,17 @@
+module Concerns::Acquisition
+  extend ActiveSupport::Concern
+
+  included do
+    # % of people who have logged in at least once
+    def self.acquired_percentage
+      people_count = Person.count
+      if people_count == 0
+        0.0
+      else
+        acquired_count = Person.where("people.login_count > 0").count
+        (acquired_count.to_f / people_count * 100).round(0)
+      end
+    end
+
+  end
+end

--- a/app/models/concerns/activation.rb
+++ b/app/models/concerns/activation.rb
@@ -3,8 +3,10 @@ module Concerns::Activation
 
   included do
     # % of people that have completeness > 80%
-    def self.activated_percentage
+    def self.activated_percentage from: nil, before: nil
       acquired = Person.where("people.login_count > 0")
+      acquired = acquired.where("created_at >= ?", from) if from
+      acquired = acquired.where("created_at < ?", before) if before
 
       if acquired.count == 0
         0

--- a/app/models/concerns/activation.rb
+++ b/app/models/concerns/activation.rb
@@ -1,0 +1,18 @@
+module Concerns::Activation
+  extend ActiveSupport::Concern
+
+  included do
+    # % of people that have completeness > 80%
+    def self.activated_percentage
+      acquired = Person.where("people.login_count > 0")
+
+      if acquired.count == 0
+        0
+      else
+        activated_count = acquired.to_a.count { |a| a.completion_score > 80 }
+        (activated_count.to_f / acquired.count * 100).round(0)
+      end
+    end
+
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,5 @@
 class Person < ActiveRecord::Base
+  include Concerns::Acquisition
   include Concerns::Completion
   include Concerns::WorkDays
   include Concerns::ExposeMandatoryFields

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,6 @@
 class Person < ActiveRecord::Base
   include Concerns::Acquisition
+  include Concerns::Activation
   include Concerns::Completion
   include Concerns::WorkDays
   include Concerns::ExposeMandatoryFields

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   get '/groups/:id/people', to: redirect('/teams/%{id}/people')
 
   namespace :metrics do
+    resources :activations, only: [:index]
     resources :completions, only: [:index]
     resources :profiles, only: [:index]
   end

--- a/spec/controllers/metrics/activations_controller_spec.rb
+++ b/spec/controllers/metrics/activations_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+RSpec.describe Metrics::ActivationsController, type: :controller do
+  let(:date) { Date.parse("2015-11-11").to_s }
+  let(:parsed_body) { JSON.parse(response.body).deep_symbolize_keys }
+
+  describe 'GET index' do
+    it 'returns geckoboard bullet graph JSON for acquisitions and activations' do
+      allow(Person).to receive(:acquired_percentage).with(from: date).and_return(37)
+      allow(Person).to receive(:acquired_percentage).with(before: date).and_return(80)
+      allow(Person).to receive(:activated_percentage).with(from: date).and_return(20)
+      allow(Person).to receive(:activated_percentage).with(before: date).and_return(10)
+      expected = {
+        orientation:"horizontal",
+        item: [
+          {
+            label: "37% logged in at least once",
+            sublabel: "users created from 2015-11-11",
+            axis: {
+              point: [0, 20, 40, 60, 80, 100]
+            },
+            range: {
+              red:   { start: 0,  end: 20 },
+              amber: { start: 21, end: 80 },
+              green: { start: 81, end: 100 }
+            },
+            measure: {
+              current:   { start: 0, end: 37 },
+              projected: { start: 0, end: 0 }
+            },
+            comparative: { point:80}
+          },
+          {
+            label: "20% of acquired users completed > 80%",
+            sublabel: "users created from 2015-11-11",
+            axis: {
+              point:[0, 20, 40, 60, 80, 100]
+            },
+            range: {
+              red:   { start:0,  end:20 },
+              amber: { start:21, end:80 },
+              green: { start:81, end:100 }
+            },
+            measure: {
+              current:   { start:0, end:20 },
+              projected: { start:0, end:0 }
+            },
+            comparative: { point:10 }
+          }
+        ]
+      }
+      get :index, cohort_split_date: date
+      expect(parsed_body).to eq(expected)
+    end
+
+    it 'returns 200 OK' do
+      get :index, cohort_split_date: date
+      expect(response).to be_ok
+    end
+  end
+end

--- a/spec/models/concerns/acquisition_spec.rb
+++ b/spec/models/concerns/acquisition_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Acquisition' do
+  include PermittedDomainHelper
+
+  context '.acquired_percentage' do
+    it 'returns 0 when no profiles' do
+      expect(Person.acquired_percentage).to eq(0)
+    end
+
+    it 'returns 0 when one person who has not logged in' do
+      create(:person, login_count: 0)
+      expect(Person.acquired_percentage).to eq(0)
+    end
+
+    it 'returns 100 when one person who has logged in' do
+      create(:person, login_count: 1)
+      expect(Person.acquired_percentage).to eq(100)
+    end
+
+    it 'returns 50 if two people, one who has logged in, one who has not' do
+      create(:person, login_count: 1)
+      create(:person, login_count: 0)
+      expect(Person.acquired_percentage).to eq(50)
+    end
+
+    it 'returns 67 when 3 people, two who have logged in, one who has not' do
+      create(:person, login_count: 1)
+      create(:person, login_count: 1)
+      create(:person, login_count: 0)
+      expect(Person.acquired_percentage).to eq(67)
+    end
+
+  end
+end

--- a/spec/models/concerns/acquisition_spec.rb
+++ b/spec/models/concerns/acquisition_spec.rb
@@ -31,5 +31,26 @@ RSpec.describe 'Acquisition' do
       expect(Person.acquired_percentage).to eq(67)
     end
 
+    context 'when one person created yesterday who has logged in' do
+      before do
+        create(:person, login_count: 1, created_at: Date.yesterday.to_time)
+      end
+
+      it 'returns 0 when from date is today' do
+        expect(Person.acquired_percentage(from: Date.today.to_s)).to eq(0)
+      end
+
+      it 'returns 100 when from date is yesterday' do
+        expect(Person.acquired_percentage(from: Date.yesterday.to_s)).to eq(100)
+      end
+
+      it 'returns 0 when before date is yesterday' do
+        expect(Person.acquired_percentage(before: Date.yesterday.to_s)).to eq(0)
+      end
+
+      it 'returns 100 when before date is today' do
+        expect(Person.acquired_percentage(before: Date.today.to_s)).to eq(100)
+      end
+    end
   end
 end

--- a/spec/models/concerns/activation_spec.rb
+++ b/spec/models/concerns/activation_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe 'Activation' do
+  include PermittedDomainHelper
+
+  let(:completed_attributes) {
+    {
+      given_name: 'Bobby',
+      surname: 'Tables',
+      email: 'user.example@digital.justice.gov.uk',
+      primary_phone_number: '020 7946 0123',
+      location_in_building: '13.13',
+      building: '102 Petty France',
+      city: 'London',
+      description: 'I am a real person',
+      profile_photo_id: profile_photo.id
+    }
+  }
+
+  let(:profile_photo) {
+    create(:profile_photo)
+  }
+
+  context '.activated_percentage' do
+    it 'returns 0 when no profiles' do
+      expect(Person.activated_percentage).to eq(0)
+    end
+
+    it 'returns 0 when one person who has not logged in' do
+      create(:person, login_count: 0)
+      expect(Person.activated_percentage).to eq(0)
+    end
+
+    it 'returns 0 when one person who has logged in but completeness < 80%' do
+      create(:person, login_count: 1)
+      expect(Person.activated_percentage).to eq(0)
+    end
+
+    it 'returns 100 when one person who has logged with completeness > 80%' do
+      create(:person, completed_attributes.merge(login_count: 1))
+      expect(Person.activated_percentage).to eq(100)
+    end
+
+    it 'returns 50 when two people who have logged in, one with completeness > 80%, one with completeness > 80%' do
+      create(:person, completed_attributes.merge(login_count: 1))
+      create(:person, login_count: 1)
+      expect(Person.activated_percentage).to eq(50)
+    end
+
+    it 'returns 67 when 3 people who have logged in, two with completeness > 80%, one with completeness > 80%' do
+      create(:person, completed_attributes.merge(login_count: 1))
+      create(:person, completed_attributes.merge(email: 'test2@digital.justice.gov.uk', login_count: 1))
+      create(:person, login_count: 1)
+      expect(Person.activated_percentage).to eq(67)
+    end
+
+    it 'returns 100 when two people one who has logged in with completeness > 80%, one who has not logged in' do
+      create(:person, completed_attributes.merge(login_count: 1))
+      create(:person, login_count: 0)
+      expect(Person.activated_percentage).to eq(100)
+    end
+  end
+end

--- a/spec/models/concerns/activation_spec.rb
+++ b/spec/models/concerns/activation_spec.rb
@@ -59,5 +59,27 @@ RSpec.describe 'Activation' do
       create(:person, login_count: 0)
       expect(Person.activated_percentage).to eq(100)
     end
+
+    context 'when one person created yesterday who has logged in and completion score > 80%' do
+      before do
+        create(:person, completed_attributes.merge(login_count: 1, created_at: Date.yesterday.to_time))
+      end
+
+      it 'returns 0 when from date is today' do
+        expect(Person.activated_percentage(from: Date.today.to_s)).to eq(0)
+      end
+
+      it 'returns 100 when from date is yesterday' do
+        expect(Person.activated_percentage(from: Date.yesterday.to_s)).to eq(100)
+      end
+
+      it 'returns 0 when before date is yesterday' do
+        expect(Person.activated_percentage(before: Date.yesterday.to_s)).to eq(0)
+      end
+
+      it 'returns 100 when before date is today' do
+        expect(Person.activated_percentage(before: Date.today.to_s)).to eq(100)
+      end
+    end
   end
 end


### PR DESCRIPTION
We plan to remove the requirement for users to be logged in to use the people finder service. We hypothesise this may effect the % of users that log in and complete their profile.

This pull request adds actionable metrics we can monitor to see the impact of the coming changes:

`Acquisition` - represents the **% of profiles** where user has **logged in at least once**.
`Activation` - represents **% of acquired users** that have profile **completion score > 80%**.

These metrics are to help identify where the drop-offs are. Helps us answer questions: Are users never logging in? Are users failing to complete their profile when logged in?

Adds new controller action to return bullet graph JSON for display on geckoboard dashboard.

**Adds metric methods via concerns, following the approach used by the existing completion metrics code. However it may be appropriate to move this logic out of concerns and into some other location in the codebase.**