### PR TITLE
Spec that photo response has MIME type set to "text"

### DIFF
--- a/spec/controllers/profile_photos_controller_spec.rb
+++ b/spec/controllers/profile_photos_controller_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe ProfilePhotosController, type: :controller do
         post :create, profile_photo: valid_params
         expect(JSON.parse(response.body)['id']).to eq photo_id
       end
+
+      it 'sets return MIME type to "text" to allow iframe target to work with > IE8' do
+        allow(ProfilePhoto).to receive(:create).and_return(photo)
+        post :create, profile_photo: valid_params
+        expect(response.header['Content-Type']).to eq 'text/html; charset=utf-8'
+      end
     end
   end
 end


### PR DESCRIPTION
To prevent fix for IE11 photo bug from being inadvertently removed.