### PR TITLE
Send virtual pageview when team link in results clicked

### DIFF
--- a/app/views/people/_person.html.haml
+++ b/app/views/people/_person.html.haml
@@ -17,7 +17,8 @@
             - person.memberships.each do |membership|
               .meta
                 = "#{ membership.role }, " if membership.role?
-                = link_to membership.group.short_name, membership.group
+                = link_to membership.group.short_name, membership.group,
+                  { data: { 'virtual-pageview': "/search-result,#{pageview_path}" } }
 
           - if feature_enabled?("communities") && person.community.present?
             .meta.community= link_to person.community, search_path(query: person.community.name)

--- a/spec/views/people/_person.html.haml_spec.rb
+++ b/spec/views/people/_person.html.haml_spec.rb
@@ -1,25 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe "rendering locals in a partial" do
+  include PermittedDomainHelper
+
+  let(:teams) do
+    [
+      create(:group),
+      create(:group),
+      create(:group),
+      create(:group)
+    ]
+  end
 
   let(:people) do
-    [
-      build(:person, given_name: "A"),
-      build(:person, given_name: "B"),
-      build(:person, given_name: "C"),
-      build(:person, given_name: "D")
+    people = [
+      create(:person),
+      create(:person),
+      create(:person),
+      create(:person)
     ]
+    people.each_with_index {|p, i| teams[i].people << p}
+    people
   end
 
   before do
     render partial: 'people/person', collection: people, locals: { edit_link: false }
   end
 
-  it "sets data-virtual-pageview correctly" do
+  it "sets data-virtual-pageview correctly on people links" do
     expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[0].name)
     expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[1].name)
     expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[2].name)
     expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: people[3].name)
+  end
+
+  it "sets data-virtual-pageview correctly on team links" do
+    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: teams[0].name)
+    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: teams[1].name)
+    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: teams[2].name)
+    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: teams[3].name)
   end
 
   it "sets data-event-category correctly" do


### PR DESCRIPTION
In order for team link clicks to appear in google analytics goal funnel, send virtual pageview when team link in search results list is clicked.