### PR TITLE
Configure login token emails to be higher priority than others

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ ruby '2.2.3'
 gem 'rails', '~> 4.2.4'
 
 gem 'ancestry'
+gem 'delayed_job', git: 'git@github.com:collectiveidea/delayed_job.git',
+    ref: '5f914105c1c38ca73a486d63de8ad62f254b3d72' # needed for queue_attributes configuration
 gem 'delayed_job_active_record'
 gem 'elasticsearch-model', '~> 0.1.4'
 gem 'elasticsearch-rails', '~> 0.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: git@github.com:collectiveidea/delayed_job.git
+  revision: 5f914105c1c38ca73a486d63de8ad62f254b3d72
+  ref: 5f914105c1c38ca73a486d63de8ad62f254b3d72
+  specs:
+    delayed_job (4.1.1)
+      activesupport (>= 3.0, < 5.0)
+
+GIT
   remote: https://github.com/carrierwaveuploader/carrierwave.git
   revision: cc39842e44edcb6187b2d379a606ec48a6b5e4a8
   tag: cc39842e44edcb6187b2d379a606ec48a6b5e4a8
@@ -114,11 +122,9 @@ GEM
       addressable
     daemons (1.1.9)
     database_cleaner (1.5.1)
-    delayed_job (4.0.6)
-      activesupport (>= 3.0, < 5.0)
-    delayed_job_active_record (4.0.3)
-      activerecord (>= 3.0, < 5.0)
-      delayed_job (>= 3.0, < 4.1)
+    delayed_job_active_record (4.1.0)
+      activerecord (>= 3.0, < 5)
+      delayed_job (>= 3.0, < 5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
@@ -589,6 +595,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   coffee-rails
   database_cleaner
+  delayed_job!
   delayed_job_active_record
   dotenv-rails
   elasticsearch-model (~> 0.1.4)

--- a/app/services/token_sender.rb
+++ b/app/services/token_sender.rb
@@ -13,7 +13,7 @@ class TokenSender
   def call view
     token = obtain_token
     if token
-      TokenMailer.new_token_email(token).deliver_later
+      TokenMailer.new_token_email(token).deliver_later queue: :high_priority
       view.render_create_view token: token
     elsif report_user_email_error?
       view.render_new_view user_email_error: user_email_error

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,4 @@
+Delayed::Worker.queue_attributes = [
+  { name: :high_priority, priority: -10 }, # lower number = higher priority
+  { name: :mailers, priority: 0 }
+]

--- a/spec/services/token_sender_spec.rb
+++ b/spec/services/token_sender_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe TokenSender, type: :service do
 
       it 'sends token email' do
         expect(TokenMailer).to receive(:new_token_email).with(token).and_return mailer
-        expect(mailer).to receive(:deliver_later)
+        expect(mailer).to receive(:deliver_later).with(queue: :high_priority)
         subject.call(view)
       end
 


### PR DESCRIPTION
- Require version of `delayed_job` that supports configuration of queue priorities.
- Configure a `:high_priority` queue with a higher priority than the default `:mailers` queue.
- Send login token emails via the `:high_priority` queue.
- Leave other emails to be sent via the default `:mailers` queue.