### PR TITLE
Use full team name in person search result and in breadcrumbs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,8 +18,12 @@ module ApplicationHelper
   end
 
   def breadcrumbs(items, show_links: true)
+    starts_with_home = items.first == Home.instance
+    starts_with_root_team = items.first == Group.department
     render partial: 'shared/breadcrumbs',
-           locals: { items: items, show_links: show_links }
+           locals: { items: items, show_links: show_links,
+             starts_with_home: starts_with_home,
+            starts_with_root_team: starts_with_root_team }
   end
 
   FLASH_NOTICE_KEYS = %w(error notice warning).freeze
@@ -44,18 +48,26 @@ module ApplicationHelper
     t(key, scope: 'views.info_text')
   end
 
-  def link_to_short_name_unless_current(obj)
-    full_name = obj.name
-
-    link_text = if obj.respond_to?(:short_name) && obj.short_name.present?
+  def link_to_breadcrumb_name_unless_current(obj, index, starts_with_home: nil, starts_with_root_team: nil)
+    index = adjust_breadcrumb_index(index, starts_with_home, starts_with_root_team)
+    link_text = if index < 3 && obj.respond_to?(:short_name) && obj.short_name.present?
                   obj.short_name
                 else
-                  full_name
+                  obj.name
                 end
 
-    html_options = (full_name == link_text) ? {} : { title: full_name }
-
+    html_options = (obj.name == link_text) ? {} : { title: obj.name }
     link_to_unless_current link_text, obj, html_options
+  end
+
+  def adjust_breadcrumb_index index, starts_with_home, starts_with_root_team
+    if starts_with_home
+      index - 1
+    elsif starts_with_root_team
+      index
+    else
+      index + 1
+    end
   end
 
   def app_title
@@ -101,9 +113,7 @@ module ApplicationHelper
   end
 
   def updated_by(obj)
-    unless obj.originator == Version.public_user
-      " by #{obj.originator}"
-    end
+    " by #{obj.originator}" unless obj.originator == Version.public_user
   end
 
   def flash_message(type)

--- a/app/views/search/_person.html.haml
+++ b/app/views/search/_person.html.haml
@@ -14,7 +14,7 @@
             - person.memberships.each do |membership|
               .meta
                 = "#{ membership.role }, " if membership.role?
-                = link_to membership.group.short_name, membership.group,
+                = link_to membership.group.name, membership.group,
                   search_result ? { data: search_result_analytics_attributes(index) } : {}
 
           - if feature_enabled?("communities") && person.community.present?

--- a/app/views/shared/_breadcrumb.html.haml
+++ b/app/views/shared/_breadcrumb.html.haml
@@ -2,4 +2,5 @@
   - if breadcrumb.is_a?(String) || !(show_links)
     = breadcrumb
   - else
-    = link_to_short_name_unless_current breadcrumb
+    = link_to_breadcrumb_name_unless_current breadcrumb, breadcrumb_counter,
+      starts_with_home: starts_with_home, starts_with_root_team: starts_with_root_team

--- a/app/views/shared/_breadcrumbs.html.haml
+++ b/app/views/shared/_breadcrumbs.html.haml
@@ -1,1 +1,4 @@
-%ol= render partial: "shared/breadcrumb", collection: items, locals: { show_links: show_links }
+%ol= render partial: "shared/breadcrumb", collection: items,
+  locals: { show_links: show_links,
+    starts_with_home: starts_with_home,
+    starts_with_root_team: starts_with_root_team }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -47,12 +47,43 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   context '#breadcrumbs' do
     it 'builds linked breadcrumbs' do
-      justice = create(:group, name: 'Justice')
+      justice = create(:department)
       digital_service = create(:group, parent: justice, name: 'Digital Services')
       generated = breadcrumbs([justice, digital_service])
       fragment = Capybara::Node::Simple.new(generated)
-      expect(fragment).to have_selector('a[href="/teams/justice"]', text: 'Justice')
+      expect(fragment).to have_selector('a[href="/teams/ministry-of-justice"]', text: 'Ministry of Justice')
       expect(fragment).to have_selector('a[href="/teams/digital-services"]', text: 'Digital Services')
+    end
+
+    let(:moj) { create(:department, acronym: 'MOJ') }
+    let(:csg) { create(:group, parent: moj, name: 'Corporate Services Group', acronym: 'CSG') }
+    let(:hr) { create(:group, parent: csg, name: 'Human Resources', acronym: 'HR') }
+    let(:hrbp) { create(:group, parent: hr, name: 'Human Resources Business Partners', acronym: 'HRBP') }
+
+    it 'builds linked breadcrumbs only showing acronyms for first two levels' do
+      generated = breadcrumbs([moj, csg, hr, hrbp])
+      fragment = Capybara::Node::Simple.new(generated)
+      expect(fragment).to have_selector('a[href="/teams/ministry-of-justice"]', text: 'MOJ')
+      expect(fragment).to have_selector('a[href="/teams/corporate-services-group"]', text: 'CSG')
+      expect(fragment).to have_selector('a[href="/teams/human-resources"]', text: 'HR')
+      expect(fragment).to have_selector('a[href="/teams/human-resources-business-partners"]', text: 'Human Resources Business Partners')
+    end
+
+    it 'builds linked breadcrumbs only showing acronyms for first two levels when Home path at front of breadcrumbs' do
+      generated = breadcrumbs(Home.path + [moj, csg, hr, hrbp])
+      fragment = Capybara::Node::Simple.new(generated)
+      expect(fragment).to have_selector('a[href="/teams/ministry-of-justice"]', text: 'MOJ')
+      expect(fragment).to have_selector('a[href="/teams/corporate-services-group"]', text: 'CSG')
+      expect(fragment).to have_selector('a[href="/teams/human-resources"]', text: 'HR')
+      expect(fragment).to have_selector('a[href="/teams/human-resources-business-partners"]', text: 'Human Resources Business Partners')
+    end
+
+    it 'builds linked breadcrumbs only showing acronyms for first two levels when root team not at front of breadcrumbs' do
+      generated = breadcrumbs([csg, hr, hrbp])
+      fragment = Capybara::Node::Simple.new(generated)
+      expect(fragment).to have_selector('a[href="/teams/corporate-services-group"]', text: 'CSG')
+      expect(fragment).to have_selector('a[href="/teams/human-resources"]', text: 'HR')
+      expect(fragment).to have_selector('a[href="/teams/human-resources-business-partners"]', text: 'Human Resources Business Partners')
     end
   end
 
@@ -98,26 +129,32 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#link_to_short_name_unless_current' do
+  describe '#link_to_breadcrumb_name_unless_current' do
     context 'with an object that has a short name' do
       let(:obj) { double('obj', name: 'Full Name', short_name: 'FN') }
 
       it 'links to the object' do
         expect(self).to receive(:link_to_unless_current).
           with(anything, obj, anything)
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
 
-      it 'uses the short name for the link text' do
+      it 'uses short name for the link text if index is < 2' do
         expect(self).to receive(:link_to_unless_current).
           with('FN', anything, anything)
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
 
-      it 'uses the name for the link title' do
+      it 'uses full name for the link text if index is >= 2' do
+        expect(self).to receive(:link_to_unless_current).
+          with('Full Name', anything, anything)
+        link_to_breadcrumb_name_unless_current(obj, 2)
+      end
+
+      it 'uses full name for the link title' do
         expect(self).to receive(:link_to_unless_current).
           with(anything, anything, title: 'Full Name')
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
     end
 
@@ -127,19 +164,19 @@ RSpec.describe ApplicationHelper, type: :helper do
       it 'links to the object' do
         expect(self).to receive(:link_to_unless_current).
           with(anything, obj, anything)
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
 
-      it 'uses the name for the link text' do
+      it 'uses full name for the link text' do
         expect(self).to receive(:link_to_unless_current).
           with('Full Name', anything, anything)
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
 
       it 'has no link title' do
         expect(self).to receive(:link_to_unless_current).
           with(anything, anything, {})
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
     end
 
@@ -149,19 +186,19 @@ RSpec.describe ApplicationHelper, type: :helper do
       it 'links to the object' do
         expect(self).to receive(:link_to_unless_current).
           with(anything, obj, anything)
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
 
-      it 'uses the name for the link text' do
+      it 'uses full name for the link text' do
         expect(self).to receive(:link_to_unless_current).
           with('Full Name', anything, anything)
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
 
       it 'has no link title' do
         expect(self).to receive(:link_to_unless_current).
           with(anything, anything, {})
-        link_to_short_name_unless_current(obj)
+        link_to_breadcrumb_name_unless_current(obj, 1)
       end
     end
   end


### PR DESCRIPTION
* Use full team name in person search result
* Only show team acronyms for first two levels of breadcrumb
* Use team full name for breadcrumb links past the first two levels of the breadcrumb