### PR TITLE
Enable staging env to only send login emails to real users

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -9,7 +9,7 @@ group :red_green_refactor, halt_on_fail: true do
     end
   end
 
-  guard :rspec, cmd: 'bundle exec rspec', all_on_start: false, failed_mode: :focus do
+  guard :rspec, cmd: 'bundle exec rspec --fail-fast', all_on_start: false, failed_mode: :focus do
     require 'guard/rspec/dsl'
     dsl = Guard::RSpec::Dsl.new(self)
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,14 +1,5 @@
 group :red_green_refactor, halt_on_fail: true do
 
-  guard :jasmine do
-    watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$}) { 'spec/javascripts' }
-    watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
-    watch(%r{spec/javascripts/fixtures/.+$})
-    watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)(?:\.\w+)*$}) do |m|
-      "spec/javascripts/#{m[1]}_spec.#{m[2]}"
-    end
-  end
-
   guard :rspec, cmd: 'bundle exec rspec --fail-fast', all_on_start: false, failed_mode: :focus do
     require 'guard/rspec/dsl'
     dsl = Guard::RSpec::Dsl.new(self)
@@ -44,6 +35,15 @@ group :red_green_refactor, halt_on_fail: true do
     # Capybara features specs
     watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
     watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+  end
+
+  guard :jasmine do
+    watch(%r{spec/javascripts/spec\.(js\.coffee|js|coffee)$}) { 'spec/javascripts' }
+    watch(%r{spec/javascripts/.+_spec\.(js\.coffee|js|coffee)$})
+    watch(%r{spec/javascripts/fixtures/.+$})
+    watch(%r{app/assets/javascripts/(.+?)\.(js\.coffee|js|coffee)(?:\.\w+)*$}) do |m|
+      "spec/javascripts/#{m[1]}_spec.#{m[2]}"
+    end
   end
 
   guard :rubocop, cli: ['--fail-fast', '--display-cop-names'] do

--- a/app/mailers/only_send_login_email_interceptor.rb
+++ b/app/mailers/only_send_login_email_interceptor.rb
@@ -1,0 +1,24 @@
+require 'mail'
+require 'recipient_interceptor'
+
+class OnlySendLoginEmailInterceptor
+
+  attr_reader :login_email_subject
+
+  def initialize recipient_string, subject_prefix:, login_email_subject:
+    @interceptor = RecipientInterceptor.new(recipient_string,
+      subject_prefix: subject_prefix)
+    @login_email_subject = login_email_subject
+  end
+
+  def delivering_email message
+    @interceptor.delivering_email(message) unless login_email? message
+  end
+
+  private
+
+  def login_email? message
+    message.subject == @login_email_subject
+  end
+
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,12 +26,6 @@ Rails.application.configure do
     :given_name, :surname, :email, :primary_phone_number,
     :secondary_phone_number, :location, :email
   ]
-  if ENV['INTERCEPTED_EMAIL_RECIPIENT'].present?
-    Mail.register_interceptor RecipientInterceptor.new(
-      ENV['INTERCEPTED_EMAIL_RECIPIENT'],
-      subject_prefix: '[STAGING]'
-    )
-  end
   config.logstasher.enabled = true
   config.logstasher.suppress_app_log = true
   config.logstasher.log_level = Logger::INFO

--- a/config/initializers/mail_interceptor.rb
+++ b/config/initializers/mail_interceptor.rb
@@ -1,0 +1,7 @@
+if ENV['INTERCEPTED_EMAIL_RECIPIENT'].present?
+  ActionMailer::Base.register_interceptor OnlySendLoginEmailInterceptor.new(
+    ENV['INTERCEPTED_EMAIL_RECIPIENT'],
+    subject_prefix: "[#{ENV['ENV']}]".upcase,
+    login_email_subject: I18n.t('token_mailer.new_token_email.subject')
+  )
+end

--- a/spec/config/initializers/mail_interceptor_spec.rb
+++ b/spec/config/initializers/mail_interceptor_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.context 'on initialization' do
+
+  context 'when INTERCEPTED_EMAIL_RECIPIENT set' do
+    before do
+      ENV['INTERCEPTED_EMAIL_RECIPIENT'] = 'test@example.com'
+      require_relative '../../../config/initializers/mail_interceptor'
+    end
+
+    after do
+      interceptor = Mail.class_variable_get(:@@delivery_interceptors).last
+      Mail.unregister_interceptor interceptor
+      ENV['INTERCEPTED_EMAIL_RECIPIENT'] = nil
+    end
+
+    it 'sets Mail delivery_interceptors correctly' do
+      interceptor = Mail.class_variable_get(:@@delivery_interceptors).last
+      expect(interceptor).to be_a(OnlySendLoginEmailInterceptor)
+      expect(interceptor.login_email_subject).to eq 'Access request to MOJ People Finder'
+    end
+  end
+
+  context 'when INTERCEPTED_EMAIL_RECIPIENT not set' do
+    it 'leaves Mail delivery_interceptor unchanged' do
+      interceptor = Mail.class_variable_get(:@@delivery_interceptors).last
+      expect(interceptor).not_to be_a(OnlySendLoginEmailInterceptor)
+    end
+  end
+end

--- a/spec/mailers/only_send_login_email_interceptor_spec.rb
+++ b/spec/mailers/only_send_login_email_interceptor_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require_relative '../../app/mailers/only_send_login_email_interceptor'
+
+RSpec.describe OnlySendLoginEmailInterceptor do
+
+  let(:recipient_string)    { 'staging@example.com' }
+  let(:subject_prefix)      { '[STAGING]' }
+  let(:login_email_subject) { 'Login email subject text' }
+  let(:recipient_interceptor) do
+    interceptor = double
+    allow(RecipientInterceptor).to receive(:new).and_return interceptor
+    interceptor
+  end
+
+  before(:each) do
+    Mail.defaults { delivery_method :test }
+  end
+
+  after(:each) do
+    Mail::TestMailer.deliveries.clear
+    Mail.defaults { delivery_method :smtp }
+  end
+
+  let(:interceptor) do
+    described_class.new(recipient_string,
+      subject_prefix: subject_prefix,
+      login_email_subject: login_email_subject)
+  end
+
+  def deliver_mail subject_text: 'some subject'
+    Mail.deliver do
+      from 'original.from@example.com'
+      to 'original.to@example.com'
+      subject subject_text
+      text_part do
+        body 'body'
+      end
+    end
+  end
+
+  describe '#initialize' do
+    it 'creates an instance of RecipientInterceptor' do
+      expect(RecipientInterceptor).to receive(:new).with(recipient_string, subject_prefix: subject_prefix).and_return recipient_interceptor
+      interceptor
+    end
+
+    it 'assigns login_email_subject' do
+      expect(interceptor.login_email_subject).to eq login_email_subject
+    end
+  end
+
+  describe 'delivering mail' do
+    context 'when non-login email' do
+      it 'calls delivering_email on RecipientInterceptor instance' do
+        expect(recipient_interceptor).to receive(:delivering_email)
+
+        Mail.register_interceptor interceptor
+        deliver_mail subject_text: 'Some subject text'
+        Mail.unregister_interceptor interceptor
+      end
+    end
+
+    context 'with login email' do
+      it 'does not call delivering_email on RecipientInterceptor instance' do
+        expect(recipient_interceptor).not_to receive(:delivering_email)
+
+        Mail.register_interceptor interceptor
+        deliver_mail subject_text: login_email_subject
+        Mail.unregister_interceptor interceptor
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
When `INTERCEPTED_EMAIL_RECIPIENT` env var is set, register mail interceptor which only sends login emails to real users and sends all other email to `INTERCEPTED_EMAIL_RECIPIENT`.