### PR TITLE
Return photo JSON with text MIME type

### DIFF
--- a/app/controllers/profile_photos_controller.rb
+++ b/app/controllers/profile_photos_controller.rb
@@ -1,7 +1,7 @@
 class ProfilePhotosController < ApplicationController
   def create
     photo = ProfilePhoto.create(profile_photo_params)
-    render json: photo
+    render text: photo.to_json
   end
 
 private


### PR DESCRIPTION
This is a work around for an IE issue. Recent versions of IE treat the photo JSON returned as a file download, instead of passing it to the target iframe.

Tested in IE11 against staging environment.