### PR TITLE
Allow search by email address

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,7 +1,7 @@
 class SearchController < ApplicationController
   def index
     @query = query
-    @people = PersonSearch.new.perform_search(@query)
+    @people = PersonSearch.new(@query).perform_search
   end
 
   private

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -8,24 +8,32 @@ class PersonSearch
   def perform_search
     return [] if @query.blank?
 
-    name_matches, query_matches, fuzzy_matches = perform_searches
-    exact_matches = name_matches.select { |p| p.name == @query }
-
-    exact_matches.
-      push(*name_matches).
-      push(*query_matches).
-      push(*fuzzy_matches).
-      uniq[0..@max - 1]
+    email_match = email_search
+    if email_match
+      [email_match]
+    else
+      exact_matches, name_matches, query_matches, fuzzy_matches = perform_searches
+      exact_matches.
+        push(*name_matches).
+        push(*query_matches).
+        push(*fuzzy_matches).
+        uniq[0..@max - 1]
+    end
   end
 
   private
+
+  def email_search
+    Person.find_by_email(@query.downcase)
+  end
 
   def perform_searches
     name_matches = search "name:#{@query}"
     query_matches = search @query
     fuzzy_matches = fuzzy_search
+    exact_matches = name_matches.select { |p| p.name == @query }
 
-    [name_matches, query_matches, fuzzy_matches]
+    [exact_matches, name_matches, query_matches, fuzzy_matches]
   end
 
   def fuzzy_search

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -10,7 +10,12 @@ class PersonSearch
 
     name_matches, query_matches, fuzzy_matches = perform_searches
     exact_matches = name_matches.select { |p| p.name == @query }
-    (exact_matches + name_matches + query_matches + fuzzy_matches).uniq[0..@max - 1]
+
+    exact_matches.
+      push(*name_matches).
+      push(*query_matches).
+      push(*fuzzy_matches).
+      uniq[0..@max - 1]
   end
 
   private

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe SearchController, type: :controller do
     let(:query) { 'válïd ☺' }
 
     it 'searches for the query' do
-      expect(search).to receive(:perform_search).with(query).
-        and_return(search_result)
+      expect(PersonSearch).to receive(:new).with(query).and_return(search)
       get :index, query: query
     end
 
@@ -36,8 +35,7 @@ RSpec.describe SearchController, type: :controller do
     let(:query) { "\x99" }
 
     it 'searches for an empty string' do
-      expect(search).to receive(:perform_search).with('').
-        and_return(search_result)
+      expect(PersonSearch).to receive(:new).with('').and_return(search)
       get :index, query: query
     end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe Person, type: :model do
   it { should validate_uniqueness_of(:email).case_insensitive }
   it { should have_many(:groups) }
 
+  describe '.email' do
+    it 'is converted to lower case' do
+      person = create(:person, email: 'User.Example@digital.justice.gov.uk')
+      expect(person.email).to eq 'user.example@digital.justice.gov.uk'
+    end
+  end
+
   describe '.name' do
     context 'with a given_name and surname' do
       let(:person) { build(:person, given_name: 'Jon', surname: 'von Brown') }

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe PersonSearch, elastic: true do
     end
 
     it 'sorts results to put exact match first' do
-      expect(described_class.new.perform_search('John Smith')).to eq [john_smith, jonathan_smith]
+      expect(described_class.new('John Smith').perform_search).to eq [john_smith, jonathan_smith]
     end
   end
 
@@ -116,11 +116,11 @@ RSpec.describe PersonSearch, elastic: true do
           }
         ), limit: 100).and_return []
 
-      described_class.new.perform_search('Smith,Bill,')
+      described_class.new('Smith,Bill,').perform_search
     end
   end
 
   def search_for(query)
-    described_class.new.perform_search(query)
+    described_class.new(query).perform_search
   end
 end

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe PersonSearch, elastic: true do
       Person.__elasticsearch__.client.indices.refresh
     end
 
+    it 'searches by email' do
+      results = search_for(alice.email.upcase)
+      expect(results).to eq [alice]
+    end
+
     it 'searches by surname' do
       results = search_for('Andrews')
       expect(results).to include(alice)


### PR DESCRIPTION
When exact email match for query, return that person as the sole search result.