### PR TITLE
Send analytics when team or email link clicked

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -85,6 +85,15 @@ module ApplicationHelper
     I18n.t([key, subkey].join('.'), options.merge(name: user))
   end
 
+  def search_result_analytics_attributes(index)
+    pageview_path = index < 3 ? '/top-3-search-result' : '/below-top-3-search-result'
+    {
+      'virtual-pageview': "/search-result,#{pageview_path}",
+      'event-category': 'Search result click',
+      'event-action': "Click result #{'%03d' % (index+1)}"
+    }
+  end
+
 private
 
   def updated_at(obj)

--- a/app/views/people/_person.html.haml
+++ b/app/views/people/_person.html.haml
@@ -20,5 +20,5 @@
           - if feature_enabled?("communities") && person.community.present?
             .meta.community= link_to person.community, search_path(query: person.community.name)
           .meta= call_to(person.phone)
-          .meta= mail_to(person.email)
+          .meta= mail_to(person.email, nil, data: search_result_analytics_attributes(index) )
 

--- a/app/views/people/_person.html.haml
+++ b/app/views/people/_person.html.haml
@@ -6,7 +6,6 @@
           = profile_image_tag person
         .details
           - index = person_iteration.index
-          - pageview_path = index < 3 ? '/top-3-search-result' : '/below-top-3-search-result'
           %h3= link_to person.name, person,
             { data: search_result_analytics_attributes(index) }
           - if person.memberships.empty?
@@ -16,7 +15,7 @@
               .meta
                 = "#{ membership.role }, " if membership.role?
                 = link_to membership.group.short_name, membership.group,
-                  { data: { 'virtual-pageview': "/search-result,#{pageview_path}" } }
+                  { data: search_result_analytics_attributes(index) }
 
           - if feature_enabled?("communities") && person.community.present?
             .meta.community= link_to person.community, search_path(query: person.community.name)

--- a/app/views/people/_person.html.haml
+++ b/app/views/people/_person.html.haml
@@ -8,9 +8,7 @@
           - index = person_iteration.index
           - pageview_path = index < 3 ? '/top-3-search-result' : '/below-top-3-search-result'
           %h3= link_to person.name, person,
-            { data: { 'virtual-pageview': "/search-result,#{pageview_path}",
-            'event-category': 'Search result click',
-            'event-action': "Click result #{'%03d' % (index+1)}" } }
+            { data: search_result_analytics_attributes(index) }
           - if person.memberships.empty?
             .meta
           - else

--- a/spec/views/people/_person.html.haml_spec.rb
+++ b/spec/views/people/_person.html.haml_spec.rb
@@ -27,43 +27,40 @@ RSpec.describe "rendering locals in a partial" do
     render partial: 'people/person', collection: people, locals: { edit_link: false }
   end
 
-  it "sets data-virtual-pageview correctly on people links" do
-    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[0].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[1].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: people[2].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: people[3].name)
-  end
+  shared_examples 'sets analytics attributes' do
+    it "sets data-virtual-pageview correctly on links" do
+      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[0].send(label))
+      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[1].send(label))
+      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[2].send(label))
+      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: list[3].send(label))
+    end
 
-  it "sets data-virtual-pageview correctly on team links" do
-    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: teams[0].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: teams[1].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: teams[2].name)
-    expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: teams[3].name)
-  end
+    it "sets data-event-category correctly on links" do
+      list.each do |item|
+        expect(rendered).to have_selector('[data-event-category="Search result click"]', text: item.send(label))
+      end
+    end
 
-  it "sets data-event-category correctly on people links" do
-    people.each do |person|
-      expect(rendered).to have_selector('[data-event-category="Search result click"]', text: person.name)
+    it "sets data-event-action correctly on links" do
+      expect(rendered).to have_selector('[data-event-action="Click result 001"]', text: list[0].send(label))
+      expect(rendered).to have_selector('[data-event-action="Click result 002"]', text: list[1].send(label))
+      expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: list[2].send(label))
+      expect(rendered).to have_selector('[data-event-action="Click result 004"]', text: list[3].send(label))
     end
   end
 
-  it "sets data-event-action correctly on people links" do
-    expect(rendered).to have_selector('[data-event-action="Click result 001"]', text: people[0].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 002"]', text: people[1].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: people[2].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 004"]', text: people[3].name)
+  describe 'people links' do
+    let(:list) { people }
+    let(:label) { :name }
+
+    include_examples 'sets analytics attributes'
   end
 
-  it "sets data-event-category correctly on team links" do
-    teams.each do |team|
-      expect(rendered).to have_selector('[data-event-category="Search result click"]', text: team.name)
-    end
+  describe 'team links' do
+    let(:list) { teams }
+    let(:label) { :name }
+
+    include_examples 'sets analytics attributes'
   end
 
-  it "sets data-event-action correctly on team links" do
-    expect(rendered).to have_selector('[data-event-action="Click result 001"]', text: teams[0].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 002"]', text: teams[1].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: teams[2].name)
-    expect(rendered).to have_selector('[data-event-action="Click result 004"]', text: teams[3].name)
-  end
 end

--- a/spec/views/people/_person.html.haml_spec.rb
+++ b/spec/views/people/_person.html.haml_spec.rb
@@ -29,36 +29,40 @@ RSpec.describe "rendering locals in a partial" do
 
   shared_examples 'sets analytics attributes' do
     it "sets data-virtual-pageview correctly on links" do
-      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[0].send(label))
-      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[1].send(label))
-      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[2].send(label))
-      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: list[3].send(label))
+      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[0])
+      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[1])
+      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/top-3-search-result"]', text: list[2])
+      expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: list[3])
     end
 
     it "sets data-event-category correctly on links" do
       list.each do |item|
-        expect(rendered).to have_selector('[data-event-category="Search result click"]', text: item.send(label))
+        expect(rendered).to have_selector('[data-event-category="Search result click"]', text: item)
       end
     end
 
     it "sets data-event-action correctly on links" do
-      expect(rendered).to have_selector('[data-event-action="Click result 001"]', text: list[0].send(label))
-      expect(rendered).to have_selector('[data-event-action="Click result 002"]', text: list[1].send(label))
-      expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: list[2].send(label))
-      expect(rendered).to have_selector('[data-event-action="Click result 004"]', text: list[3].send(label))
+      expect(rendered).to have_selector('[data-event-action="Click result 001"]', text: list[0])
+      expect(rendered).to have_selector('[data-event-action="Click result 002"]', text: list[1])
+      expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: list[2])
+      expect(rendered).to have_selector('[data-event-action="Click result 004"]', text: list[3])
     end
   end
 
   describe 'people links' do
-    let(:list) { people }
-    let(:label) { :name }
+    let(:list) { people.map(&:name) }
 
     include_examples 'sets analytics attributes'
   end
 
   describe 'team links' do
-    let(:list) { teams }
-    let(:label) { :name }
+    let(:list) { teams.map(&:name) }
+
+    include_examples 'sets analytics attributes'
+  end
+
+  describe 'email links' do
+    let(:list) { people.map(&:email) }
 
     include_examples 'sets analytics attributes'
   end

--- a/spec/views/people/_person.html.haml_spec.rb
+++ b/spec/views/people/_person.html.haml_spec.rb
@@ -41,14 +41,13 @@ RSpec.describe "rendering locals in a partial" do
     expect(rendered).to have_selector('[data-virtual-pageview="/search-result,/below-top-3-search-result"]', text: teams[3].name)
   end
 
-  it "sets data-event-category correctly" do
-    expect(rendered).to have_selector('[data-event-category="Search result click"]', text: people[0].name)
-    expect(rendered).to have_selector('[data-event-category="Search result click"]', text: people[1].name)
-    expect(rendered).to have_selector('[data-event-category="Search result click"]', text: people[2].name)
-    expect(rendered).to have_selector('[data-event-category="Search result click"]', text: people[3].name)
+  it "sets data-event-category correctly on people links" do
+    people.each do |person|
+      expect(rendered).to have_selector('[data-event-category="Search result click"]', text: person.name)
+    end
   end
 
-  it "sets data-event-action correctly" do
+  it "sets data-event-action correctly on people links" do
     expect(rendered).to have_selector('[data-event-action="Click result 001"]', text: people[0].name)
     expect(rendered).to have_selector('[data-event-action="Click result 002"]', text: people[1].name)
     expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: people[2].name)

--- a/spec/views/people/_person.html.haml_spec.rb
+++ b/spec/views/people/_person.html.haml_spec.rb
@@ -53,4 +53,17 @@ RSpec.describe "rendering locals in a partial" do
     expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: people[2].name)
     expect(rendered).to have_selector('[data-event-action="Click result 004"]', text: people[3].name)
   end
+
+  it "sets data-event-category correctly on team links" do
+    teams.each do |team|
+      expect(rendered).to have_selector('[data-event-category="Search result click"]', text: team.name)
+    end
+  end
+
+  it "sets data-event-action correctly on team links" do
+    expect(rendered).to have_selector('[data-event-action="Click result 001"]', text: teams[0].name)
+    expect(rendered).to have_selector('[data-event-action="Click result 002"]', text: teams[1].name)
+    expect(rendered).to have_selector('[data-event-action="Click result 003"]', text: teams[2].name)
+    expect(rendered).to have_selector('[data-event-action="Click result 004"]', text: teams[3].name)
+  end
 end


### PR DESCRIPTION
Send analytics event and virtual pageviews when team or email link in search results is clicked. This matches the analytics sent when the person link is clicked in search results.