### PR TITLE
Change team leader checkbox text based on team selection

### DIFF
--- a/app/assets/javascripts/peoplefinder/autocomplete.js
+++ b/app/assets/javascripts/peoplefinder/autocomplete.js
@@ -44,12 +44,28 @@ var TeamAutocomplete = (function (){
       });
     },
 
+    setTeamLedText: function(select, teamLed) {
+      if (teamLed != null) {
+        var team = select.find('option').filter(':selected');
+        if (team != null) {
+          teamLed.text(team.text() + ' team');
+        }
+      }
+    },
+
     enhance: function ( o ){
       TeamAutocomplete.runTransformations(o);
 
-      $(o).select2({
+      var teamSelect = $(o).select2({
         templateResult: TeamAutocomplete.formatResults
-      }).addClass('team-select-enhanced');
+      });
+      var teamLed = $('#team-led');
+
+      teamSelect.addClass('team-select-enhanced');
+      teamSelect.on('change', function (e) {
+        TeamAutocomplete.setTeamLedText(teamSelect, teamLed);
+      });
+      TeamAutocomplete.setTeamLedText(teamSelect, teamLed);
     }
   };
 

--- a/app/views/people/_membership_fields.html.haml
+++ b/app/views/people/_membership_fields.html.haml
@@ -14,8 +14,9 @@
   .form-group
     = membership_f.label :leader, 'Team leader?', class: 'form-label-bold'
     = membership_f.check_box :leader
-    %span.hint= role_translate(membership.person, 'memberships.leader')
+    %span.hint= role_translate(membership.person, 'memberships.leader').html_safe
 
+  .form-group
     = membership_f.label :subscribed, 'Team updates', class: 'form-label-bold'
     = membership_f.check_box :subscribed, class: 'membership-subscribed-check-box'
     %span.hint= role_translate(membership.person, 'memberships.subscribed')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,10 +88,10 @@ en:
   memberships:
     leader:
       mine: |
-        Tick this box if you lead the team above.
+        Tick this box if you lead the <span id="team-led">team above</span>.
         (More than one person can be selected as team leader.)
       other: |
-        This person leads the team above.
+        This person leads the <span id="team-led">team above</span>.
         (More than one person can be selected as team leader.)
     subscribed:
       mine: |

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -15,7 +15,14 @@ feature "Person maintenance" do
     fill_in 'Surname', with: 'Taylor'
     fill_in 'Main email', with: person_attributes[:email]
     fill_in 'Job title', with: 'Head Honcho'
+
+    expect(page).to have_selector('#team-led', text: 'Ministry of Justice team')
+    expect(page).to have_selector('.hint', text: 'This person leads the Ministry of Justice team. (More than one person can be selected as team leader.)')
+
     select_in_team_select 'Digital Justice'
+
+    expect(page).to have_selector('#team-led', text: 'Digital Justice [MOJ] team')
+    expect(page).to have_selector('.hint', text: 'This person leads the Digital Justice [MOJ] team. (More than one person can be selected as team leader.)')
     check 'leader'
     click_button 'Save', match: :first
 
@@ -31,6 +38,7 @@ feature "Person maintenance" do
 
     javascript_log_in
     visit edit_person_path(person)
+    expect(page).to have_selector('#team-led', text: 'Digital Justice [MOJ] team')
 
     fill_in 'Job title', with: 'Head Honcho'
     click_button 'Save', match: :first
@@ -100,7 +108,7 @@ feature "Person maintenance" do
 end
 
 def create_person_in_digital_justice
-  department = create(:department, name: 'Digital Justice')
+  department = create(:department, name: 'Ministry of Justice')
   group = create(:group, name: 'Digital Justice', parent: department)
   person = create(:person)
   person.memberships.create(group: group)

--- a/spec/support/org_browser.rb
+++ b/spec/support/org_browser.rb
@@ -3,6 +3,7 @@ module SpecSupport
     def select_in_team_select(text)
       page.execute_script("$('select.team-select-enhanced').css({display: 'inherit'})")
       select text
+      page.execute_script("$('.team-select-enhanced').trigger('change')")
     end
 
     def click_on_team_in_org_browser(text)


### PR DESCRIPTION
People need to understand the impact of clicking 'I am the leader of this team'.

On page load set the team name in the team leader checkbox to the current team selection.

When team selection changes set the new team name in the team leader checkbox hint text.