### PR TITLE
Show subteam completion score on team view

### DIFF
--- a/app/assets/stylesheets/peoplefinder/groups.css.scss
+++ b/app/assets/stylesheets/peoplefinder/groups.css.scss
@@ -127,3 +127,10 @@ $focus-color: #FFBF47;
     color: $grey-1;
   }
 }
+
+.subgroup-completion {
+  display: block;
+  color: #6F777B;
+  margin-bottom: 5px;
+  margin-top: 0px;
+}

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -62,12 +62,14 @@ class Group < ActiveRecord::Base
   end
 
   def completion_score
-    people = all_people
-    if people.blank?
-      0
-    else
-      total_score = people.inject(0) { |total, person| total + person.completion_score }
-      (total_score / people.length.to_f).round(0)
+    Rails.cache.fetch("#{id}-completion-score", expires_in: 1.hour) do
+      people = all_people
+      if people.blank?
+        0
+      else
+        total_score = people.inject(0) { |total, person| total + person.completion_score }
+        (total_score / people.length.to_f).round(0)
+      end
     end
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -61,6 +61,16 @@ class Group < ActiveRecord::Base
     Person.all_in_groups(subtree_ids)
   end
 
+  def completion_score
+    people = all_people
+    if people.blank?
+      0
+    else
+      total_score = people.map(&:completion_score).inject(0) {|s, total| total + s }
+      (total_score / people.length.to_f).round(0)
+    end
+  end
+
   def editable_parent?
     new_record? || parent.present? || children.empty?
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -66,7 +66,7 @@ class Group < ActiveRecord::Base
     if people.blank?
       0
     else
-      total_score = people.map(&:completion_score).inject(0) {|s, total| total + s }
+      total_score = people.inject(0) { |total, person| total + person.completion_score }
       (total_score / people.length.to_f).round(0)
     end
   end

--- a/app/views/groups/_subgroup.html.haml
+++ b/app/views/groups/_subgroup.html.haml
@@ -1,6 +1,9 @@
 %div.grid.grid-1-3.subgroup
   %a.subgroup-link-block.inner-block{ href: url_for(subgroup) }
     %h3= subgroup
+    .subgroup-completion
+      %span.score< #{subgroup.completion_score}%
+      of profile information completed
     %div.about-subgroup
       .formatted-text
         = govspeak(truncate(subgroup.with_placeholder_default(:description), length: 350))

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -27,13 +27,22 @@ feature 'Group browsing' do
     expect(page).to have_link('A Leaf Node')
   end
 
-  scenario 'A team with subteams' do
+  scenario 'A team with people and subteams with people' do
     current_group = team
     add_people_to_group(names, current_group)
+    add_people_to_group(names, subteam)
     visit group_path(current_group)
 
     expect(page).to have_text("Teams within #{ current_group.name }")
     expect(page).to have_link("View all people in #{ current_group.name }")
+    expect(page).to have_text("#{subteam.completion_score}% of profile information completed")
+  end
+
+  scenario 'A team and subteams without people' do
+    current_group = team
+    visit group_path(current_group)
+
+    expect(page).to have_text("0% of profile information completed")
   end
 
   scenario 'A team with no subteams (leaf_node) and some people' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Group, type: :model do
 
       it 'has team with completion_score equal to bob\'s completion_score' do
         expect(team.completion_score).to eq(bob.completion_score)
+        expect(Rails.cache.read("#{team.id}-completion-score")).to eq(bob.completion_score)
       end
 
       context 'and alice in the subteam' do
@@ -122,6 +123,7 @@ RSpec.describe Group, type: :model do
         it 'has team with completion_score equal to average of bob and alice\'s completion_score' do
           average_score = ( (bob.completion_score + alice.completion_score) / 2.0).round(0)
           expect(team.completion_score).to eq(average_score)
+          expect(Rails.cache.read("#{team.id}-completion-score")).to eq(average_score)
         end
 
         context 'and bob also in the subteam' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -93,9 +93,13 @@ RSpec.describe Group, type: :model do
     let(:subteam) { create(:group, parent: team) }
 
     let(:alice) { create(:person, given_name: 'alice', surname: 'smith') }
-    let(:bob) { create(:person, given_name: 'bob', surname: 'smith') }
+    let(:bob) { create(:person, given_name: 'bob', surname: 'smith', city: 'Winchester') }
 
     subject { team.all_people }
+
+    it 'has team with completion_score equal to zero' do
+      expect(team.completion_score).to eq(0)
+    end
 
     context 'with bob in the team' do
       before { team.people << bob }
@@ -104,11 +108,20 @@ RSpec.describe Group, type: :model do
         expect(subject.length).to eq(1)
       end
 
+      it 'has team with completion_score equal to bob\'s completion_score' do
+        expect(team.completion_score).to eq(bob.completion_score)
+      end
+
       context 'and alice in the subteam' do
         before { subteam.people << alice }
 
         it 'has 2 membership' do
           expect(subject.length).to eq(2)
+        end
+
+        it 'has team with completion_score equal to average of bob and alice\'s completion_score' do
+          average_score = ( (bob.completion_score + alice.completion_score) / 2.0).round(0)
+          expect(team.completion_score).to eq(average_score)
         end
 
         context 'and bob also in the subteam' do


### PR DESCRIPTION
Group completion_score is average of completion_score of all people in group.

Allows us to see how complete a team's members profiles are. Enables us to compare teams completeness. This is to encourage team members to complete their profile, and hence increase the team completion score.

If there are any performance problems after deployment to production, we will add to the backlog a ticket to periodically cache team completion score results.