### PR TITLE
Resend active token value

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,5 +123,9 @@ Rails/Date:
   Exclude:
     - 'spec/**/*'
 
+Lint/Debugger:
+  Exclude:
+    - 'spec/**/*'
+
 Style/SingleLineBlockParams:
   Enabled: false

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -5,18 +5,20 @@ class TokensController < ApplicationController
   before_action :ensure_token_auth_enabled!
 
   def create
-    @unauthorised_login = params[:token][:unauthorised_login]
     token_sender = TokenSender.new(token_params[:user_email])
-    @token = token_sender.token
+    token_sender.call(self)
+  end
 
-    if @token
-      send_token_and_render(@token)
-    elsif token_sender.report_user_email_error?
-      @user_email_error = token_sender.user_email_error
-      render action: :new
-    else
-      render action: :create
-    end
+  def render_new_view user_email_error:
+    @unauthorised_login = unauthorised_login
+    @user_email_error = user_email_error
+    render action: :new
+  end
+
+  def render_create_view token:
+    @unauthorised_login = unauthorised_login
+    @token = token
+    render action: :create
   end
 
   def show
@@ -60,15 +62,14 @@ class TokensController < ApplicationController
 
   private
 
+  def unauthorised_login
+    params[:token][:unauthorised_login]
+  end
+
   def find_token_securly(token)
     Token.find_each do |t|
       return t if Secure.compare(t.value, token)
     end
-  end
-
-  def send_token_and_render(token)
-    TokenMailer.new_token_email(token).deliver_later
-    render
   end
 
   def ttl_seconds_in_hours

--- a/app/services/token_sender.rb
+++ b/app/services/token_sender.rb
@@ -1,0 +1,32 @@
+require 'secure'
+
+class TokenSender
+
+  attr_reader :user_email_error
+
+  REPORT_EMAIL_ERROR_REGEXP = %r{(not formatted correctly|reached the limit)}
+
+  def initialize(user_email)
+    @user_email = user_email
+  end
+
+  def token
+    token = Token.find_by_user_email(@user_email)
+    if token && token.active?
+      token
+    else
+      token = Token.new(user_email: @user_email)
+      if token.save
+        token
+      else
+        @user_email_error = token.errors[:user_email].first
+        nil
+      end
+    end
+  end
+
+  def report_user_email_error?
+    @user_email_error[REPORT_EMAIL_ERROR_REGEXP]
+  end
+
+end

--- a/app/services/token_sender.rb
+++ b/app/services/token_sender.rb
@@ -23,22 +23,28 @@ class TokenSender
   end
 
   def obtain_token
-    token = Token.find_by_user_email(@user_email)
-    if token && token.active?
+    token = build_token
+    if token.save
       token
     else
-      token = Token.new(user_email: @user_email)
-      if token.save
-        token
-      else
-        @user_email_error = token.errors[:user_email].first
-        nil
-      end
+      @user_email_error = token.errors[:user_email].first
+      nil
     end
   end
 
+  private
+
   def report_user_email_error?
     user_email_error[REPORT_EMAIL_ERROR_REGEXP]
+  end
+
+  def build_token
+    token = Token.find_by_user_email(@user_email)
+    if token && token.active?
+      Token.new(user_email: @user_email, value: token.value)
+    else
+      Token.new(user_email: @user_email)
+    end
   end
 
 end

--- a/app/services/token_sender.rb
+++ b/app/services/token_sender.rb
@@ -10,7 +10,19 @@ class TokenSender
     @user_email = user_email
   end
 
-  def token
+  def call view
+    token = obtain_token
+    if token
+      TokenMailer.new_token_email(token).deliver_later
+      view.render_create_view token: token
+    elsif report_user_email_error?
+      view.render_new_view user_email_error: user_email_error
+    else
+      view.render_create_view token: nil
+    end
+  end
+
+  def obtain_token
     token = Token.find_by_user_email(@user_email)
     if token && token.active?
       token
@@ -26,7 +38,7 @@ class TokenSender
   end
 
   def report_user_email_error?
-    @user_email_error[REPORT_EMAIL_ERROR_REGEXP]
+    user_email_error[REPORT_EMAIL_ERROR_REGEXP]
   end
 
 end

--- a/app/views/sessions/_login_page.html.haml
+++ b/app/views/sessions/_login_page.html.haml
@@ -22,10 +22,10 @@
 
   = form_for (@token ||= Token.new) do |f|
 
-    .form-group{ :class => ('gov-uk-field-error' if @token.errors.include?(:user_email)) }
+    .form-group{ class: ('gov-uk-field-error' if @user_email_error) }
       = f.label :user_email, class: 'visuallyhidden'
-      - if @token.errors.include?(:user_email)
-        %span.error= @token.errors[:user_email].first
+      - if @user_email_error
+        %span.error= @user_email_error
       = f.text_field :user_email, class: 'form-control'
       = f.hidden_field(:unauthorised_login, value: @unauthorised_login)
 

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Token, type: :model do
     let!(:expiring_tokens) { create_list(:token, 3) }
 
     it 'removes expired tokens' do
-      Timecop.travel(Time.now + described_class.ttl) do
+      Timecop.travel(Time.now + token.ttl) do
         expect { token.save }.to change { described_class.expired.count }.by(-3)
       end
     end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -31,6 +31,25 @@ RSpec.describe Token, type: :model do
     expect(token).not_to be_valid
   end
 
+  describe 'create second token with same value as saved token' do
+    let(:new_token) do
+      described_class.new(user_email: token.user_email, value: token.value)
+    end
+
+    before do
+      token.save
+      new_token.save!
+    end
+
+    it 'sets spent true on previous token' do
+      expect(token.reload.spent?).to eq true
+    end
+
+    it 'allows new token to have the same value as original token' do
+      expect(new_token.value).to eq token.value
+    end
+  end
+
   context 'scopes' do
     before do
       # Seems like a smell, but if I don't then it kills all the expired records

--- a/spec/services/token_sender_spec.rb
+++ b/spec/services/token_sender_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe TokenSender, type: :service do
 
   describe '#obtain_token' do
     context 'when active token exists for given user_email' do
-      let!(:token) { double(active?: true) }
+      let!(:token) { double(active?: true, value: 'xyz') }
+      let!(:new_token) { double(save: true) }
       before do
         allow(Token).to receive(:find_by_user_email).and_return token
       end
 
-      it 'returns that token' do
-        expect(subject.obtain_token).to eq token
+      it 'returns new token with same value' do
+        expect(Token).to receive(:new).with(user_email: email, value: 'xyz').and_return new_token
+        expect(subject.obtain_token).to eq new_token
       end
     end
 

--- a/spec/services/token_sender_spec.rb
+++ b/spec/services/token_sender_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+require_relative '../../app/services/token_sender'
+
+RSpec.describe TokenSender, type: :service do
+  include PermittedDomainHelper
+
+  let(:email) { 'user.name@digital.justice.gov.uk' }
+  subject { described_class.new(email) }
+
+  shared_examples 'generates token' do
+    it 'returns new token' do
+      new_token = double(save: true)
+      allow(Token).to receive(:new).with(user_email: email).and_return new_token
+      expect(subject.token).to eq new_token
+    end
+  end
+
+  describe '#token' do
+    context 'when active token exists for given user_email' do
+      let!(:token) { double(active?: true) }
+      before do
+        allow(Token).to receive(:find_by_user_email).and_return token
+      end
+
+      it 'returns that token' do
+        expect(subject.token).to eq token
+      end
+    end
+
+    context 'when inactive token exists for given user_email' do
+      let!(:token) { double(active?: false) }
+      before do
+        allow(Token).to receive(:find_by_user_email).and_return token
+      end
+
+      it 'does not return existing token' do
+        expect(subject.token).not_to eq token
+      end
+
+      include_examples 'generates token'
+    end
+
+    context 'when no token exists for given user_email' do
+      include_examples 'generates token'
+
+      context 'and error when saving new token' do
+        let(:error_message) { 'Email address is not formatted correctly' }
+        before do
+          new_token = double(save: false, errors: { user_email: [error_message] })
+          allow(Token).to receive(:new).with(user_email: email).and_return new_token
+        end
+
+        it 'returns nil token' do
+          expect(subject.token).to eq nil
+        end
+
+        it 'sets user_email_error' do
+          subject.token
+          expect(subject.user_email_error).to eq error_message
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
When user requests a login token email, and has an active token, then send the same token value in the login email.

Ensure token throttle limit is respected when sending token email by always creating a new token even when we resend the same token value.

Move token sending logic out of the controller and into a service object.