### PR TITLE
Change login copy for unauthorised actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,6 +90,7 @@ private
   def user_not_authorized
     if logged_in_readonly?
       session[:desired_path] = request.fullpath
+      session[:unauthorised_login] = true
       redirect_to new_sessions_path
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,6 +14,7 @@ class SessionsController < ApplicationController
   end
 
   def new
+    @unauthorised_login = session.delete(:unauthorised_login)
   end
 
   def destroy

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -6,7 +6,9 @@ class TokensController < ApplicationController
   REPORT_EMAIL_ERROR_REGEXP = %r{(not formatted correctly|reached the limit)}
 
   def create
+    @unauthorised_login = params[:token][:unauthorised_login]
     @token = Token.new(token_params)
+
     if @token.save
       send_token_and_render(@token)
     elsif @token.errors[:user_email].first[REPORT_EMAIL_ERROR_REGEXP]

--- a/app/views/sessions/_login_page.html.haml
+++ b/app/views/sessions/_login_page.html.haml
@@ -3,8 +3,13 @@
 - content_for :body_classes, 'login-page'
 %h1.no-line= t('.heading')
 
--t('.intro').each_line do |line|
-  %p= line
+%div.description
+  - if @unauthorised_login
+    -t('.intro_unauthorised').each_line do |line|
+      %p= line
+  -else
+    -t('.intro').each_line do |line|
+      %p= line
 
 .spacer-25
 
@@ -18,6 +23,7 @@
       - if @token.errors.include?(:user_email)
         %span.error= @token.errors[:user_email].first
       = f.text_field :user_email, class: 'form-control'
+      = f.hidden_field(:unauthorised_login, value: @unauthorised_login)
 
     .spacer-20
     = f.submit t('.log_in_email'), class: 'button'

--- a/app/views/tokens/create.html.haml
+++ b/app/views/tokens/create.html.haml
@@ -1,5 +1,7 @@
 %h1.no-line= t('tokens.create.title')
 %div.login-email-info.grid-2-3
   %p= t('tokens.create.body_intro')
+  - if @unauthorised_login
+    %p= t('tokens.create.body_unauthorised')
   %p= t('tokens.create.body_informative_html')
   %p= t('tokens.create.body_dont_panic')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,9 @@ en:
       heading: Request link to access People Finder
       intro: |
         We will email you a secure link so you can log in to People Finder and create or edit profiles. The link will be active for 3 hours.
+      intro_unauthorised: |
+        For security reasons, you have to be logged in to People Finder to make any changes.
+        We will email you a secure link so you can log in. This link will be active for 3 hours.
       heading_google: Got a government Google account?
       body_google:
         If you have a Google account ending in gov.uk, you can log in now.
@@ -40,6 +43,7 @@ en:
     create:
       title: Link sent — check your email
       body_intro: We’re just emailing you a link to access People Finder. This can take up to 5 minutes.
+      body_unauthorised: When it arrives, click on the link (which is active for 3 hours). This will log you in to People Finder and enable you to make any changes.
       body_informative_html: Please check your inbox for this email from <a href="mailto:people-finder-support@digital.justice.gov.uk">people-finder-support@digital.justice.gov.uk</a>.
       body_dont_panic: If you can’t find it, check your junk folder and add our address to your safe list.
       token_auth_disabled: "Sorry, the alternate login method is not availabe. Please login using your Google account."

--- a/spec/features/login_page_spec.rb
+++ b/spec/features/login_page_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+feature 'Login page' do
+  include PermittedDomainHelper
+
+  let(:login_page) { Pages::Login.new }
+  let(:token_created_page) { Pages::TokenCreated.new }
+
+  context 'User from outside the network' do
+    scenario 'Is presented with standard login page and copy' do
+      visit '/'
+
+      expect(login_page).to be_displayed
+      expect(login_page.description).to have_text('We will email you a secure link so you can log in to People Finder and create or edit profiles.')
+    end
+  end
+  context 'User from inside the network' do
+    before do
+      page.driver.browser.header('RO', 'ENABLED')
+    end
+
+    scenario 'Is presented with standard login page and copy if they decide to login' do
+      visit '/sessions/new'
+
+      expect(login_page).to be_displayed
+      expect(login_page.description).to have_text('We will email you a secure link so you can log in to People Finder and create or edit profiles.')
+    end
+
+    scenario 'Is presented with special login page and copy if they are forced to login to make changes' do
+      person = create(:person)
+
+      visit person_path(person)
+      click_link 'Edit this profile'
+
+      expect(login_page).to be_displayed
+      expect(login_page.description).to have_text('For security reasons, you have to be logged in to People Finder to make any changes.')
+      expect(login_page.description).to have_text('We will email you a secure link so you can log in.')
+
+      login_page.email.set(person.email)
+      login_page.request_button.click
+
+      expect(token_created_page).to be_displayed
+      expect(token_created_page.info).to have_text('When it arrives, click on the link (which is active for 3 hours). This will log you in to People Finder and enable you to make any changes.')
+    end
+  end
+end

--- a/spec/support/pages/login.rb
+++ b/spec/support/pages/login.rb
@@ -1,5 +1,10 @@
 module Pages
   class Login < SitePrism::Page
     set_url_matcher(%r{/sessions/new$})
+
+    element :description, '.description'
+
+    element :email, '.new_token #token_user_email'
+    element :request_button, '.new_token .button'
   end
 end

--- a/spec/support/pages/token_created.rb
+++ b/spec/support/pages/token_created.rb
@@ -1,0 +1,7 @@
+module Pages
+  class TokenCreated < SitePrism::Page
+    set_url_matcher(%r{/tokens$})
+
+    element :info, '.login-email-info'
+  end
+end

--- a/spec/support/permitted_domain_helper.rb
+++ b/spec/support/permitted_domain_helper.rb
@@ -1,3 +1,5 @@
+# TODO: This helper should automatically be included to all specs and therefore we can avoid
+#       having the extra line in all specs
 module PermittedDomainHelper
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
Slightly different copy is required for the login screen when the readonly user tries to edit something. 