### PR TITLE
Strip digits from names before validating person

### DIFF
--- a/app/models/concerns/sanitizable.rb
+++ b/app/models/concerns/sanitizable.rb
@@ -12,9 +12,28 @@ module Concerns::Sanitizable
     fields_to_sanitize.each do |field, options|
       value = send(field)
       next unless value
-      value.strip! if value.respond_to?(:strip!) && options[:strip]
-      value.downcase! if value.respond_to?(:downcase) && options[:downcase]
+      sanitize_value! value, options
     end
+  end
+
+  private
+
+  def sanitize_value! value, options
+    value.strip! if strip?(value, options)
+    value.downcase! if downcase?(value, options)
+    value.gsub!(/\d/, '') if remove_digits?(value, options)
+  end
+
+  def strip? value, options
+    value.respond_to?(:strip!) && options[:strip]
+  end
+
+  def downcase? value, options
+    value.respond_to?(:downcase!) && options[:downcase]
+  end
+
+  def remove_digits? value, options
+    value.respond_to?(:gsub!) && options[:remove_digits]
   end
 
   module ClassMethods

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -32,7 +32,7 @@ class Person < ActiveRecord::Base
   end
 
   include Concerns::Sanitizable
-  sanitize_fields :given_name, :surname, strip: true
+  sanitize_fields :given_name, :surname, strip: true, remove_digits: true
   sanitize_fields :email, strip: true, downcase: true
 
   attr_accessor :crop_x, :crop_y, :crop_w, :crop_h

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   sequence(:email) { |n| 'example.user.%d@digital.justice.gov.uk' % n }
-  sequence(:given_name) { |n| 'First name-%04d' % n }
-  sequence(:surname) { |n| 'Surname-%04d' % n }
+  sequence(:given_name) { |n| "First name #{('a'.ord + (n % 25)).chr}" }
+  sequence(:surname) { |n| "Surname #{('a'.ord + (n % 25)).chr}" }
   sequence(:building) { |n| '%d High Street' % n }
   sequence(:city) { |n| 'Megacity %d' % n }
   sequence(:phone_number) { |n| '07700 %06d' % (900_000 + n) }

--- a/spec/models/concerns/sanitizable_spec.rb
+++ b/spec/models/concerns/sanitizable_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Concerns::Sanitizable do
     include Concerns::Sanitizable
     sanitize_fields :color, strip: true
     sanitize_fields :shape, downcase: true
-    sanitize_fields :flavor, downcase: true, strip: true
+    sanitize_fields :flavor, downcase: true, strip: true, remove_digits: true
   end
 
   subject do
     TestModel.new(
-      color: ' Orange ',
+      color: ' Orange3 ',
       shape: ' Square ',
-      flavor: ' Strawberry ',
+      flavor: ' Strawberry2 ',
       smell: ' Rancid '
     )
   end
@@ -32,8 +32,13 @@ RSpec.describe Concerns::Sanitizable do
       subject.valid?
     end
 
+    it 'removes digits when requested' do
+      expect(subject.color).to match(/\AOrange3\z/i)
+      expect(subject.flavor).to match(/\AStrawberry\z/i)
+    end
+
     it 'strips white spaces when requested' do
-      expect(subject.color).to match(/\AOrange\z/i)
+      expect(subject.color).to match(/\AOrange3\z/i)
       expect(subject.flavor).to match(/\AStrawberry\z/i)
     end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe Person, type: :model do
         expect(person.name).to eql('von Brown')
       end
     end
+
+    context 'with surname containing digit' do
+      let(:person) { build(:person, given_name: 'John', surname: 'Smith2') }
+      it 'removes digit' do
+        person.valid?
+        expect(person.name).to eql('John Smith')
+      end
+    end
   end
 
   describe '.all_in_groups' do

--- a/spec/services/person_csv_importer_spec.rb
+++ b/spec/services/person_csv_importer_spec.rb
@@ -88,15 +88,16 @@ RSpec.describe PersonCsvImporter, type: :service do
       let(:csv) do
         <<-CSV.strip_heredoc
           email,given_name,surname
-          peter.bly@valid.gov.uk,Peter,Bly
+          peter.bly2@valid.gov.uk,Peter,Bly2
           jon.con@valid.gov.uk,Jon,Con
         CSV
       end
 
       it 'creates new records' do
         subject.import
-        created = Person.where(email: 'peter.bly@valid.gov.uk')
-        expect(created.size).to be 1
+        created = Person.where(email: 'peter.bly2@valid.gov.uk').first
+        expect(created).not_to be nil
+        expect(created.name).to eq 'Peter Bly'
       end
 
       it 'uses the PersonCreator' do
@@ -116,7 +117,7 @@ RSpec.describe PersonCsvImporter, type: :service do
 
         it 'merges CSV fields into supplied parameters' do
           subject.import
-          person = Person.find_by(email: 'peter.bly@valid.gov.uk')
+          person = Person.find_by(email: 'peter.bly2@valid.gov.uk')
           expect(person.groups).to eq([group])
         end
       end


### PR DESCRIPTION
Ensure that digits are stripped from names during the import process, as in some cases names have been generated from email addresses that containing a digit in the surname.