### PR TITLE
Ensure locales text loaded when configuring mail interceptor

### DIFF
--- a/config/initializers/mail_interceptor.rb
+++ b/config/initializers/mail_interceptor.rb
@@ -1,7 +1,18 @@
+
 if ENV['INTERCEPTED_EMAIL_RECIPIENT'].present?
+  def login_subject_text
+    I18n.t('token_mailer.new_token_email.subject')
+  end
+
+  if login_subject_text[/translation missing/]
+    I18n.load_path += Dir[Rails.root.join('config', 'locales', '*.{rb,yml}')]
+    I18n.default_locale = :en
+    I18n.reload!
+  end
+
   ActionMailer::Base.register_interceptor OnlySendLoginEmailInterceptor.new(
     ENV['INTERCEPTED_EMAIL_RECIPIENT'],
     subject_prefix: "[#{ENV['ENV']}]".upcase,
-    login_email_subject: I18n.t('token_mailer.new_token_email.subject')
+    login_email_subject: login_subject_text
   )
 end


### PR DESCRIPTION
Fixes bug where login email subject text is not found due to locales text not being loaded when mail interceptor initializer is run.