### PR TITLE
Search only for unspent user token in token_sender 

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -21,6 +21,10 @@ class Token < ActiveRecord::Base
   scope :active,           -> { unspent.unexpired }
   scope :in_the_last_hour, -> { where(created_at: 1.hour.ago..Time.zone.now) }
 
+  def self.find_unspent_by_user_email user_email
+    unspent.find_by_user_email(user_email)
+  end
+
   def to_param
     value
   end

--- a/app/services/token_sender.rb
+++ b/app/services/token_sender.rb
@@ -39,7 +39,7 @@ class TokenSender
   end
 
   def build_token
-    token = Token.find_by_user_email(@user_email)
+    token = Token.find_unspent_by_user_email(@user_email)
     if token && token.active?
       rebuild_token(token)
     else

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe Token, type: :model do
     it { expect(described_class.unexpired).to match_array([token, spent, half_hour_ago]) }
     it { expect(described_class.expired).to match_array([expired]) }
     it { expect(described_class.in_the_last_hour).to match_array([token, spent, half_hour_ago]) }
+
+    it do
+      email = half_hour_ago.user_email
+      unspent = described_class.find_unspent_by_user_email(email)
+      expect(unspent).to eq(half_hour_ago)
+    end
   end
 
   context 'maintenance' do

--- a/spec/services/token_sender_spec.rb
+++ b/spec/services/token_sender_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TokenSender, type: :service do
       let!(:token) { double(active?: true, value: 'xyz') }
       let!(:new_token) { double(save: true, valid?: true) }
       before do
-        allow(Token).to receive(:find_by_user_email).and_return token
+        allow(Token).to receive(:find_unspent_by_user_email).and_return token
       end
 
       it 'returns new token with same value and changes value on original token' do
@@ -34,7 +34,7 @@ RSpec.describe TokenSender, type: :service do
     context 'when inactive token exists for given user_email' do
       let!(:token) { double(active?: false) }
       before do
-        allow(Token).to receive(:find_by_user_email).and_return token
+        allow(Token).to receive(:find_unspent_by_user_email).and_return token
       end
 
       it 'does not return existing token' do


### PR DESCRIPTION
Look for unspent user token. Fixes bug where spent token was found, resulting in user receiving a new token value instead of being resent active token value.