### PR TITLE
Always show completion score and edit link on profile

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -114,7 +114,4 @@ class Person < ActiveRecord::Base
     EmailAddress.new(email).valid_address? && person_responsible.try(:email) != email
   end
 
-  def is? person
-    person && person.email == self.email
-  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -113,4 +113,8 @@ class Person < ActiveRecord::Base
   def notify_of_change?(person_responsible)
     EmailAddress.new(email).valid_address? && person_responsible.try(:email) != email
   end
+
+  def is? person
+    person && person.email == self.email
+  end
 end

--- a/app/models/readonly_user.rb
+++ b/app/models/readonly_user.rb
@@ -15,4 +15,8 @@ class ReadonlyUser
   def super_admin?
     false
   end
+
+  def is? person
+    false
+  end
 end

--- a/app/models/readonly_user.rb
+++ b/app/models/readonly_user.rb
@@ -16,7 +16,4 @@ class ReadonlyUser
     false
   end
 
-  def is? person
-    false
-  end
 end

--- a/app/views/people/_completeness.html.haml
+++ b/app/views/people/_completeness.html.haml
@@ -6,6 +6,7 @@
   .score #{person.completion_score}%
   - unless @preview
     - if person.incomplete?
-      %p= link_to 'complete your profile', edit_person_path(person, activity: 'complete')
+      - complete_text = current_user.is?(person) ? 'complete your profile' : 'complete this profile'
+      %p= link_to complete_text, edit_person_path(person, activity: 'complete')
     - else
       %p Thanks for improving People Finder for everyone!

--- a/app/views/people/_completeness.html.haml
+++ b/app/views/people/_completeness.html.haml
@@ -6,7 +6,7 @@
   .score #{person.completion_score}%
   - unless @preview
     - if person.incomplete?
-      - complete_text = current_user.is?(person) ? 'complete your profile' : 'complete this profile'
+      - complete_text = (current_user == person) ? 'complete your profile' : 'complete this profile'
       %p= link_to complete_text, edit_person_path(person, activity: 'complete')
     - else
       %p Thanks for improving People Finder for everyone!

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -51,9 +51,11 @@
         %p= @person.description
 
 - if @person.email.present? && !@preview
-  - if logged_in_regular? && current_user.email == @person.email
+  - if current_user.is?(@person)
     = render partial: "completeness", locals: { person: @person }
   - else
+    - if @person.incomplete?
+      = render partial: "completeness", locals: { person: @person }
     = render partial: "request_information", locals: { person: @person }
 
 - unless @versions.nil?

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -54,9 +54,9 @@
   - if current_user == @person
     = render partial: "completeness", locals: { person: @person }
   - else
+    = render partial: "request_information", locals: { person: @person }
     - if @person.incomplete?
       = render partial: "completeness", locals: { person: @person }
-    = render partial: "request_information", locals: { person: @person }
 
 - unless @versions.nil?
   %h1 Audit Log

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -51,7 +51,7 @@
         %p= @person.description
 
 - if @person.email.present? && !@preview
-  - if current_user.is?(@person)
+  - if current_user == @person
     = render partial: "completeness", locals: { person: @person }
   - else
     - if @person.incomplete?

--- a/app/views/people/_request_information.html.haml
+++ b/app/views/people/_request_information.html.haml
@@ -1,4 +1,5 @@
-.spacer-55
+.spacer-20
+.spacer-20
 %hr
 .spacer-10
 %p

--- a/app/views/people/_request_information.html.haml
+++ b/app/views/people/_request_information.html.haml
@@ -1,8 +1,6 @@
-.spacer-20
-.spacer-20
-%hr
 .spacer-10
 %p
   = info_text('request_information')
   <br/>
   = link_to info_text('request_information_link'), new_person_suggestion_path(@person)
+.spacer-10

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -227,4 +227,23 @@ RSpec.describe Person, type: :model do
       end
     end
   end
+
+  describe '#is?' do
+    context 'given another person' do
+      it 'returns false' do
+        other_person = create(:person, email: 'test.user@digital.justice.gov.uk')
+        expect(person.is?(other_person)).to be false
+      end
+    end
+
+    context 'given a person with matching email' do
+      it 'returns true' do
+        email = 'test.user@digital.justice.gov.uk'
+        person.email = email
+        other_person = create(:person, email: email)
+        expect(person.is?(other_person)).to be true
+      end
+    end
+  end
+
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -228,22 +228,4 @@ RSpec.describe Person, type: :model do
     end
   end
 
-  describe '#is?' do
-    context 'given another person' do
-      it 'returns false' do
-        other_person = create(:person, email: 'test.user@digital.justice.gov.uk')
-        expect(person.is?(other_person)).to be false
-      end
-    end
-
-    context 'given a person with matching email' do
-      it 'returns true' do
-        email = 'test.user@digital.justice.gov.uk'
-        person.email = email
-        other_person = create(:person, email: email)
-        expect(person.is?(other_person)).to be true
-      end
-    end
-  end
-
 end

--- a/spec/models/readonly_user_spec.rb
+++ b/spec/models/readonly_user_spec.rb
@@ -40,4 +40,11 @@ RSpec.describe ReadonlyUser, type: :model do
       expect(subject).not_to be_super_admin
     end
   end
+
+  describe '#is?' do
+    it 'returns false' do
+      person = build(:person, email: 'test.user@digital.justice.gov.uk')
+      expect(subject.is?(person)).to be false
+    end
+  end
 end

--- a/spec/models/readonly_user_spec.rb
+++ b/spec/models/readonly_user_spec.rb
@@ -41,10 +41,4 @@ RSpec.describe ReadonlyUser, type: :model do
     end
   end
 
-  describe '#is?' do
-    it 'returns false' do
-      person = build(:person, email: 'test.user@digital.justice.gov.uk')
-      expect(subject.is?(person)).to be false
-    end
-  end
 end


### PR DESCRIPTION
To encourage users to complete profiles, now show completion score to all users both logged in and not
logged in.

Edit link takes non-logged in users to login page.