### PR TITLE
Remove redundant checks of email validity

### DIFF
--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -13,7 +13,7 @@ class EmailAddress
     @parsed_ok = false
   end
 
-  def valid_domain?
+  def permitted_domain?
     valid_login_domains.any? { |pattern| pattern === domain }
   end
 
@@ -22,7 +22,7 @@ class EmailAddress
   end
 
   def valid_address?
-    valid_format? && valid_domain?
+    valid_format? && permitted_domain?
   end
 
   def inferred_last_name

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -4,9 +4,9 @@ class EmailAddress
   extend Forwardable
   def_delegators :@mail_address, :domain, :address, :local, :to_s
 
-  def initialize(string, valid_login_domains = nil)
+  def initialize(string)
     @raw_address = string
-    @valid_login_domains = valid_login_domains || default_valid_login_domains
+    @valid_login_domains = default_valid_login_domains
     @mail_address = Mail::Address.new(string)
     @parsed_ok = true
   rescue Mail::Field::ParseError

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -130,7 +130,7 @@ class Person < ActiveRecord::Base
   concatenated_field :name, :given_name, :surname, join_with: ' '
 
   def notify_of_change?(person_responsible)
-    EmailAddress.new(email).valid_address? && person_responsible.try(:email) != email
+    person_responsible.try(:email) != email
   end
 
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -129,6 +129,10 @@ class Person < ActiveRecord::Base
   concatenated_field :location, :location_in_building, :building, :city, join_with: ', '
   concatenated_field :name, :given_name, :surname, join_with: ' '
 
+  def at_permitted_domain?
+    EmailAddress.new(email).permitted_domain?
+  end
+
   def notify_of_change?(person_responsible)
     person_responsible.try(:email) != email
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -134,7 +134,7 @@ class Person < ActiveRecord::Base
   end
 
   def notify_of_change?(person_responsible)
-    person_responsible.try(:email) != email
+    at_permitted_domain? && person_responsible.try(:email) != email
   end
 
 end

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -28,7 +28,7 @@ class Token < ActiveRecord::Base
   def valid_email_address
     if !EmailAddress.new(user_email).valid_format?
       errors.add(:user_email, :invalid_address)
-    elsif !EmailAddress.new(user_email).valid_domain?
+    elsif !EmailAddress.new(user_email).permitted_domain?
       errors.add(:user_email, :invalid_domain)
     end
   end

--- a/app/services/find_create_person.rb
+++ b/app/services/find_create_person.rb
@@ -2,7 +2,7 @@ module FindCreatePerson
   class << self
     def from_auth_hash(auth_hash)
       email = EmailAddress.new(auth_hash['info']['email'])
-      return unless email.valid_domain?
+      return unless email.permitted_domain?
 
       find_or_create(email) do |person|
         person.given_name = auth_hash['info']['first_name']

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -3,7 +3,7 @@ class EmailValidator < ActiveModel::EachValidator
     email_address = EmailAddress.new(value)
 
     if email_address.valid_format?
-      unless email_address.valid_domain?
+      unless email_address.permitted_domain?
         record.errors.add(attribute, :invalid_domain, options)
       end
     else

--- a/lib/tasks/peoplefinder.rake
+++ b/lib/tasks/peoplefinder.rake
@@ -29,16 +29,9 @@ namespace :peoplefinder do
 
     if STDIN.gets.chomp == 'Y'
       recipients.each do |recipient|
-
-        if EmailAddress.new(recipient.email).valid_address?
-          ReminderMailer.inadequate_profile(recipient).deliver
-          puts "Email sent to: #{ recipient.email }"
-
-        else
-          puts "Email *not* sent to: #{ recipient.email }"
-        end
+        ReminderMailer.inadequate_profile(recipient).deliver_now
+        puts "Email sent to: #{ recipient.email }"
       end
-
     end
   end
 end

--- a/lib/tasks/peoplefinder.rake
+++ b/lib/tasks/peoplefinder.rake
@@ -4,8 +4,8 @@ namespace :peoplefinder do
     @inadequate_profiles = Person.inadequate_profiles
   end
 
-  def inadequate_profiles_with_email
-    inadequate_profiles.select { |person| person.email.present? }
+  def inadequate_profiles_at_permitted_email_domain
+    inadequate_profiles.select { |person| person.at_permitted_domain? }
   end
 
   desc 'list the email addresses of people with inadequate profiles'
@@ -15,14 +15,14 @@ namespace :peoplefinder do
       puts "#{ person.surname }, #{ person.given_name }: #{ person.email }"
     end
     puts "\n** There are #{ inadequate_profiles.count } inadequate profiles."
-    puts "** #{ inadequate_profiles_with_email.count }
-      inadequate profiles have email addresses."
+    puts "** #{ inadequate_profiles_at_permitted_email_domain.count }
+      inadequate profiles have email addresses at permitted domains."
     puts "\n"
   end
 
   desc 'email people with inadequate profiles'
   task inadequate_profile_reminders: :environment do
-    recipients = inadequate_profiles_with_email
+    recipients = inadequate_profiles_at_permitted_email_domain
 
     puts "\nYou are about to email #{ recipients.count } people"
     puts 'Are you sure you want to do this? [Y/N]'

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe EmailAddress do
   let(:valid_login_domains) { ['something.gov.uk'] }
 
-  subject { described_class.new(email, valid_login_domains) }
+  before do
+    allow(PermittedDomain).to receive(:pluck).with(:domain).and_return valid_login_domains
+  end
+
+  subject { described_class.new(email) }
 
   describe '.to_s' do
     let(:email_string) { 'valid@something.gov.uk' }
@@ -18,19 +22,19 @@ RSpec.describe EmailAddress do
       let(:valid_login_domains) { ['dept.gov.uk'] }
 
       it "does not match a similar domain" do
-        expect(described_class.new('me@dept-gov-uk.com', valid_login_domains)).not_to be_valid_domain
+        expect(described_class.new('me@dept-gov-uk.com')).not_to be_valid_domain
       end
 
       it "does not match a subdomain" do
-        expect(described_class.new('me@sub.dept.gov.uk', valid_login_domains)).not_to be_valid_domain
+        expect(described_class.new('me@sub.dept.gov.uk')).not_to be_valid_domain
       end
 
       it "only matches the whole domain" do
-        expect(described_class.new('me@dept.gov.uk', valid_login_domains)).to be_valid_domain
+        expect(described_class.new('me@dept.gov.uk')).to be_valid_domain
       end
 
       it "does not match against the local part of the address" do
-        expect(described_class.new('dept.gov.uk@dept.com', valid_login_domains)).not_to be_valid_domain
+        expect(described_class.new('dept.gov.uk@dept.com')).not_to be_valid_domain
       end
     end
 
@@ -38,15 +42,15 @@ RSpec.describe EmailAddress do
       let(:valid_login_domains) { [/depta?\.gov\.uk/] }
 
       it "does not match a similar domain" do
-        expect(described_class.new('me@dept-gov.uk.com', valid_login_domains)).not_to be_valid_domain
+        expect(described_class.new('me@dept-gov.uk.com')).not_to be_valid_domain
       end
 
       it "matches a subdomain" do
-        expect(described_class.new('me@dept.gov.uk', valid_login_domains)).to be_valid_domain
+        expect(described_class.new('me@dept.gov.uk')).to be_valid_domain
       end
 
       it "does not match against the local part of the address" do
-        expect(described_class.new('depta.gov.uk@dept-gov-uk.com', valid_login_domains)).not_to be_valid_domain
+        expect(described_class.new('depta.gov.uk@dept-gov-uk.com')).not_to be_valid_domain
       end
     end
   end
@@ -65,42 +69,42 @@ RSpec.describe EmailAddress do
 
   describe '.valid_address' do
     it 'is nil' do
-      expect(described_class.new(nil, valid_login_domains)).not_to be_valid_address
+      expect(described_class.new(nil)).not_to be_valid_address
     end
 
     it 'is an empty string' do
-      expect(described_class.new('', valid_login_domains)).not_to be_valid_address
+      expect(described_class.new('')).not_to be_valid_address
     end
 
     it 'is badly formatted' do
-      expect(described_class.new('me-at-example.co.uk', valid_login_domains)).not_to be_valid_address
+      expect(described_class.new('me-at-example.co.uk')).not_to be_valid_address
     end
 
     it 'is from an invalid domain' do
-      expect(described_class.new('me-at-example.co.uk', valid_login_domains)).not_to be_valid_address
+      expect(described_class.new('me-at-example.co.uk')).not_to be_valid_address
     end
 
     it 'does not break the mail gem address_list initialiser' do
-      expect(described_class.new('me@', valid_login_domains)).not_to be_valid_address
+      expect(described_class.new('me@')).not_to be_valid_address
     end
 
     it 'is valid' do
-      expect(described_class.new("me@something.gov.uk", valid_login_domains)).to be_valid_address
+      expect(described_class.new("me@something.gov.uk")).to be_valid_address
     end
 
     it "contains an apostrophe" do
-      expect(described_class.new("michael.o'postrophe@something.gov.uk", valid_login_domains)).to be_valid_address
+      expect(described_class.new("michael.o'postrophe@something.gov.uk")).to be_valid_address
     end
 
     it "contains capital letters in the mailbox part" do
-      expect(described_class.new("Important.Person@something.gov.uk", valid_login_domains)).to be_valid_address
+      expect(described_class.new("Important.Person@something.gov.uk")).to be_valid_address
     end
   end
 
   context 'name inferral' do
-    let(:email_john_smith) { described_class.new('john.smith.1@example.com', valid_login_domains) }
-    let(:email_smithy) { described_class.new('smithy@example.com', valid_login_domains) }
-    let(:email_anne_marie) { described_class.new('anne-marie.boris-smythe@example.com', valid_login_domains) }
+    let(:email_john_smith) { described_class.new('john.smith.1@example.com') }
+    let(:email_smithy) { described_class.new('smithy@example.com') }
+    let(:email_anne_marie) { described_class.new('anne-marie.boris-smythe@example.com') }
 
     describe '.inferred_given_name' do
       it 'returns john.smith' do

--- a/spec/models/email_address_spec.rb
+++ b/spec/models/email_address_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe EmailAddress do
-  let(:valid_login_domains) { ['something.gov.uk'] }
+  let(:permitted_login_domains) { ['something.gov.uk'] }
 
   before do
-    allow(PermittedDomain).to receive(:pluck).with(:domain).and_return valid_login_domains
+    allow(PermittedDomain).to receive(:pluck).with(:domain).and_return permitted_login_domains
   end
 
   subject { described_class.new(email) }
@@ -17,40 +17,40 @@ RSpec.describe EmailAddress do
     end
   end
 
-  describe '.valid_domain' do
+  describe '.permitted_domain' do
     context 'with strings to match login domains' do
-      let(:valid_login_domains) { ['dept.gov.uk'] }
+      let(:permitted_login_domains) { ['dept.gov.uk'] }
 
       it "does not match a similar domain" do
-        expect(described_class.new('me@dept-gov-uk.com')).not_to be_valid_domain
+        expect(described_class.new('me@dept-gov-uk.com')).not_to be_permitted_domain
       end
 
       it "does not match a subdomain" do
-        expect(described_class.new('me@sub.dept.gov.uk')).not_to be_valid_domain
+        expect(described_class.new('me@sub.dept.gov.uk')).not_to be_permitted_domain
       end
 
       it "only matches the whole domain" do
-        expect(described_class.new('me@dept.gov.uk')).to be_valid_domain
+        expect(described_class.new('me@dept.gov.uk')).to be_permitted_domain
       end
 
       it "does not match against the local part of the address" do
-        expect(described_class.new('dept.gov.uk@dept.com')).not_to be_valid_domain
+        expect(described_class.new('dept.gov.uk@dept.com')).not_to be_permitted_domain
       end
     end
 
     context 'with regexp to match login domains' do
-      let(:valid_login_domains) { [/depta?\.gov\.uk/] }
+      let(:permitted_login_domains) { [/depta?\.gov\.uk/] }
 
       it "does not match a similar domain" do
-        expect(described_class.new('me@dept-gov.uk.com')).not_to be_valid_domain
+        expect(described_class.new('me@dept-gov.uk.com')).not_to be_permitted_domain
       end
 
       it "matches a subdomain" do
-        expect(described_class.new('me@dept.gov.uk')).to be_valid_domain
+        expect(described_class.new('me@dept.gov.uk')).to be_permitted_domain
       end
 
       it "does not match against the local part of the address" do
-        expect(described_class.new('depta.gov.uk@dept-gov-uk.com')).not_to be_valid_domain
+        expect(described_class.new('depta.gov.uk@dept-gov-uk.com')).not_to be_permitted_domain
       end
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe EmailAddress do
       expect(described_class.new('me-at-example.co.uk')).not_to be_valid_address
     end
 
-    it 'is from an invalid domain' do
+    it 'is from a non-permitted domain' do
       expect(described_class.new('me-at-example.co.uk')).not_to be_valid_address
     end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -215,6 +215,13 @@ RSpec.describe Person, type: :model do
     it 'is true when email valid with permitted domain' do
       person.email = 'test@digital.justice.gov.uk'
       expect(person.valid?).to be true
+      expect(person.at_permitted_domain?).to be true
+    end
+
+    it 'is false when email does not have permitted domain' do
+      person.email = 'test@example.com'
+      expect(person.valid?).to be false
+      expect(person.at_permitted_domain?).to be false
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -226,19 +226,36 @@ RSpec.describe Person, type: :model do
   end
 
   describe '#notify_of_change?' do
-    it 'is true if there is no reponsible person' do
-      rp = nil
-      expect(person.notify_of_change?(rp)).to be_truthy
+    context 'when the email is not at a permitted domain' do
+      before { allow(person).to receive(:at_permitted_domain?).and_return false }
+
+      it 'is false if there is no reponsible person' do
+        expect(person.notify_of_change?(nil)).to be false
+      end
+
+      it 'is false if the reponsible person is this person' do
+        expect(person.notify_of_change?(person)).to be false
+      end
+
+      it 'is false if the reponsible person is a third party' do
+        other_person = build(:person)
+        expect(person.notify_of_change?(other_person)).to be false
+      end
     end
 
-    it 'is false if the reponsible person is this person' do
-      rp = person
-      expect(person.notify_of_change?(rp)).to be_falsy
-    end
+    context 'when the email is at a permitted domain' do
+      it 'is true if there is no reponsible person' do
+        expect(person.notify_of_change?(nil)).to be true
+      end
 
-    it 'is true if the reponsible person is a third party' do
-      rp = build(:person)
-      expect(person.notify_of_change?(rp)).to be_truthy
+      it 'is false if the reponsible person is this person' do
+        expect(person.notify_of_change?(person)).to be false
+      end
+
+      it 'is true if the reponsible person is a third party' do
+        other_person = build(:person)
+        expect(person.notify_of_change?(other_person)).to be true
+      end
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -205,6 +205,19 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe 'valid?' do
+    it 'is false when email invalid' do
+      person.email = 'bad'
+      expect(person.valid?).to be false
+      expect(person.errors.messages[:email]).to eq ["isn’t valid"]
+    end
+
+    it 'is true when email valid with permitted domain' do
+      person.email = 'test@digital.justice.gov.uk'
+      expect(person.valid?).to be true
+    end
+  end
+
   describe '#notify_of_change?' do
     context 'when the email is invalid' do
       before do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -219,32 +219,19 @@ RSpec.describe Person, type: :model do
   end
 
   describe '#notify_of_change?' do
-    context 'when the email is invalid' do
-      before do
-        person.email = 'invalid'
-      end
-
-      it 'is false' do
-        expect(person.notify_of_change?(build(:person))).
-          to be_falsy
-      end
+    it 'is true if there is no reponsible person' do
+      rp = nil
+      expect(person.notify_of_change?(rp)).to be_truthy
     end
 
-    context 'when the email is valid' do
-      it 'is true if there is no reponsible person' do
-        rp = nil
-        expect(person.notify_of_change?(rp)).to be_truthy
-      end
+    it 'is false if the reponsible person is this person' do
+      rp = person
+      expect(person.notify_of_change?(rp)).to be_falsy
+    end
 
-      it 'is false if the reponsible person is this person' do
-        rp = person
-        expect(person.notify_of_change?(rp)).to be_falsy
-      end
-
-      it 'is true if the reponsible person is a third party' do
-        rp = build(:person)
-        expect(person.notify_of_change?(rp)).to be_truthy
-      end
+    it 'is true if the reponsible person is a third party' do
+      rp = build(:person)
+      expect(person.notify_of_change?(rp)).to be_truthy
     end
   end
 


### PR DESCRIPTION
- Remove redundant checks of email validity.
- Replace with checks that email has a domain matching list of configured permitted domains.

Email validity is checked when person is created or updated. So a person's email can always be considered valid. All invalid email addresses in legacy production data have been fixed.