### PR TITLE
Mock elasticsearch status in healthcheck spec

### DIFF
--- a/spec/features/application_health_check_spec.rb
+++ b/spec/features/application_health_check_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 feature 'healthcheck.json' do
+
   before(:each) do
     allow(Net::SMTP).to receive(:start).and_return('OK')
+    allow(::Elasticsearch::Model.client.cluster).to receive(:health).and_return('status' => 'green')
   end
 
   scenario 'when there are no errors it should return a 200 code' do


### PR DESCRIPTION
Allow healthcheck spec to pass when development machine elasticsearch instance has a non-green cluster status.