### PR TITLE
Float grid-2-3 left when screen < 980px

### DIFF
--- a/app/assets/stylesheets/peoplefinder/application.scss
+++ b/app/assets/stylesheets/peoplefinder/application.scss
@@ -13,6 +13,18 @@
 @import "measurements";
 @import "elements/helpers";
 
+@media (min-width: 641px) {
+  .grid-2-3 {
+    float: left;
+    width: 100%;
+  }
+}
+
+@media (min-width: 980px) {
+  .grid-2-3 {
+    width: 66.666666667%;
+  }
+}
 
 *{
   box-sizing: border-box;


### PR DESCRIPTION
Float grid-2-3 left at 980px instead of at 640px.

Fixes issue with photo image covering text on profile view and team view when screen width is between 640px and 980px.