### PR TITLE
Put exact name matches above synonym name matches

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -15,6 +15,10 @@ module Concerns::Searchable
       __elasticsearch__.delete_index! index: index_name
     end
 
+    def self.search_results(query, limit:)
+      search(query).records.limit(limit)
+    end
+
     settings analysis: {
       filter: {
         name_synonyms_expand: {

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -3,7 +3,7 @@ class PersonSearch
     return [] if query.blank?
     @max = max
     name_matches = search "name:#{query}"
-    exact_matches = search query
+    query_matches = search query
     fuzzy_matches = search(
       size: max,
       query: {
@@ -17,12 +17,13 @@ class PersonSearch
       }
     )
 
-    (name_matches + exact_matches + fuzzy_matches).uniq[0..max-1]
+    exact_matches = name_matches.select{|p| p.name == query }
+    (exact_matches + name_matches + query_matches + fuzzy_matches).uniq[0..max-1]
   end
 
   private
 
   def search query
-    Person.search(query).records.limit(@max)
+    Person.search_results(query, limit: @max)
   end
 end

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -92,6 +92,19 @@ RSpec.describe PersonSearch, elastic: true do
     end
   end
 
+  context 'with name synonyms above exact match in results' do
+    let(:jonathan_smith) { build(:person, given_name: 'Jonathan', surname: 'Smith') }
+    let(:john_smith) { build(:person, given_name: 'John', surname: 'Smith') }
+
+    before do
+      allow(Person).to receive(:search_results).and_return [jonathan_smith, john_smith]
+    end
+
+    it 'sorts results to put exact match first' do
+      expect(described_class.new.fuzzy_search('John Smith')).to eq [john_smith, jonathan_smith]
+    end
+  end
+
   def search_for(query)
     described_class.new.fuzzy_search(query)
   end


### PR DESCRIPTION
Ensure exact name matches are at the top of search results.