### PR TITLE
Send two virtual pageviews on search result click

### DIFF
--- a/app/assets/javascripts/analytics/virtual_pageview.coffee
+++ b/app/assets/javascripts/analytics/virtual_pageview.coffee
@@ -9,8 +9,9 @@ root.VirtualPageview = (->
 
   onClick = (event) ->
     element = event.currentTarget
-    url = $(element).data('virtual-pageview')
-    root.dispatchPageView url
+    urls = $(element).data('virtual-pageview').split(',')
+    _.each urls, (url) ->
+      root.dispatchPageView url
     return true
 
   bindLinks: bindLinks

--- a/app/views/people/_person.html.haml
+++ b/app/views/people/_person.html.haml
@@ -8,7 +8,7 @@
           - index = person_iteration.index
           - pageview_path = index < 3 ? '/top-3-search-result' : '/below-top-3-search-result'
           %h3= link_to person.name, person,
-            { data: { 'virtual-pageview': pageview_path,
+            { data: { 'virtual-pageview': "/search-result,#{pageview_path}",
             'event-category': 'Search result click',
             'event-action': "Click result #{'%03d' % (index+1)}" } }
           - if person.memberships.empty?

--- a/spec/javascripts/analytics/virtual_pageview_spec.coffee
+++ b/spec/javascripts/analytics/virtual_pageview_spec.coffee
@@ -5,9 +5,9 @@ describe 'VirtualPageview', ->
 
   describe 'given "data-virtual-pageview" anchor link', ->
 
-    beforeEach ->
+    setUpPage = (page_url) ->
       element = $('<body>' +
-        '<a id="a_link" data-virtual-pageview="/top-3-search-result" href="https://peoplefinder.service.gov.uk/people/john-smith">John Smith</a>' +
+        '<a id="a_link" data-virtual-pageview="' + page_url + '" href="https://peoplefinder.service.gov.uk/people/john-smith">John Smith</a>' +
         '</body>')
       $(document.body).append(element)
       new window.VirtualPageview.bindLinks()
@@ -16,9 +16,13 @@ describe 'VirtualPageview', ->
       element.remove()
       element = null
 
-    describe 'on first click', ->
-      it 'dispatches pageview', ->
-        spyOn window, 'dispatchPageView'
-        $('#a_link').trigger 'click'
+    describe 'with single page url', ->
+      beforeEach ->
+        setUpPage('/top-3-search-result')
 
-        expect(window.dispatchPageView).toHaveBeenCalledWith('/top-3-search-result')
+      describe 'on first click', ->
+        it 'dispatches pageview', ->
+          spyOn window, 'dispatchPageView'
+          $('#a_link').trigger 'click'
+
+          expect(window.dispatchPageView).toHaveBeenCalledWith('/top-3-search-result')

--- a/spec/javascripts/analytics/virtual_pageview_spec.coffee
+++ b/spec/javascripts/analytics/virtual_pageview_spec.coffee
@@ -26,3 +26,15 @@ describe 'VirtualPageview', ->
           $('#a_link').trigger 'click'
 
           expect(window.dispatchPageView).toHaveBeenCalledWith('/top-3-search-result')
+
+    describe 'with comma list of page urls', ->
+      beforeEach ->
+        setUpPage('/search-result,/top-3-search-result')
+
+      describe 'on first click', ->
+        it 'dispatches pageview for each url', ->
+          spyOn window, 'dispatchPageView'
+          $('#a_link').trigger 'click'
+
+          expect(window.dispatchPageView).toHaveBeenCalledWith('/search-result')
+          expect(window.dispatchPageView).toHaveBeenCalledWith('/top-3-search-result')

--- a/spec/views/people/_person.html.haml_spec.rb
+++ b/spec/views/people/_person.html.haml_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe "rendering locals in a partial" do
   end
 
   it "sets data-virtual-pageview correctly" do
-    expect(rendered).to have_selector('[data-virtual-pageview="/top-3-search-result"]', text: people[0].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/top-3-search-result"]', text: people[1].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/top-3-search-result"]', text: people[2].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/below-top-3-search-result"]', text: people[3].name)
+    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[0].name)
+    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[1].name)
+    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[2].name)
+    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: people[3].name)
   end
 
   it "sets data-event-category correctly" do


### PR DESCRIPTION
In order to setup a goal funnel where we can confirm a link has been clicked, send a `/search-result` pageview to google analytics, in addition to the `/top-3-search-result` or `/below-top-3-search-result` pageview.