### PR TITLE
Zero pad index in event action text

### DIFF
--- a/app/views/people/_person.html.haml
+++ b/app/views/people/_person.html.haml
@@ -9,8 +9,8 @@
           - pageview_path = index < 3 ? '/top-3-search-result' : '/below-top-3-search-result'
           %h3= link_to person.name, person,
             { data: { 'virtual-pageview': pageview_path,
-            'event-category': 'Search result',
-            'event-action': "Click result #{index+1}" } }
+            'event-category': 'Search result click',
+            'event-action': "Click result #{'%03d' % (index+1)}" } }
           - if person.memberships.empty?
             .meta
           - else

--- a/spec/views/people/_person.html.haml_spec.rb
+++ b/spec/views/people/_person.html.haml_spec.rb
@@ -23,16 +23,16 @@ RSpec.describe "rendering locals in a partial" do
   end
 
   it "sets data-event-category correctly" do
-    expect(rendered).to have_selector('[data-event-category="Search result"]', text: people[0].name)
-    expect(rendered).to have_selector('[data-event-category="Search result"]', text: people[1].name)
-    expect(rendered).to have_selector('[data-event-category="Search result"]', text: people[2].name)
-    expect(rendered).to have_selector('[data-event-category="Search result"]', text: people[3].name)
+    expect(rendered).to have_selector('[data-event-category="Search result click"]', text: people[0].name)
+    expect(rendered).to have_selector('[data-event-category="Search result click"]', text: people[1].name)
+    expect(rendered).to have_selector('[data-event-category="Search result click"]', text: people[2].name)
+    expect(rendered).to have_selector('[data-event-category="Search result click"]', text: people[3].name)
   end
 
   it "sets data-event-action correctly" do
-    expect(rendered).to have_selector('[data-event-action="Click result 1"]', text: people[0].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 2"]', text: people[1].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 3"]', text: people[2].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 4"]', text: people[3].name)
+    expect(rendered).to have_selector('[data-event-action="Click result 001"]', text: people[0].name)
+    expect(rendered).to have_selector('[data-event-action="Click result 002"]', text: people[1].name)
+    expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: people[2].name)
+    expect(rendered).to have_selector('[data-event-action="Click result 004"]', text: people[3].name)
   end
 end


### PR DESCRIPTION
Change to zero padded index so alphanumeric sorting in google analytics dashboard will order the event action text ascending by index number.

Also change event category text to "Search result click" for clarity.