### PR TITLE
Notify leaders of teams missing team descriptions

### DIFF
--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -14,4 +14,10 @@ class ReminderMailer < ActionMailer::Base
     @token_url = token_url(token)
     mail to: @person.email_address_with_name
   end
+
+  def team_description_missing(person, group)
+    @group = group
+    @person = person
+    mail to: @person.email_address_with_name
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -110,6 +110,15 @@ class Group < ActiveRecord::Base
     memberships.subscribing.joins(:person).map(&:person)
   end
 
+  def description_reminder_email_sent? within_days:
+    description_reminder_email_at.present? &&
+      description_reminder_email_at.end_of_day >= within_days.day.ago
+  end
+
+  def send_description_reminder?
+    !description_reminder_email_sent?(within_days: 30)
+  end
+
   private
 
   def not_second_root_group

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -4,7 +4,7 @@ module NeverLoggedInNotifier
     return unless Rails.configuration.send_reminder_emails
 
     Person.never_logged_in(25).each do |person|
-      person.with_lock do # use db lock in case cronjob running on two instances
+      person.with_lock do # use db lock to allow cronjob to run on more than one instance
         send_reminder person
       end
     end

--- a/app/services/team_description_notifier.rb
+++ b/app/services/team_description_notifier.rb
@@ -1,0 +1,25 @@
+module TeamDescriptionNotifier
+
+  def self.send_reminders
+    return unless Rails.configuration.send_reminder_emails
+
+    Group.without_description.each do |group|
+      group.with_lock do # use db lock to allow cronjob to run on more than one instance
+        send_reminder group
+      end
+    end
+  end
+
+  def self.send_reminder group
+    group.reload
+    if group.send_description_reminder?
+      group.leaders.each do |leader|
+        ReminderMailer.team_description_missing(leader, group).deliver_later
+      end
+      group.update(description_reminder_email_at: Time.zone.now)
+    end
+  end
+
+  private_class_method :send_reminder
+
+end

--- a/app/views/reminder_mailer/team_description_missing.html.erb
+++ b/app/views/reminder_mailer/team_description_missing.html.erb
@@ -1,0 +1,31 @@
+<table cellpadding="0" cellspacing="0" border="0" align="center" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+  <tbody><tr>
+    <td width="20" style="min-width:10px;border-collapse:collapse;"></td>
+    <td width="560" align="center" valign="top" style="border-collapse:collapse;">
+      <table cellpadding="0" cellspacing="0" border="0" align="center" class="body" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;">
+        <tbody>
+        <tr>
+          <td width="560" align="left" valign="top" style="font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:30px;color:#434343;padding-bottom:20px;border-collapse:collapse;">
+            Hello <%= @person.given_name %>,
+          </td>
+        </tr>
+        <tr>
+          <td width="560" align="left" valign="top" style="font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:30px;color:#434343;padding-bottom:20px;border-collapse:collapse;">
+            <p>We’ve noticed that <%= link_to 'your team’s profile', edit_group_url(@group), target: '_blank' %> is missing a team description.</p>
+
+            <p>Ensuring your team has a brief description of its role and responsibilities makes it easier for people to find relevant people in the organisation.</p>
+
+            <p>Each person in your team can edit the team description themselves or you can do it by going to the team page then clicking on the <%= link_to 'Edit this team link', edit_group_url(@group), target: '_blank' %> - you’ll need to sign in when prompted.</p>
+
+            <p>The People Finder Team</p>
+
+            <p>This email is automatically generated. Do not reply.</p>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+    <td width="20" style="min-width:10px;border-collapse:collapse;"></td>
+  </tr>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,8 @@ en:
       subject: 'Reminder: update your profile today'
     reported_profile:
       subject: "A People Finder profile has been reported"
+    team_description_missing:
+      subject: 'Improve your team’s profile on People Finder'
   suggestion_mailer:
     person_email:
       subject: "Your People Finder profile"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,3 +5,7 @@ job_type :rails_script, "cd /usr/src/app && ./rails_runner.sh ':task' :output"
 every :weekday, at: '8am' do
   rails_script 'NeverLoggedInNotifier.send_reminders'
 end
+
+every :weekday, at: '8:10am' do
+  rails_script 'TeamDescriptionNotifier.send_reminders'
+end

--- a/db/migrate/20160304155510_add_description_reminder_email_at_to_group.rb
+++ b/db/migrate/20160304155510_add_description_reminder_email_at_to_group.rb
@@ -1,0 +1,5 @@
+class AddDescriptionReminderEmailAtToGroup < ActiveRecord::Migration
+  def change
+    add_column :groups, :description_reminder_email_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -126,7 +126,8 @@ CREATE TABLE groups (
     description text,
     ancestry text,
     ancestry_depth integer DEFAULT 0 NOT NULL,
-    acronym text
+    acronym text,
+    description_reminder_email_at timestamp without time zone
 );
 
 
@@ -658,4 +659,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150604110007');
 INSERT INTO schema_migrations (version) VALUES ('20150604110654');
 
 INSERT INTO schema_migrations (version) VALUES ('20151217094046');
+
+INSERT INTO schema_migrations (version) VALUES ('20160304155510');
 

--- a/spec/services/team_description_notifier_spec.rb
+++ b/spec/services/team_description_notifier_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe TeamDescriptionNotifier, type: :service do
+  include PermittedDomainHelper
+
+  subject { described_class }
+
+  let(:person) { create(:person) }
+  let(:group)  do
+    team = create(:group)
+    team.people << person
+    person.memberships.first.update(leader: true)
+    team
+  end
+
+  let(:mailer) { double(ReminderMailer) }
+
+  before do
+    group.update(description_reminder_email_at: description_reminder_email_at)
+  end
+
+  shared_examples 'sends email' do
+    context 'when config.send_reminder_emails true' do
+      it 'sends email to team leaders of group' do
+        allow(Rails.configuration).to receive(:send_reminder_emails).and_return true
+        mail = double
+        expect(ReminderMailer).to receive(:team_description_missing).with(person, group).and_return mail
+        expect(mail).to receive(:deliver_later)
+        subject.send_reminders
+      end
+    end
+    context 'when config.send_reminder_emails false' do
+      it 'does not send email' do
+        allow(Rails.configuration).to receive(:send_reminder_emails).and_return false
+        expect(ReminderMailer).not_to receive(:team_description_missing)
+        subject.send_reminders
+      end
+    end
+  end
+
+  describe 'send_reminders' do
+    context 'when never-logged-in person created more than 30 days ago has' do
+
+      context 'no reminder email sent' do
+        let(:description_reminder_email_at) { nil }
+        include_examples 'sends email'
+      end
+
+      context 'reminder email sent over 30 days ago' do
+        let(:description_reminder_email_at) { 31.days.ago }
+        include_examples 'sends email'
+      end
+
+      context 'reminder email sent within last 30 days' do
+        let(:description_reminder_email_at) { 30.days.ago }
+
+        it 'does not send email' do
+          allow(Rails.configuration).to receive(:send_reminder_emails).and_return true
+          expect(ReminderMailer).not_to receive(:team_description_missing)
+          subject.send_reminders
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Send reminder email to team leaders of any teams that do not have a team description. 
- Configure to resend after 30 days of having sent the last reminder. 
- Cronjob runs the job each weekday morning.