### PR TITLE
Ensure login works for second login token email sent within 3 hours

### DIFF
--- a/app/services/token_sender.rb
+++ b/app/services/token_sender.rb
@@ -41,10 +41,16 @@ class TokenSender
   def build_token
     token = Token.find_by_user_email(@user_email)
     if token && token.active?
-      Token.new(user_email: @user_email, value: token.value)
+      rebuild_token(token)
     else
       Token.new(user_email: @user_email)
     end
+  end
+
+  def rebuild_token original_token
+    new_token = Token.new(user_email: @user_email, value: original_token.value)
+    original_token.update_attribute(:value, SecureRandom.uuid) if new_token.valid?
+    new_token
   end
 
 end

--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,7 @@ test:
   override:
 
   post:
+    - bundle exec rubocop
     # - bundle exec rake
     #     environment:
     #       RAILS_ENV: test

--- a/spec/services/token_sender_spec.rb
+++ b/spec/services/token_sender_spec.rb
@@ -18,13 +18,15 @@ RSpec.describe TokenSender, type: :service do
   describe '#obtain_token' do
     context 'when active token exists for given user_email' do
       let!(:token) { double(active?: true, value: 'xyz') }
-      let!(:new_token) { double(save: true) }
+      let!(:new_token) { double(save: true, valid?: true) }
       before do
         allow(Token).to receive(:find_by_user_email).and_return token
       end
 
-      it 'returns new token with same value' do
+      it 'returns new token with same value and changes value on original token' do
         expect(Token).to receive(:new).with(user_email: email, value: 'xyz').and_return new_token
+        allow(SecureRandom).to receive(:uuid).and_return 'abc'
+        expect(token).to receive(:update_attribute).with(:value, 'abc')
         expect(subject.obtain_token).to eq new_token
       end
     end


### PR DESCRIPTION
Ensure clicking login link in email results in the right token being found. Change value on old token when sending new token with the same value. Means only the new token is found when searching for the token value.

Add spec that when user requests a login token a second time within 3 hours of the previous request, send the same token url.

Add spec that when user requests a login token a second time 3 hours after the previous request, send a different token url.