### PR TITLE
Send reminder emails to users that haven't logged in

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,10 +102,10 @@ Style/AlignHash:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 110
+  Max: 115
 
 Metrics/ModuleLength:
-  Max: 105
+  Max: 115
 
 RSpec/DescribeClass:
   Exclude:
@@ -133,4 +133,3 @@ Style/SingleLineBlockParams:
 Style/ClassVars:
   Exclude:
     - 'spec/**/*'
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,7 +102,7 @@ Style/AlignHash:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 115
+  Max: 120
 
 Metrics/ModuleLength:
   Max: 115

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,6 @@ ENV UNICORN_PORT 3000
 
 EXPOSE $UNICORN_PORT
 
-RUN apt-get update
-RUN apt-get install -y cron
 RUN bundle exec rake assets:precompile RAILS_ENV=assets
 
 ENTRYPOINT ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ ENV UNICORN_PORT 3000
 
 EXPOSE $UNICORN_PORT
 
+RUN apt-get update
+RUN apt-get install -y cron
 RUN bundle exec rake assets:precompile RAILS_ENV=assets
 
 ENTRYPOINT ["./run.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'unf'
 gem 'unicorn', '~> 4.8.3'
 gem 'useragent', '~> 0.10.0'
 gem 'virtus'
+gem 'whenever'
 gem 'will_paginate', '~> 3.0'
 
 gem 'carrierwave',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
       fastimage
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    chronic (0.10.2)
     cliver (0.3.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -578,6 +579,8 @@ GEM
     websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -648,6 +651,7 @@ DEPENDENCIES
   unicorn (~> 4.8.3)
   useragent (~> 0.10.0)
   virtus
+  whenever
   will_paginate (~> 3.0)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ defined on a per environment basis.
 
 `config.support_email` e.g. 'peoplefinder-support@example.com'
 
+`config.send_reminder_emails` Set to true if reminder emails are to be sent by cronjobs
+
 ## Permitted domains
 
 The system allows logging in for emails which have domains from the whitelist. The whitelist is in the database, managed by `PermittedDomain` model. At least one domain has to be whitelisted before anyone can log in (that applies to development too).

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,10 +65,8 @@ class ApplicationController < ActionController::Base
     login_service = Login.new(session, person)
     login_service.login
 
-    path = session.delete(:desired_path) || '/'
-    if path == '/' && login_service.edit_profile?
-      path = edit_person_path(person, prompt: :profile)
-    end
+    path = session.delete(:desired_path) || person_path(person, prompt: :profile)
+
     redirect_to path
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,5 +1,4 @@
 # FIXME: Refactor this controller - it's too long and mailing shouldn't be done in models
-# rubocop:disable ClassLength
 class PeopleController < ApplicationController
   before_action :set_person, only: [:show, :edit, :update, :destroy]
   before_action :set_org_structure,

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -7,4 +7,11 @@ class ReminderMailer < ActionMailer::Base
     @edit_url = edit_person_url(@person)
     mail to: @person.email
   end
+
+  def never_logged_in(person)
+    @person = person
+    token = Token.for_person(person)
+    @token_url = token_url(token)
+    mail to: @person.email
+  end
 end

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -5,13 +5,13 @@ class ReminderMailer < ActionMailer::Base
   def inadequate_profile(person)
     @person = person
     @edit_url = edit_person_url(@person)
-    mail to: @person.email
+    mail to: @person.email_address_with_name
   end
 
   def never_logged_in(person)
     @person = person
     token = Token.for_person(person)
     @token_url = token_url(token)
-    mail to: @person.email
+    mail to: @person.email_address_with_name
   end
 end

--- a/app/models/concerns/acquisition.rb
+++ b/app/models/concerns/acquisition.rb
@@ -13,7 +13,7 @@ module Concerns::Acquisition
     end
 
     def self.acquired_count from: nil, before: nil
-      acquired = Person.where('people.login_count > 0')
+      acquired = Person.logged_in_at_least_once
       acquired = acquired.where('created_at >= ?', from) if from
       acquired = acquired.where('created_at < ?', before) if before
       acquired.count

--- a/app/models/concerns/activation.rb
+++ b/app/models/concerns/activation.rb
@@ -4,7 +4,7 @@ module Concerns::Activation
   included do
     # % of people that have completeness > 80%
     def self.activated_percentage from: nil, before: nil
-      acquired = Person.where('people.login_count > 0')
+      acquired = Person.logged_in_at_least_once
       acquired = acquired.where('created_at >= ?', from) if from
       acquired = acquired.where('created_at < ?', before) if before
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -66,6 +66,9 @@ class Person < ActiveRecord::Base
 
   default_scope { order(surname: :asc, given_name: :asc) }
 
+  scope :never_logged_in, -> { where(login_count: 0) }
+  scope :logged_in_at_least_once, -> { where('people.login_count > 0') }
+
   def self.namesakes(person)
     where(surname: person.surname, given_name: person.given_name).where.not(id: person.id)
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -105,8 +105,6 @@ class Person < ActiveRecord::Base
       where("memberships.group_id": group_ids)
   end
 
-  public
-
   def to_s
     name
   end
@@ -147,6 +145,12 @@ class Person < ActiveRecord::Base
     !reminder_email_sent?(within_days: within_days) &&
       login_count == 0 &&
       created_at.end_of_day < within_days.day.ago
+  end
+
+  def email_address_with_name
+    address = Mail::Address.new email
+    address.display_name = name
+    address.format
   end
 
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -66,7 +66,12 @@ class Person < ActiveRecord::Base
 
   default_scope { order(surname: :asc, given_name: :asc) }
 
-  scope :never_logged_in, -> { where(login_count: 0) }
+  scope :never_logged_in, lambda { |limit = nil|
+    users = unscoped.where(login_count: 0).order('RANDOM()')
+    users = users.limit(limit) if limit
+    users
+  }
+
   scope :logged_in_at_least_once, -> { where('people.login_count > 0') }
 
   def self.namesakes(person)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -132,4 +132,9 @@ class Person < ActiveRecord::Base
     at_permitted_domain? && person_responsible.try(:email) != email
   end
 
+  def reminder_email_sent? within_days:
+    last_reminder_email_at.present? &&
+      last_reminder_email_at.end_of_day >= within_days.day.ago
+  end
+
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -54,18 +54,14 @@ class Person < ActiveRecord::Base
 
   validates :given_name, presence: true, on: :update
   validates :surname, presence: true
-  validates :email,
-    presence: true, uniqueness: { case_sensitive: false }, email: true
+  validates :email, presence: true, uniqueness: { case_sensitive: false }, email: true
   validates :secondary_email, email: true, allow_blank: true
 
-  has_many :memberships,
-    -> { includes(:group).order('groups.name') },
-    dependent: :destroy
+  has_many :memberships, -> { includes(:group).order('groups.name') }, dependent: :destroy
   has_many :groups, through: :memberships
   belongs_to :community
 
-  accepts_nested_attributes_for :memberships,
-    allow_destroy: true,
+  accepts_nested_attributes_for :memberships, allow_destroy: true,
     reject_if: proc { |membership| membership['group_id'].blank? }
 
   default_scope { order(surname: :asc, given_name: :asc) }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -137,4 +137,11 @@ class Person < ActiveRecord::Base
       last_reminder_email_at.end_of_day >= within_days.day.ago
   end
 
+  def send_never_logged_in_reminder?
+    within_days = 30
+    !reminder_email_sent?(within_days: within_days) &&
+      login_count == 0 &&
+      created_at.end_of_day < within_days.day.ago
+  end
+
 end

--- a/app/services/login.rb
+++ b/app/services/login.rb
@@ -18,11 +18,6 @@ class Login
     @session.delete(SESSION_KEY)
   end
 
-  def edit_profile?
-    @person.incomplete? &&
-      ((@person.login_count == 1) || (@person.login_count % 5 == 0))
-  end
-
   def self.current_user(session)
     Person.find(session[SESSION_KEY]) if session[SESSION_KEY].present?
   end

--- a/app/services/metrics_publisher.rb
+++ b/app/services/metrics_publisher.rb
@@ -13,7 +13,7 @@ class MetricsPublisher
   def profiles_report
     {
       'total' => Person.count,
-      'not_logged_in' => Person.where(login_count: 0).count
+      'not_logged_in' => Person.never_logged_in.count
     }
   end
 

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -3,7 +3,7 @@ module NeverLoggedInNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Person.never_logged_in(2).each do |person|
+    Person.never_logged_in(25).each do |person|
       person.with_lock do # use db lock in case cronjob running on two instances
         send_reminder person
       end

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -6,8 +6,7 @@ module NeverLoggedInNotifier
     Person.never_logged_in.each do |person|
       person.with_lock do # use db lock in case cronjob running on two instances
         person.reload
-        dont_send = person.reminder_email_sent?(within_days: 30) || person.login_count > 0
-        unless dont_send
+        if person.send_never_logged_in_reminder?
           ReminderMailer.never_logged_in(person).deliver_later
           person.update(last_reminder_email_at: Time.zone.now)
         end

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -5,12 +5,19 @@ module NeverLoggedInNotifier
 
     Person.never_logged_in.each do |person|
       person.with_lock do # use db lock in case cronjob running on two instances
-        person.reload
-        if person.send_never_logged_in_reminder?
-          ReminderMailer.never_logged_in(person).deliver_later
-          person.update(last_reminder_email_at: Time.zone.now)
-        end
+        send_reminder person
       end
     end
   end
+
+  def self.send_reminder person
+    person.reload
+    if person.send_never_logged_in_reminder?
+      ReminderMailer.never_logged_in(person).deliver_later
+      person.update(last_reminder_email_at: Time.zone.now)
+    end
+  end
+
+  private_class_method :send_reminder
+
 end

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -1,0 +1,10 @@
+module NeverLoggedInNotifier
+
+  def self.send_reminders
+    Person.never_logged_in.each do |person|
+      unless person.reminder_email_sent?(within_days: 30)
+        ReminderMailer.never_logged_in(person).deliver_later
+      end
+    end
+  end
+end

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -1,6 +1,8 @@
 module NeverLoggedInNotifier
 
   def self.send_reminders
+    return unless Rails.configuration.send_reminder_emails
+
     Person.never_logged_in.each do |person|
       person.with_lock do # use db lock in case cronjob running on two instances
         person.reload

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -3,7 +3,7 @@ module NeverLoggedInNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Person.never_logged_in.each do |person|
+    Person.never_logged_in(2).each do |person|
       person.with_lock do # use db lock in case cronjob running on two instances
         send_reminder person
       end

--- a/app/views/reminder_mailer/never_logged_in.html.erb
+++ b/app/views/reminder_mailer/never_logged_in.html.erb
@@ -1,0 +1,31 @@
+<table cellpadding="0" cellspacing="0" border="0" align="center" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+  <tbody><tr>
+    <td width="20" style="min-width:10px;border-collapse:collapse;"></td>
+    <td width="560" align="center" valign="top" style="border-collapse:collapse;">
+      <table cellpadding="0" cellspacing="0" border="0" align="center" class="body" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+        <tbody><tr>
+          <td width="560" align="left" valign="top" style="font-family:Arial, sans-serif;font-size:22px;font-weight:normal;line-height:normal;color:#434343;padding-bottom:30px;border-collapse:collapse;">
+            Log in to complete your People Finder profile
+          </td>
+        </tr>
+        <tr>
+          <td width="560" align="left" valign="top" style="font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:30px;color:#434343;padding-bottom:20px;border-collapse:collapse;">
+            Hello <%= @person.given_name %>,
+          </td>
+        </tr>
+        <tr>
+          <td width="560" align="left" valign="top" style="font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:30px;color:#434343;padding-bottom:20px;border-collapse:collapse;">
+            <p>It only takes a couple of minutes to complete your People Finder profile and adding up-to-date details will make it easier for colleagues to collaborate and communicate with you.</p>
+
+            <p>Use this secure link <%= link_to @token_url, @token_url, target: '_blank' %> to be taken to your ‘edit profile’ page. If you don’t use this link in the next 3 hours you’ll be asked to request a new one.</p>
+
+            <p>You’ll stop receiving emails once you’ve completed your profile.</p>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+    <td width="20" style="min-width:10px;border-collapse:collapse;"></td>
+  </tr>
+  </tbody>
+</table>

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,9 @@ module Peoplefinder
 
     config.action_mailer.asset_host = ENV['ACTION_MAILER_DEFAULT_URL']
 
+    # Note: ENV is set to 'staging' on staging environment
+    config.send_reminder_emails = (ENV['ENV'] == 'production')
+
     # The following values are required by the phase banner
     config.phase = 'live'
     config.feedback_url = 'https://docs.google.com/a/digital.justice.gov.uk/forms/d/1dJ9xQ66QFvk8K7raf60W4ZXfK4yTQ1U3EeO4OLLlq88/viewform'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,8 @@ en:
       subject: "Reminder: update your profile today"
     information_request:
       subject: "Request to update your People Finder profile"
+    never_logged_in:
+      subject: 'Reminder: update your profile today'
     reported_profile:
       subject: "A People Finder profile has been reported"
   suggestion_mailer:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every :weekday, at: '8am' do
+  runner 'NeverLoggedInNotifier.send_reminders'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,7 @@
+set :output, '/var/log/cron_log.log'
+
+job_type :rails_script, "cd /usr/src/app && ./rails_runner.sh ':task' :output"
+
 every :weekday, at: '8am' do
-  runner 'NeverLoggedInNotifier.send_reminders'
+  rails_script 'NeverLoggedInNotifier.send_reminders'
 end

--- a/db/migrate/20151217094046_add_last_reminder_email_at_to_people.rb
+++ b/db/migrate/20151217094046_add_last_reminder_email_at_to_people.rb
@@ -1,0 +1,5 @@
+class AddLastReminderEmailAtToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :last_reminder_email_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -216,7 +216,8 @@ CREATE TABLE people (
     building text,
     city text,
     secondary_email text,
-    profile_photo_id integer
+    profile_photo_id integer,
+    last_reminder_email_at timestamp without time zone
 );
 
 
@@ -655,3 +656,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150420132854');
 INSERT INTO schema_migrations (version) VALUES ('20150604110007');
 
 INSERT INTO schema_migrations (version) VALUES ('20150604110654');
+
+INSERT INTO schema_migrations (version) VALUES ('20151217094046');
+

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ esac
 
 case ${ROLE} in
 worker)
+    bundle exec whenever -w
     echo "running worker"
     bundle exec rake jobs:work
     ;;

--- a/run.sh
+++ b/run.sh
@@ -11,8 +11,25 @@ esac
 
 case ${ROLE} in
 worker)
-    echo "running whenever"
+    echo "creating rails_runner.sh for running rails runners via a cron job"
+    env > env.sh
+    sed -i '/ADMIN_IP_RANGES.*/d' env.sh
+    sed -i '/NEW_RELIC_APP_NAME.*/d' env.sh
+    cat env.sh | xargs > rails_runner.sh
+    PATH_APPENDS='PATH=/usr/local/bundle/bin:$PATH GEM_HOME=/usr/local/bundle GEM_PATH=/usr/local/bundle:$GEM_PATH'
+    echo '#!/bin/bash' > rails_runner.sh
+    echo "cd /usr/src/app" >> rails_runner.sh
+    echo "cd /usr/src/app && $(cat env.sh | xargs) $PATH_APPENDS bin/rails runner -e production \$1" >> rails_runner.sh
+    chmod a+x rails_runner.sh
+
+    echo "installing and running cron"
+    apt-get update
+    apt-get install -y cron
+    cron
+
+    echo "running whenever to create crontab"
     bundle exec whenever -w
+
     echo "running worker"
     bundle exec rake jobs:work
     ;;

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ esac
 
 case ${ROLE} in
 worker)
+    echo "running whenever"
     bundle exec whenever -w
     echo "running worker"
     bundle exec rake jobs:work

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -111,20 +111,20 @@ feature 'Group maintenance' do
     let(:sibling_group) { create(:group, name: 'Technology', parent: parent_group) }
     let(:group_three_deep) { create(:group, name: 'Digital Services', parent: parent_group) }
 
-    def setup_three_level_team
+    def setup_three_level_group
       sibling_group
       group_three_deep
     end
 
-    def setup_team_member group
+    def setup_group_member group
       user = create(:person)
       create :membership, person: user, group: group, subscribed: true
       user
     end
 
     scenario 'Editing a team name', js: true do
-      group = setup_three_level_team
-      user = setup_team_member group
+      group = setup_three_level_group
+      user = setup_group_member group
       visit_edit_view(group)
 
       expect(page).to have_title("Edit team - #{app_title}")
@@ -146,8 +146,8 @@ feature 'Group maintenance' do
     end
 
     scenario 'Changing a team parent via clicking "Back"', js: true do
-      group = setup_three_level_team
-      setup_team_member group
+      group = setup_three_level_group
+      setup_group_member group
       expect(dept.name).to eq 'Ministry of Justice'
       visit_edit_view(group)
 
@@ -164,8 +164,8 @@ feature 'Group maintenance' do
     end
 
     scenario 'Changing a team parent via clicking sibling team name', js: true do
-      group = setup_three_level_team
-      setup_team_member group
+      group = setup_three_level_group
+      setup_group_member group
       visit_edit_view(group)
 
       within('.group-parent') { click_link 'Edit' }
@@ -184,9 +184,9 @@ feature 'Group maintenance' do
     end
 
     scenario 'Changing a team parent via clicking sibling team\'s subteam name', js: true do
-      group = setup_three_level_team
+      group = setup_three_level_group
       subteam_group = create(:group, name: 'Test team', parent: sibling_group)
-      setup_team_member group
+      setup_group_member group
       visit_edit_view(group)
 
       within('.group-parent') { click_link 'Edit' }

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -173,6 +173,9 @@ feature 'Group maintenance' do
         expect(page).to have_link(sibling_group.name)
         click_link sibling_group.name
       end
+      within('.editable-fields') do
+        click_link 'Done'
+      end
 
       click_button 'Save'
 
@@ -195,6 +198,9 @@ feature 'Group maintenance' do
       within('.team.selected') do
         expect(page).to have_link(subteam_group.name)
         click_link subteam_group.name
+      end
+      within('.editable-fields') do
+        click_link 'Done'
       end
 
       click_button 'Save'

--- a/spec/features/login_flow_spec.rb
+++ b/spec/features/login_flow_spec.rb
@@ -8,31 +8,23 @@ feature 'Login flow' do
   let(:current_time) { Time.now }
 
   let(:edit_profile_page) { Pages::EditProfile.new }
+  let(:profile_page) { Pages::Profile.new }
   let(:search_page) { Pages::Search.new }
   let(:base_page) { Pages::Base.new }
 
-  scenario 'When user logs in for the first time, they are prompted to fill in their profile' do
+  scenario 'When user logs in for the first time, they see their profile' do
     omni_auth_log_in_as(email)
 
-    expect(edit_profile_page).to be_displayed
+    expect(profile_page).to be_displayed
   end
 
-  scenario 'User is prompted to update their profile every 5 logins it their profile is incomplete' do
-    login_count = 4
-    create(:person_with_multiple_logins, email: email, login_count: login_count)
-
-    omni_auth_log_in_as(email)
-
-    expect(edit_profile_page).to be_displayed
-  end
-
-  scenario 'When user logs in other than 1st or every 5th time, the search page is displayed' do
+  scenario 'When user logs in, their profile page is displayed' do
     login_count = 5
     create(:person_with_multiple_logins, email: email, login_count: login_count)
 
     omni_auth_log_in_as(email)
 
-    expect(search_page).to be_displayed
+    expect(profile_page).to be_displayed
   end
 
   scenario 'Login counter is updated every time user logs in' do

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -54,15 +54,12 @@ feature 'Token Authentication' do
     end
   end
 
-  scenario 'following valid link from email and getting prompted to complete my profile' do
+  scenario 'following valid link from email and seeing my profile' do
     token = create(:token)
     visit token_path(token)
 
     expect(page).to have_text('Signed in as')
-    expect(page).to have_text('Start building your profile now')
-    within('h1') do
-      expect(page).to have_text('Edit profile')
-    end
+    expect(page).to have_text('Edit this profile')
   end
 
   scenario "logging in with a fake token" do

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ReminderMailer do
 
   shared_examples 'body contains' do |text|
     it 'includes body text' do
-      %w[plain html].each do |part_type|
+      %w(plain html).each do |part_type|
         expect(get_message_part(mail, part_type)).to have_text(text)
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe ReminderMailer do
 
   shared_examples 'includes link to edit person' do
     it 'includes the person edit url' do
-      %w[plain html].each do |part_type|
+      %w(plain html).each do |part_type|
         expect(get_message_part(mail, part_type)).to have_text(edit_person_url(person))
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe ReminderMailer do
 
   shared_examples 'includes link to token login' do
     it 'includes the token login url' do
-      %w[plain html].each do |part_type|
+      %w(plain html).each do |part_type|
         expect(get_message_part(mail, part_type)).to have_text('http://www.example.com/tokens/')
       end
     end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ReminderMailer do
   include PermittedDomainHelper
 
-  let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
+  let(:person) { create(:person, given_name: 'John', email: 'test.user@digital.justice.gov.uk') }
 
   shared_examples 'sets email to and from correctly' do
     it 'sets the sender' do
@@ -30,9 +30,17 @@ RSpec.describe ReminderMailer do
   end
 
   shared_examples 'includes link to edit person' do
-    it 'includes the the person edit url' do
-      %w(plain html).each do |part_type|
+    it 'includes the person edit url' do
+      %w[plain html].each do |part_type|
         expect(get_message_part(mail, part_type)).to have_text(edit_person_url(person))
+      end
+    end
+  end
+
+  shared_examples 'includes link to token login' do
+    it 'includes the token login url' do
+      %w[plain html].each do |part_type|
+        expect(get_message_part(mail, part_type)).to have_text('http://www.example.com/tokens/')
       end
     end
   end
@@ -47,6 +55,18 @@ RSpec.describe ReminderMailer do
     include_examples 'body contains', "profile is 33% complete"
 
     include_examples 'includes link to edit person'
+  end
+
+  describe '.never_logged_in' do
+    let(:mail) { described_class.never_logged_in(person).deliver_now }
+
+    include_examples 'sets email to and from correctly'
+
+    include_examples 'subject contains', 'Reminder: update your profile today'
+
+    include_examples 'body contains', 'Hello John'
+
+    include_examples 'includes link to token login'
   end
 
 end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -3,10 +3,9 @@ require 'rails_helper'
 RSpec.describe ReminderMailer do
   include PermittedDomainHelper
 
-  describe '.inadequate_profile' do
-    let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
-    let(:mail) { described_class.inadequate_profile(person).deliver_now }
+  let(:person) { create(:person, email: 'test.user@digital.justice.gov.uk') }
 
+  shared_examples 'sets email to and from correctly' do
     it 'sets the sender' do
       expect(mail.from).to include(Rails.configuration.support_email)
     end
@@ -14,21 +13,40 @@ RSpec.describe ReminderMailer do
     it 'sets the correct recipient' do
       expect(mail.to).to include(person.email)
     end
+  end
 
+  shared_examples 'subject contains' do |subject|
     it 'sets the subject' do
-      expect(mail.subject).to have_text('Reminder: update your profile today')
+      expect(mail.subject).to have_text(subject)
     end
+  end
 
-    it 'describes the profile completion score' do
-      %w(plain html).each do |part_type|
-        expect(get_message_part(mail, part_type)).to have_text("profile is #{person.completion_score}% complete")
+  shared_examples 'body contains' do |text|
+    it 'includes body text' do
+      %w[plain html].each do |part_type|
+        expect(get_message_part(mail, part_type)).to have_text(text)
       end
     end
+  end
 
+  shared_examples 'includes link to edit person' do
     it 'includes the the person edit url' do
       %w(plain html).each do |part_type|
         expect(get_message_part(mail, part_type)).to have_text(edit_person_url(person))
       end
     end
   end
+
+  describe '.inadequate_profile' do
+    let(:mail) { described_class.inadequate_profile(person).deliver_now }
+
+    include_examples 'sets email to and from correctly'
+
+    include_examples 'subject contains', 'Reminder: update your profile today'
+
+    include_examples 'body contains', "profile is 33% complete"
+
+    include_examples 'includes link to edit person'
+  end
+
 end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ReminderMailer do
   include PermittedDomainHelper
 
-  let(:person) { create(:person, given_name: 'John', email: 'test.user@digital.justice.gov.uk') }
+  let(:person) { create(:person, given_name: 'John', surname: 'Coe', email: 'test.user@digital.justice.gov.uk') }
 
   shared_examples 'sets email to and from correctly' do
     it 'sets the sender' do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Person, type: :model do
       expect(described_class.never_logged_in).to include(person)
     end
 
+    it 'is not returned by .never_logged_in with limit set to 0' do
+      expect(described_class.never_logged_in(0)).to be_empty
+    end
+
     it 'is not returned by .logged_in_at_least_once' do
       expect(described_class.logged_in_at_least_once).not_to include(person)
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -358,4 +358,33 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe 'send_never_logged_in_reminder?' do
+    context 'when person created within last 30 days' do
+      before { person.update(created_at: Time.now - 30.days) }
+      it 'returns false' do
+        expect(person.send_never_logged_in_reminder?).to be false
+      end
+    end
+
+    context 'when person created more than 30 days ago' do
+      before { person.update(created_at: Time.now - 31.days) }
+
+      it 'returns true when never logged in and no reminder sent within last 30 days' do
+        allow(person).to receive(:reminder_email_sent?).and_return false
+        expect(person.send_never_logged_in_reminder?).to be true
+      end
+
+      it 'returns false when logged in before' do
+        allow(person).to receive(:reminder_email_sent?).and_return false
+        person.login_count = 1
+        expect(person.send_never_logged_in_reminder?).to be false
+      end
+
+      it 'returns false when reminder sent within last 30 days' do
+        allow(person).to receive(:reminder_email_sent?).and_return true
+        expect(person.send_never_logged_in_reminder?).to be false
+      end
+    end
+  end
+
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe '.email_address_with_name' do
+    it 'returns name and email' do
+      person = create(:person, given_name: 'Sue', surname: 'Boe', email: 'User.Example@digital.justice.gov.uk')
+      expect(person.email_address_with_name).to eq 'Sue Boe <user.example@digital.justice.gov.uk>'
+    end
+  end
+
   context 'who has never logged in' do
     before { person.save }
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -325,4 +325,16 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe '.last_reminder_email_at' do
+    it 'is nil on create' do
+      expect(person.last_reminder_email_at).to be_nil
+    end
+
+    it 'can be set to a datetime' do
+      datetime = Time.now
+      person.last_reminder_email_at = datetime
+      expect(person.last_reminder_email_at).to eq(datetime)
+    end
+  end
+
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -337,4 +337,25 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe 'reminder_email_sent? within 30 days' do
+    it 'is false on create' do
+      expect(person.reminder_email_sent?(within_days: 30)).to be false
+    end
+
+    it 'is true when last_reminder_email_at is today' do
+      person.last_reminder_email_at = Time.now
+      expect(person.reminder_email_sent?(within_days: 30)).to be true
+    end
+
+    it 'is true when last_reminder_email_at is 30 days ago' do
+      person.last_reminder_email_at = Time.now - 30.days
+      expect(person.reminder_email_sent?(within_days: 30)).to be true
+    end
+
+    it 'is false when last_reminder_email_at is 31 days ago' do
+      person.last_reminder_email_at = Time.now - 31.days
+      expect(person.reminder_email_sent?(within_days: 30)).to be false
+    end
+  end
+
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -17,6 +17,33 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  context 'who has never logged in' do
+    before { person.save }
+
+    it 'is returned by .never_logged_in' do
+      expect(described_class.never_logged_in).to include(person)
+    end
+
+    it 'is not returned by .logged_in_at_least_once' do
+      expect(described_class.logged_in_at_least_once).not_to include(person)
+    end
+  end
+
+  context 'who has logged in' do
+    before do
+      person.login_count = 1
+      person.save!
+    end
+
+    it 'is not returned by .never_logged_in' do
+      expect(described_class.never_logged_in).not_to include(person)
+    end
+
+    it 'is returned by .logged_in_at_least_once' do
+      expect(described_class.logged_in_at_least_once).to include(person)
+    end
+  end
+
   describe '.name' do
     context 'with a given_name and surname' do
       let(:person) { build(:person, given_name: 'Jon', surname: 'von Brown') }

--- a/spec/services/login_spec.rb
+++ b/spec/services/login_spec.rb
@@ -35,46 +35,6 @@ RSpec.describe Login, type: :service do
     end
   end
 
-  describe '#edit_profile?' do
-
-    subject { service.edit_profile? }
-    before do
-      allow(person).to receive(:incomplete?).and_return(!is_complete)
-      person.login_count = login_count
-    end
-
-    context 'for complete profile' do
-      let(:is_complete) { true }
-      let(:login_count) { 1 }
-
-      it { is_expected.to be false }
-    end
-
-    context 'for incomplete profile' do
-      let(:is_complete) { false }
-
-      context 'for a first time login' do
-        let(:login_count) { 1 }
-
-        it { is_expected.to be true }
-      end
-
-      [5, 45].each do |count|
-        context "every #{count}th login" do
-          let(:login_count) { count }
-
-          it { is_expected.to be true }
-        end
-      end
-
-      context 'for not first or every fifth login' do
-        let(:login_count) { 4 }
-
-        it { is_expected.to be false }
-      end
-    end
-  end
-
   describe '.current_user' do
     subject { described_class.current_user(session) }
 

--- a/spec/services/metrics_publisher_spec.rb
+++ b/spec/services/metrics_publisher_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'metrics_publisher'
+require_relative '../../app/services/metrics_publisher'
 
 RSpec.describe MetricsPublisher, type: :service do
   subject { described_class.new(recipient) }
@@ -12,6 +12,7 @@ RSpec.describe MetricsPublisher, type: :service do
       bucketed_completion: {}
     ).as_stubbed_const
     allow(pc).to receive(:where).and_return(pc)
+    allow(pc).to receive(:never_logged_in).and_return double(count: 0)
     pc
   end
 
@@ -48,7 +49,7 @@ RSpec.describe MetricsPublisher, type: :service do
 
   it 'sends the number of profiles that have not logged in' do
     scope = double(count: 42)
-    allow(person_class).to receive(:where).with(login_count: 0).
+    allow(person_class).to receive(:never_logged_in).
       and_return(scope)
     expect(recipient).to receive(:publish).
       with(:profiles, a_hash_including('not_logged_in' => 42))

--- a/spec/services/never_logged_in_notifier_spec.rb
+++ b/spec/services/never_logged_in_notifier_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe NeverLoggedInNotifier, type: :service do
+  subject { described_class }
+
+  let(:person) { double(Person) }
+  let(:mailer) { double(ReminderMailer) }
+
+  before do
+    allow(Person).to receive(:never_logged_in).and_return [person]
+    allow(person).to receive(:reminder_email_sent?).with(within_days: 30).and_return reminder_email_sent
+  end
+
+  describe 'send_reminders' do
+    context 'when never-logged-in person has' do
+
+      context 'no reminder email sent within last 30 days' do
+        let(:reminder_email_sent) { false }
+
+        it 'sends email to person' do
+          mail = double()
+          expect(ReminderMailer).to receive(:never_logged_in).with(person).and_return mail
+          expect(mail).to receive(:deliver_later)
+          subject.send_reminders
+        end
+      end
+
+      context 'reminder email sent within last 30 days' do
+        let(:reminder_email_sent) { true }
+
+        it 'does not send email to person' do
+          expect(ReminderMailer).not_to receive(:never_logged_in)
+          subject.send_reminders
+        end
+      end
+    end
+  end
+end

--- a/spec/services/never_logged_in_notifier_spec.rb
+++ b/spec/services/never_logged_in_notifier_spec.rb
@@ -1,32 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe NeverLoggedInNotifier, type: :service do
+  include PermittedDomainHelper
+
   subject { described_class }
 
-  let(:person) { double(Person) }
+  let(:person) { create(:person) }
   let(:mailer) { double(ReminderMailer) }
 
   before do
-    allow(Person).to receive(:never_logged_in).and_return [person]
-    allow(person).to receive(:reminder_email_sent?).with(within_days: 30).and_return reminder_email_sent
+    person.update(last_reminder_email_at: last_reminder_email_at)
+  end
+
+  shared_examples 'sends email' do
+    it 'sends email to person' do
+      mail = double
+      expect(ReminderMailer).to receive(:never_logged_in).with(person).and_return mail
+      expect(mail).to receive(:deliver_later)
+      subject.send_reminders
+    end
   end
 
   describe 'send_reminders' do
     context 'when never-logged-in person has' do
 
-      context 'no reminder email sent within last 30 days' do
-        let(:reminder_email_sent) { false }
+      context 'no reminder email sent' do
+        let(:last_reminder_email_at) { nil }
+        include_examples 'sends email'
+      end
 
-        it 'sends email to person' do
-          mail = double()
-          expect(ReminderMailer).to receive(:never_logged_in).with(person).and_return mail
-          expect(mail).to receive(:deliver_later)
-          subject.send_reminders
-        end
+      context 'reminder email sent over 30 days ago' do
+        let(:last_reminder_email_at) { 31.days.ago }
+        include_examples 'sends email'
       end
 
       context 'reminder email sent within last 30 days' do
-        let(:reminder_email_sent) { true }
+        let(:last_reminder_email_at) { 30.days.ago }
 
         it 'does not send email to person' do
           expect(ReminderMailer).not_to receive(:never_logged_in)

--- a/spec/services/never_logged_in_notifier_spec.rb
+++ b/spec/services/never_logged_in_notifier_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe NeverLoggedInNotifier, type: :service do
 
   before do
     person.update(last_reminder_email_at: last_reminder_email_at)
+    person.update(created_at: Time.now - 31.days)
   end
 
   shared_examples 'sends email' do
@@ -32,7 +33,7 @@ RSpec.describe NeverLoggedInNotifier, type: :service do
   end
 
   describe 'send_reminders' do
-    context 'when never-logged-in person has' do
+    context 'when never-logged-in person created more than 30 days ago has' do
 
       context 'no reminder email sent' do
         let(:last_reminder_email_at) { nil }

--- a/spec/services/never_logged_in_notifier_spec.rb
+++ b/spec/services/never_logged_in_notifier_spec.rb
@@ -13,11 +13,21 @@ RSpec.describe NeverLoggedInNotifier, type: :service do
   end
 
   shared_examples 'sends email' do
-    it 'sends email to person' do
-      mail = double
-      expect(ReminderMailer).to receive(:never_logged_in).with(person).and_return mail
-      expect(mail).to receive(:deliver_later)
-      subject.send_reminders
+    context 'when config.send_reminder_emails true' do
+      it 'sends email to person' do
+        allow(Rails.configuration).to receive(:send_reminder_emails).and_return true
+        mail = double
+        expect(ReminderMailer).to receive(:never_logged_in).with(person).and_return mail
+        expect(mail).to receive(:deliver_later)
+        subject.send_reminders
+      end
+    end
+    context 'when config.send_reminder_emails false' do
+      it 'does not send email to person' do
+        allow(Rails.configuration).to receive(:send_reminder_emails).and_return false
+        expect(ReminderMailer).not_to receive(:never_logged_in)
+        subject.send_reminders
+      end
     end
   end
 


### PR DESCRIPTION
- Send reminder emails when users haven't logged in 30 days after being added to the system, and every 30 days after that if they have not logged in.