### PR TITLE
Show people outside of subteams

### DIFF
--- a/app/assets/stylesheets/peoplefinder/groups.css.scss
+++ b/app/assets/stylesheets/peoplefinder/groups.css.scss
@@ -108,12 +108,18 @@ $focus-color: #FFBF47;
     clip: rect(0px, 300px, 300px, 0px);
   }
 }
-.view-all-people {
+
+.view-people-outside-subteams {
   float:right;
   font-size: 44.5%;
   font-weight: normal;
   margin-top: 1em;
-  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .view-people-outside-subteams {
+    font-size: 15px;
+  }
 }
 
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -18,6 +18,8 @@ class GroupsController < ApplicationController
   # GET /groups/1
   def show
     authorize @group
+    @all_people_count = @group.all_people_count
+    @people_outside_subteams_count = @group.people_outside_subteams_count
 
     respond_to do |format|
       format.html { session[:last_group_visited] = @group.id }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,6 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [
-    :show, :edit, :update, :destroy, :all_people
+    :show, :edit, :update, :destroy, :all_people, :people_outside_subteams
   ]
   before_action :set_org_structure, only: [:new, :edit, :create, :update]
   before_action :load_versions, only: [:show]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+
+  def pluralize_with_delimiter number, text
+    "#{ number_with_delimiter(number) } #{ text.pluralize(number) }"
+  end
+
   def last_update
     current_object = @person || @group
     if current_object && current_object.updated_at.present?

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -66,11 +66,11 @@ class Group < ActiveRecord::Base
   end
 
   def people_outside_subteams
-    Person.all_in_groups([self.id])
+    Person.all_in_groups([self.id]) - Person.all_in_groups(subteam_ids)
   end
 
   def people_outside_subteams_count
-    people.count
+    Person.count_in_groups([self.id], excluded_group_ids: subteam_ids)
   end
 
   def completion_score
@@ -103,5 +103,9 @@ private
 
   def check_deletability
     errors.add :base, :memberships_exist unless deletable?
+  end
+
+  def subteam_ids
+    subtree_ids - [self.id]
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -61,6 +61,10 @@ class Group < ActiveRecord::Base
     Person.all_in_groups(subtree_ids)
   end
 
+  def all_people_count
+    Person.count_in_groups(subtree_ids)
+  end
+
   def completion_score
     Rails.cache.fetch("#{id}-completion-score", expires_in: 1.hour) do
       people = all_people

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -65,6 +65,14 @@ class Group < ActiveRecord::Base
     Person.count_in_groups(subtree_ids)
   end
 
+  def people_outside_subteams
+    Person.all_in_groups([self.id])
+  end
+
+  def people_outside_subteams_count
+    people.count
+  end
+
   def completion_score
     Rails.cache.fetch("#{id}-completion-score", expires_in: 1.hour) do
       people = all_people

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -88,6 +88,15 @@ class Person < ActiveRecord::Base
     find_by_sql([query, group_ids])
   end
 
+  def self.count_in_groups(group_ids)
+    query = <<-SQL
+      SELECT COUNT(DISTINCT p.id)
+      FROM memberships m, people p
+      WHERE m.person_id = p.id AND group_id in (?)
+    SQL
+    Person.count_by_sql([query, group_ids])
+  end
+
   def to_s
     name
   end

--- a/app/services/random_generator.rb
+++ b/app/services/random_generator.rb
@@ -32,6 +32,9 @@ private
     else
       @groups_per_level.times do
         new_group = create_group(group)
+        @people_per_group.times do
+          create_person(new_group)
+        end
         generate_level(new_group, level + 1)
       end
     end

--- a/app/views/groups/people_outside_subteams.html.haml
+++ b/app/views/groups/people_outside_subteams.html.haml
@@ -1,6 +1,6 @@
 - content_for :breadcrumbs do
-  = breadcrumbs(Home.path + @group.path + ['People outside of subteams'])
+  = breadcrumbs(Home.path + @group.path + ['People not assigned to a sub-team'])
 
-%h1= @page_title = "People in #{ @group.name } outside of subteams"
+%h1= @page_title = "People in #{ @group.name } not assigned to a sub-team"
 .grid-wrapper
   = render partial: "people/summary", collection: @group.people_outside_subteams

--- a/app/views/groups/people_outside_subteams.html.haml
+++ b/app/views/groups/people_outside_subteams.html.haml
@@ -1,0 +1,6 @@
+- content_for :breadcrumbs do
+  = breadcrumbs(Home.path + @group.path + ['People outside of subteams'])
+
+%h1= @page_title = "People in #{ @group.name } outside of subteams"
+.grid-wrapper
+  = render partial: "people/summary", collection: @group.people_outside_subteams

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -5,13 +5,16 @@
 = render partial: 'detail'
 
 - unless @group.leaf_node?
-  .view-all-people
-    = link_to "View all #{ @group.all_people_count } people in #{ @group.name }", people_group_path(@group)
+  .spacer-25
+  - if @all_people_count > 0
+    .view-all-people
+      = link_to "View all #{ number_with_delimiter @all_people_count } people in #{ @group.name }", people_group_path(@group)
   %h2#teams
     Teams within
     = @group.name
-    .view-people-outside-subteams
-      = link_to "View #{ @group.people_outside_subteams_count } people not assigned to a sub-team", people_outside_subteams_group_path(@group)
+    - if @people_outside_subteams_count > 0
+      .view-people-outside-subteams
+        = link_to "View #{ number_with_delimiter @people_outside_subteams_count } people not assigned to a sub-team", people_outside_subteams_group_path(@group)
   .grid-wrapper
     = render partial: "subgroup", collection: @group.children
 

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -6,15 +6,15 @@
 
 - unless @group.leaf_node?
   .spacer-25
-  - if @all_people_count > 0
+  - if @all_people_count > 0 && @group.parent.present?
     .view-all-people
-      = link_to "View all #{ number_with_delimiter @all_people_count } people in #{ @group.name }", people_group_path(@group)
+      = link_to "View #{ @all_people_count > 1 ? 'all' : '' } #{ pluralize_with_delimiter @all_people_count, 'person' } in #{ @group.name }", people_group_path(@group)
   %h2#teams
     Teams within
     = @group.name
     - if @people_outside_subteams_count > 0
       .view-people-outside-subteams
-        = link_to "View #{ number_with_delimiter @people_outside_subteams_count } people not assigned to a sub-team", people_outside_subteams_group_path(@group)
+        = link_to "View #{ pluralize_with_delimiter @people_outside_subteams_count, 'person' } not assigned to a sub-team", people_outside_subteams_group_path(@group)
   .grid-wrapper
     = render partial: "subgroup", collection: @group.children
 

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -5,12 +5,12 @@
 = render partial: 'detail'
 
 - unless @group.leaf_node?
-  %h2
+  .view-all-people
+    = link_to "View all #{ @group.all_people_count } people in #{ @group.name }", people_group_path(@group)
+  %h2#teams
     Teams within
     = @group.name
-    .view-all-people
-      = link_to "View all #{ @group.all_people_count } people in #{ @group.name }", people_group_path(@group)
-      %br
+    .view-people-outside-subteams
       = link_to "View #{ @group.people_outside_subteams_count } people outside of subteams", people_outside_subteams_group_path(@group)
   .grid-wrapper
     = render partial: "subgroup", collection: @group.children

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -8,7 +8,7 @@
   %h2
     Teams within
     = @group.name
-    .view-all-people= link_to "View all people in #{ @group.name }", people_group_path(@group)
+    .view-all-people= link_to "View all #{ @group.all_people_count } people in #{ @group.name }", people_group_path(@group)
   .grid-wrapper
     = render partial: "subgroup", collection: @group.children
 

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -8,7 +8,10 @@
   %h2
     Teams within
     = @group.name
-    .view-all-people= link_to "View all #{ @group.all_people_count } people in #{ @group.name }", people_group_path(@group)
+    .view-all-people
+      = link_to "View all #{ @group.all_people_count } people in #{ @group.name }", people_group_path(@group)
+      %br
+      = link_to "View #{ @group.people_outside_subteams_count } people outside of subteams", people_outside_subteams_group_path(@group)
   .grid-wrapper
     = render partial: "subgroup", collection: @group.children
 

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -11,7 +11,7 @@
     Teams within
     = @group.name
     .view-people-outside-subteams
-      = link_to "View #{ @group.people_outside_subteams_count } people outside of subteams", people_outside_subteams_group_path(@group)
+      = link_to "View #{ @group.people_outside_subteams_count } people not assigned to a sub-team", people_outside_subteams_group_path(@group)
   .grid-wrapper
     = render partial: "subgroup", collection: @group.children
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :groups, path: 'teams' do
     resources :groups, only: [:new]
     get :people, on: :member, action: 'all_people'
+    get :"people-outside-subteams", on: :member, action: 'people_outside_subteams'
   end
 
   resources :people do

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -34,7 +34,7 @@ feature 'Group browsing' do
     visit group_path(current_group)
 
     expect(page).to have_text("Teams within #{ current_group.name }")
-    expect(page).to have_link("View all people in #{ current_group.name }")
+    expect(page).to have_link("View all 6 people in #{ current_group.name }")
     expect(page).to have_text("#{subteam.completion_score}% of profile information completed")
   end
 
@@ -69,7 +69,7 @@ feature 'Group browsing' do
     current_group = team
     add_people_to_group(names, current_group)
     visit group_path(current_group)
-    click_link("View all people in #{ current_group.name }")
+    click_link("View all 3 people in #{ current_group.name }")
 
     expect(page).to have_title("People in #{ current_group.name } - #{ app_title }")
     within('.breadcrumbs') do

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -27,17 +27,6 @@ feature 'Group browsing' do
     expect(page).to have_link('A Leaf Node')
   end
 
-  scenario 'A team with people and subteams with people' do
-    current_group = team
-    add_people_to_group(names, current_group)
-    add_people_to_group(names, subteam)
-    visit group_path(current_group)
-
-    expect(page).to have_text("Teams within #{ current_group.name }")
-    expect(page).to have_link("View all 6 people in #{ current_group.name }")
-    expect(page).to have_text("#{subteam.completion_score}% of profile information completed")
-  end
-
   scenario 'A team and subteams without people' do
     current_group = team
     visit group_path(current_group)
@@ -62,24 +51,54 @@ feature 'Group browsing' do
     visit group_path(leaf_node)
 
     expect(page).not_to have_text("Teams within #{ current_group.name }")
-    expect(page).not_to have_link("View all people in #{ current_group.name }")
+    expect(page).not_to have_link("View all 3 people in #{ current_group.name }")
   end
 
-  scenario 'Following the view all people link' do
-    current_group = team
-    add_people_to_group(names, current_group)
-    visit group_path(current_group)
-    click_link("View all 3 people in #{ current_group.name }")
-
-    expect(page).to have_title("People in #{ current_group.name } - #{ app_title }")
-    within('.breadcrumbs') do
-      expect(page).to have_link(current_group.name)
-      expect(page).to have_text('All people')
+  context 'A team with people and subteams with people' do
+    before do
+      current_group = team
+      add_people_to_group(names, current_group)
+      add_people_to_group(subteam_names, subteam)
     end
 
-    expect(page).to have_text("People in #{ current_group.name }")
-    names.each do |name|
-      expect(page).to have_link(name.join(' '))
+    scenario 'viewing text on page' do
+      visit group_path(team)
+      expect(page).to have_text("Teams within #{ team.name }")
+      expect(page).to have_link("View all 6 people in #{ team.name }")
+      expect(page).to have_link("View 3 people outside of subteams")
+      expect(page).to have_text("#{subteam.completion_score}% of profile information completed")
+    end
+
+    scenario 'following the view all people link' do
+      visit group_path(team)
+      click_link("View all 6 people in #{ team.name }")
+
+      expect(page).to have_title("People in #{ team.name } - #{ app_title }")
+      within('.breadcrumbs') do
+        expect(page).to have_link(team.name)
+        expect(page).to have_text('All people')
+      end
+
+      expect(page).to have_text("People in #{ team.name }")
+      names.each do |name|
+        expect(page).to have_link(name.join(' '))
+      end
+    end
+
+    scenario 'following the view people outside of subteams link' do
+      visit group_path(team)
+      click_link("View 3 people outside of subteams")
+
+      expect(page).to have_title("People in #{ team.name } outside of subteams - #{ app_title }")
+      within('.breadcrumbs') do
+        expect(page).to have_link(team.name)
+        expect(page).to have_text('People outside of subteams')
+      end
+
+      expect(page).to have_text("People in #{ team.name } outside of subteams")
+      names.each do |name|
+        expect(page).to have_link(name.join(' '))
+      end
     end
   end
 
@@ -110,4 +129,13 @@ feature 'Group browsing' do
       %w[ Merle Haggard ]
     ]
   end
+
+  def subteam_names
+    [
+      %w[ Cash Johnny ],
+      %w[ Parton Dolly ],
+      %w[ Haggard Merle ]
+    ]
+  end
+
 end

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -65,7 +65,7 @@ feature 'Group browsing' do
       visit group_path(team)
       expect(page).to have_text("Teams within #{ team.name }")
       expect(page).to have_link("View all 6 people in #{ team.name }")
-      expect(page).to have_link("View 3 people outside of subteams")
+      expect(page).to have_link("View 3 people not assigned to a sub-team")
       expect(page).to have_text("#{subteam.completion_score}% of profile information completed")
     end
 
@@ -85,17 +85,17 @@ feature 'Group browsing' do
       end
     end
 
-    scenario 'following the view people outside of subteams link' do
+    scenario 'following link to view people not assigned to a sub-team' do
       visit group_path(team)
-      click_link("View 3 people outside of subteams")
+      click_link('View 3 people not assigned to a sub-team')
 
-      expect(page).to have_title("People in #{ team.name } outside of subteams - #{ app_title }")
+      expect(page).to have_title("People in #{ team.name } not assigned to a sub-team - #{ app_title }")
       within('.breadcrumbs') do
         expect(page).to have_link(team.name)
-        expect(page).to have_text('People outside of subteams')
+        expect(page).to have_text('People not assigned to a sub-team')
       end
 
-      expect(page).to have_text("People in #{ team.name } outside of subteams")
+      expect(page).to have_text("People in #{ team.name } not assigned to a sub-team")
       names.each do |name|
         expect(page).to have_link(name.join(' '))
       end

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -64,6 +64,14 @@ feature 'Group browsing' do
       add_people_to_group(subteam_names, subteam)
     end
 
+    scenario 'viewing top level group' do
+      add_people_to_group([%w[Perm Sec]], department)
+
+      visit group_path(department)
+      expect(page).not_to have_link("View all 7 people in #{ department.name }")
+      expect(page).to have_link("View 1 person not assigned to a sub-team")
+    end
+
     scenario 'viewing text on page' do
       visit group_path(team)
       expect(page).to have_text("Teams within #{ team.name }")

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -32,6 +32,8 @@ feature 'Group browsing' do
     visit group_path(current_group)
 
     expect(page).to have_text("0% of profile information completed")
+    expect(page).not_to have_link("View all 0 people in #{ current_group.name }")
+    expect(page).not_to have_link("View 0 people not assigned to a sub-team")
   end
 
   scenario 'A team with no subteams (leaf_node) and some people' do
@@ -51,7 +53,8 @@ feature 'Group browsing' do
     visit group_path(leaf_node)
 
     expect(page).not_to have_text("Teams within #{ current_group.name }")
-    expect(page).not_to have_link("View all 3 people in #{ current_group.name }")
+    expect(page).not_to have_link("View all 0 people in #{ current_group.name }")
+    expect(page).not_to have_link("View 0 people not assigned to a sub-team")
   end
 
   context 'A team with people and subteams with people' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe ApplicationHelper, type: :helper do
   let(:stubbed_time) { Time.new(2012, 10, 31, 2, 2, 2, "+01:00") }
   let(:originator) { Version.public_user }
 
+  describe '#pluralize_with_delimiter' do
+    it 'handles singular correctly' do
+      expect(pluralize_with_delimiter(1, 'person')).to eq '1 person'
+    end
+
+    it 'handles plural correctly' do
+      expect(pluralize_with_delimiter(2000, 'person')).to eq '2,000 people'
+    end
+  end
+
   context '#last_update' do
     it 'shows last_update for a person by a system generated user' do
       @person = double(:person, updated_at: stubbed_time, originator: originator)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -42,8 +42,11 @@ RSpec.describe Person, type: :model do
       expect(result).to include(people[1])
       expect(result).not_to include(people[2])
 
-      people_count = described_class.count_in_groups(group_ids)
-      expect(people_count).to eq(2)
+      count = described_class.count_in_groups(group_ids)
+      expect(count).to eq(2)
+
+      count = described_class.count_in_groups(group_ids, excluded_group_ids: groups.take(1))
+      expect(count).to eq(1)
     end
 
     it 'concatenates all roles alphabetically with commas' do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -32,14 +32,18 @@ RSpec.describe Person, type: :model do
     let(:groups) { create_list(:group, 3) }
     let(:people) { create_list(:person, 3) }
 
-    it 'returns all people in any listed groups' do
+    it 'returns all people in any listed groups and .count_in_groups returns correct count' do
       people.zip(groups).each do |person, group|
         create :membership, person: person, group: group
       end
-      result = described_class.all_in_groups(groups.take(2))
+      group_ids = groups.take(2)
+      result = described_class.all_in_groups(group_ids)
       expect(result).to include(people[0])
       expect(result).to include(people[1])
       expect(result).not_to include(people[2])
+
+      people_count = described_class.count_in_groups(group_ids)
+      expect(people_count).to eq(2)
     end
 
     it 'concatenates all roles alphabetically with commas' do

--- a/spec/services/random_generator_spec.rb
+++ b/spec/services/random_generator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RandomGenerator do
       expect(group.descendants.count).to eq(6)
     end
     it 'generate people for the leaf groups' do
-      expect(Person.all_in_groups(group.descendants.pluck(:id)).count).to eq(12)
+      expect(Person.all_in_groups(group.descendants.pluck(:id)).count).to eq(30)
     end
   end
 end


### PR DESCRIPTION
* Add link to "view people not assigned to sub-teams" on team view
* Show count of people in "view people" links
* New view shows people in team that are not assigned to a subteam

Potentially highlights incomplete data, as we expect most people to be assigned to a subteam. But in
live production data we are seeing a lot of people outside of subteams.