### PR TITLE
Move main email hint text to avoid confusion

### DIFF
--- a/app/form_builders/mark_mandatory_labels.rb
+++ b/app/form_builders/mark_mandatory_labels.rb
@@ -18,6 +18,7 @@ class MarkMandatoryLabels < SimpleDelegator
 
   def presence_validated?(method)
     object.respond_to?(:mandates_presence_of?) &&
-      object.mandates_presence_of?(method)
+      object.mandates_presence_of?(method) &&
+      method != :email
   end
 end

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -49,15 +49,15 @@
         = f.form_group :email do
           = f.label :email, class: 'form-label-bold' do
             = t(:email, scope: 'activerecord.attributes.person')
+            - if @person.persisted?
+              %p.form-hint
+                =t('.notes.email')
             - if @person.errors.include?(:email)
               %span.error= @person.errors[:email].first
           = f.text_field :email, class: 'form-control', readonly: @person.persisted?
-          - if @person.persisted?
-            %p.form-hint
-              =t('.notes.email')
-          = f.form_group :secondary_email do
-            = f.label :secondary_email, class: 'form-label-bold'
-            = f.text_field :secondary_email, class: 'form-control'
+        = f.form_group :secondary_email do
+          = f.label :secondary_email, class: 'form-label-bold'
+          = f.text_field :secondary_email, class: 'form-control'
 
       = f.form_group :location_in_building do
         = f.label :location_in_building, class: 'form-label-bold' do


### PR DESCRIPTION
Move main email hint text to sit between label and input instead of being below the input.

User reported issue caused by hint text being thought to be related to the alternate email field.

Remove the mandatory '*' character from the main email label as this is not a user editable input.