### PR TITLE
Don't invalidate token after login

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -34,7 +34,6 @@ class TokensController < ApplicationController
     if token.active?
       person = FindCreatePerson.from_token(token)
       login_person(person)
-      token.destroy!
     else
       error :expired_token, time: ttl_seconds_in_hours
       redirect_to new_sessions_path

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -24,8 +24,8 @@ describe TokensController, type: :controller do
       before { PermittedDomain.find_or_create_by(domain: 'digital.justice.gov.uk') }
       let!(:token) { create(:token) }
 
-      it 'token gets removed after use' do
-        expect { get :show, id: token.value; }.to change { Token.count }.by(-1)
+      it 'token does not get removed after first use' do
+        expect { get :show, id: token.value }.to change { Token.count }.by(0)
       end
     end
   end


### PR DESCRIPTION
User research has shown users click on token link in login email more than once. They get confused and frustrated when it does not work a second time.

Solution is to let token work for duration of its time to live.