### PR TITLE
Fix blank query bug

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -7,7 +7,7 @@ group :red_green_refactor, halt_on_fail: true do
     watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)(?:\.\w+)*$}) { |m| "spec/javascripts/#{ m[1] }_spec.#{ m[2] }" }
   end
 
-  guard :rspec, cmd: "bundle exec rspec", all_on_start: true do
+  guard :rspec, cmd: "bundle exec rspec", all_on_start: false, failed_mode: :focus do
     require "guard/rspec/dsl"
     dsl = Guard::RSpec::Dsl.new(self)
 

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -1,5 +1,6 @@
 class PersonSearch
   def fuzzy_search(query, max = 100)
+    return [] if query.blank?
     @max = max
     name_matches = search "name:#{query}"
     exact_matches = search query

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -85,6 +85,11 @@ RSpec.describe PersonSearch, elastic: true do
       expect(results).to include(alice)
       expect(results).to_not include(bob)
     end
+
+    it 'returns [] for blank search' do
+      results = search_for('')
+      expect(results).to eq([])
+    end
   end
 
   def search_for(query)


### PR DESCRIPTION
Return empty array when search term is blank, instead of letting elasticsearch raise an exception.