### PR TITLE
Strip commas from search query

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,7 +1,7 @@
 class SearchController < ApplicationController
   def index
     @query = query
-    @people = PersonSearch.new.fuzzy_search(@query)
+    @people = PersonSearch.new.perform_search(@query)
   end
 
 private

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -1,5 +1,5 @@
 class PersonSearch
-  def fuzzy_search(query, max = 100)
+  def perform_search(query, max = 100)
     return [] if query.blank?
     @max = max
     name_matches = search "name:#{query}"

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -1,6 +1,9 @@
 class PersonSearch
   def perform_search(query, max = 100)
     return [] if query.blank?
+    query.gsub!(',',' ')
+    query.squeeze!(' ')
+    query.strip!
     @max = max
     name_matches = search "name:#{query}"
     query_matches = search query

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SearchController, type: :controller do
   include PermittedDomainHelper
 
   let(:search) {
-    double(PersonSearch, fuzzy_search: search_result)
+    double(PersonSearch, perform_search: search_result)
   }
 
   let(:search_result) {
@@ -20,7 +20,7 @@ RSpec.describe SearchController, type: :controller do
     let(:query) { 'válïd ☺' }
 
     it 'searches for the query' do
-      expect(search).to receive(:fuzzy_search).with(query).
+      expect(search).to receive(:perform_search).with(query).
         and_return(search_result)
       get :index, query: query
     end
@@ -40,7 +40,7 @@ RSpec.describe SearchController, type: :controller do
     let(:query) { "\x99" }
 
     it 'searches for an empty string' do
-      expect(search).to receive(:fuzzy_search).with('').
+      expect(search).to receive(:perform_search).with('').
         and_return(search_result)
       get :index, query: query
     end

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -105,6 +105,16 @@ RSpec.describe PersonSearch, elastic: true do
     end
   end
 
+  context 'with commas in search query' do
+    it 'should perform search without commas' do
+      expect(Person).to receive(:search_results).with('name:Smith Bill', limit: 100).and_return []
+      expect(Person).to receive(:search_results).with('Smith Bill', limit: 100).and_return []
+      expect(Person).to receive(:search_results).with(hash_including(query: {fuzzy_like_this: hash_including(like_text: 'Smith Bill')}), limit: 100).and_return []
+
+      described_class.new.perform_search('Smith,Bill,')
+    end
+  end
+
   def search_for(query)
     described_class.new.perform_search(query)
   end

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -101,11 +101,11 @@ RSpec.describe PersonSearch, elastic: true do
     end
 
     it 'sorts results to put exact match first' do
-      expect(described_class.new.fuzzy_search('John Smith')).to eq [john_smith, jonathan_smith]
+      expect(described_class.new.perform_search('John Smith')).to eq [john_smith, jonathan_smith]
     end
   end
 
   def search_for(query)
-    described_class.new.fuzzy_search(query)
+    described_class.new.perform_search(query)
   end
 end


### PR DESCRIPTION
This improves search result relevance when searching via elasticsearch.