### PR TITLE
Allow person with two roles in same team to save

### DIFF
--- a/app/assets/stylesheets/peoplefinder/retinal_images.css.scss
+++ b/app/assets/stylesheets/peoplefinder/retinal_images.css.scss
@@ -11,7 +11,7 @@ only screen and (min-device-pixel-ratio: 1.5) {
 
   a.add-new-person {
     background-image: image-url('icon_plus_retina.png') !important;
-    background-size: 31px 31px !important;
+    background-size: 24px 24px !important;
   }
 
   .delete-actions .deletable {

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -73,6 +73,10 @@ class Group < ActiveRecord::Base
     Person.count_in_groups([self.id], excluded_group_ids: subteam_ids)
   end
 
+  def leaderships_by_person
+    leaderships.group_by(&:person)
+  end
+
   def completion_score
     Rails.cache.fetch("#{id}-completion-score", expires_in: 1.hour) do
       people = all_people

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,8 +4,8 @@ class Membership < ActiveRecord::Base
 
   belongs_to :person, touch: true
   belongs_to :group, touch: true
-  validates :person, presence: true, uniqueness: { scope: :group }, on: :update
-  validates :group, presence: true, uniqueness: { scope: :person }, on: :update
+  validates :person, presence: true, on: :update
+  validates :group, presence: true, on: :update
 
   delegate :name, to: :person, prefix: true
   delegate :image, to: :person, prefix: true

--- a/app/views/groups/_detail.html.haml
+++ b/app/views/groups/_detail.html.haml
@@ -9,8 +9,8 @@
 %div.grid-wrapper.details
   %div.grid.grid-1-3
     %div.inner-block.group-leader
-      - @group.leaderships.each do |leadership|
-        = render partial: 'leadership', object: leadership
+      - @group.leaderships_by_person.each do |person, leaderships|
+        = render partial: 'leaderships', object: leaderships, locals: { person: person }
 
   %div.grid.grid-2-3
     %div.inner-block.about.text

--- a/app/views/groups/_leadership.html.haml
+++ b/app/views/groups/_leadership.html.haml
@@ -1,4 +1,0 @@
-.image-background
-  = profile_image_tag leadership.person
-%h4= link_to leadership.person, leadership.person
-.leader-role= leadership.role

--- a/app/views/groups/_leaderships.html.haml
+++ b/app/views/groups/_leaderships.html.haml
@@ -1,0 +1,4 @@
+.image-background
+  = profile_image_tag person
+%h4= link_to person, person
+.leader-role= leaderships.map(&:role).select(&:present?).sort.join(', ')

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -13,12 +13,13 @@
 
   .grid.grid-2-3
     .inner-block
-      - @person.memberships.each do |membership|
-        %h3= membership.role
-        - if membership.path.length > 1
+      - @person.memberships.group_by(&:group).each do |group, memberships|
+        %h3= memberships.map(&:role).select(&:present?).sort.join(', ')
+        - path = memberships.first.path
+        - if path.length > 1
           %dl.inline-labels.role-and-location
             %dt Team
-            %dd.breadcrumbs= breadcrumbs(membership.path.drop(1))
+            %dd.breadcrumbs= breadcrumbs(path.drop(1))
 
       %dl.inline-labels
         - if feature_enabled?(:communities)

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -31,6 +31,10 @@ feature "Person maintenance" do
     expect(membership.group).to eql(group)
     expect(membership.leader?).to be true
     expect(membership).to be_subscribed
+
+    visit group_path(group)
+    expect(page).to have_selector('.group-leader h4', text: 'Taylor')
+    expect(page).to have_selector('.group-leader .leader-role', text: 'Head Honcho')
   end
 
   scenario 'Editing a job title', js: true do
@@ -55,7 +59,7 @@ feature "Person maintenance" do
     visit edit_person_path(person)
 
     click_link('Add another role')
-    sleep 1
+    sleep 0.2
 
     within all('#memberships .membership').last do
       select_in_team_select 'Communications'
@@ -64,6 +68,30 @@ feature "Person maintenance" do
 
     click_button 'Save', match: :first
     expect(Person.last.memberships.length).to eql(2)
+  end
+
+  scenario 'Adding an additional leadership role in same team', js: true do
+    person = create_person_in_digital_justice
+    javascript_log_in
+    visit edit_person_path(person)
+    fill_in 'First name', with: 'Samantha'
+    fill_in 'Surname', with: 'Taylor'
+    fill_in 'Job title', with: 'Head Honcho'
+    check 'leader'
+
+    click_link('Add another role')
+    sleep 0.2
+
+    within all('#memberships .membership').last do
+      select_in_team_select 'Digital Justice'
+      fill_in 'Job title', with: 'Master of None'
+      check 'leader'
+    end
+    click_button 'Save', match: :first
+
+    visit group_path(Group.find_by_name('Digital Justice'))
+    expect(page).to have_selector('.group-leader h4', text: 'Samantha Taylor')
+    expect(page).to have_selector('.group-leader .leader-role', text: 'Head Honcho, Master of None')
   end
 
   scenario 'Unsubscribing from notifications', js: true do

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -92,6 +92,9 @@ feature "Person maintenance" do
     visit group_path(Group.find_by_name('Digital Justice'))
     expect(page).to have_selector('.group-leader h4', text: 'Samantha Taylor')
     expect(page).to have_selector('.group-leader .leader-role', text: 'Head Honcho, Master of None')
+
+    visit person_path(person)
+    expect(page).to have_selector('h3', text: 'Head Honcho, Master of None')
   end
 
   scenario 'Unsubscribing from notifications', js: true do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -125,6 +125,22 @@ RSpec.describe Group, type: :model do
     context 'with bob in the team' do
       before { team.people << bob }
 
+      context 'and bob is a team leader' do
+        before do
+          @leadership = bob.memberships.first
+          @leadership.leader = true
+          @leadership.save!
+        end
+
+        it 'has .leaderships return bob\'s membership' do
+          expect(team.leaderships.to_a).to eq [@leadership]
+        end
+
+        it 'has .leaderships_by_person return bob and his membership' do
+          expect(team.leaderships_by_person[bob]).to eq [@leadership]
+        end
+      end
+
       it 'has 1 in all_people array' do
         expect(team.all_people.length).to eq(1)
       end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -125,19 +125,19 @@ RSpec.describe Group, type: :model do
     context 'with bob in the team' do
       before { team.people << bob }
 
+
       context 'and bob is a team leader' do
+
         before do
-          @leadership = bob.memberships.first
-          @leadership.leader = true
-          @leadership.save!
+          bob.memberships.first.update(leader: true)
         end
 
-        it 'has .leaderships return bob\'s membership' do
-          expect(team.leaderships.to_a).to eq [@leadership]
+        it 'has .leaderships return array containing bob\'s membership' do
+          expect(team.leaderships.to_a).to eq [bob.memberships.first]
         end
 
-        it 'has .leaderships_by_person return bob and his membership' do
-          expect(team.leaderships_by_person[bob]).to eq [@leadership]
+        it 'has .leaderships_by_person return hash containing bob and his membership' do
+          expect(team.leaderships_by_person[bob]).to eq [bob.memberships.first]
         end
       end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -102,30 +102,26 @@ RSpec.describe Person, type: :model do
     end
   end
 
-  context 'with two roles in the same group' do
+  context 'with two memberships in the same group' do
     before do
       person.save!
       digital_services = create(:group, name: 'Digital Services')
       person.memberships.create(group: digital_services, role: 'Service Assessments Lead')
       person.memberships.create(group: digital_services, role: 'Head of Delivery')
+      person.reload
     end
 
-    it 'can be saved and updates can be saved' do
-      person.save!
-      person.reload
+    it 'allows updates to those memberships' do
       expect(person.memberships.first.leader).to be false
 
-      membership = person.memberships.first
-      membership.leader = true
-
-      person.assign_attributes({
+      membership_attributes = person.memberships.first.attributes
+      person.assign_attributes(
         memberships_attributes: {
-          membership.id => membership.attributes
+          membership_attributes[:id] => membership_attributes.merge(leader: true)
         }
-      })
+      )
       person.save!
-      person.reload
-      expect(person.memberships.first.leader).to be true
+      expect(person.reload.memberships.first.leader).to be true
     end
 
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -102,6 +102,34 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  context 'with two roles in the same group' do
+    before do
+      person.save!
+      digital_services = create(:group, name: 'Digital Services')
+      person.memberships.create(group: digital_services, role: 'Service Assessments Lead')
+      person.memberships.create(group: digital_services, role: 'Head of Delivery')
+    end
+
+    it 'can be saved and updates can be saved' do
+      person.save!
+      person.reload
+      expect(person.memberships.first.leader).to be false
+
+      membership = person.memberships.first
+      membership.leader = true
+
+      person.assign_attributes({
+        memberships_attributes: {
+          membership.id => membership.attributes
+        }
+      })
+      person.save!
+      person.reload
+      expect(person.memberships.first.leader).to be true
+    end
+
+  end
+
   context 'path' do
     let(:person) { described_class.new }
 


### PR DESCRIPTION
Remove the person, group uniqueness validation on memberships. Person is allowed to have multiple roles in the same team.

Fixes bug that prevented users with two roles on same team from saving edits to their profiles.

Only show person with two leadership roles once on team view.