### PR TITLE
Reduce docker build time to speed up builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.bowerrc
+.env
+.env.example
+.git
+.gitignore
+.rspec
+.rubocop.yml
+Guardfile
+LICENCE.txt
+Procfile
+README.md
+bower.json
+circle.yml
+log/*
+smoke_test
+spec
+tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,15 @@ COPY Gemfile.lock /usr/src/app/
 
 RUN bundle install
 
-COPY . /usr/src/app
+# Copy files for assets precompile
+COPY config/application.rb config/boot.rb config/environment.rb config/database.yml /usr/src/app/config/
+COPY config/environments/assets.rb /usr/src/app/config/environments/
+COPY app/assets/ /usr/src/app/app/assets/
+COPY vendor/assets/ /usr/src/app/vendor/assets/
+COPY Rakefile /usr/src/app/
 
-RUN bundle exec rake assets:precompile RAILS_ENV=assets
+RUN bundle exec rake assets:precompile RAILS_ENV=assets SUPPORT_EMAIL=''
+
+COPY . /usr/src/app
 
 ENTRYPOINT ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.2
 
-# install socat to proxy SSH traffic for private repos
-RUN apt-get update && apt-get install -y socat apt-transport-https && \
+RUN apt-get update && apt-get install -y apt-transport-https && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && rm -fr *Release* *Sources* *Packages* && \
     truncate -s 0 /var/log/*log
@@ -32,10 +31,6 @@ RUN apt-get update && apt-get install -y runit nodejs && \
     rm -rf /var/lib/apt/lists/* && rm -fr *Release* *Sources* *Packages* && \
     truncate -s 0 /var/log/*log
 
-# SSH proxy settings
-ENV SSH_AUTH_SOCK /tmp/ssh-auth
-ENV SSH_AUTH_PROXY_PORT 1234
-
 RUN mkdir -p /usr/src/app
 RUN bundle config --global without test:development
 WORKDIR /usr/src/app
@@ -47,7 +42,7 @@ COPY Gemfile.lock /usr/src/app/
 RUN echo ':verbose: true' > $HOME/.gemrc && echo 'install: --no-document' >> $HOME/.gemrc && echo 'update: --no-document' >> $HOME/.gemrc
 
 # Hack to install private gems
-RUN socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork TCP4:$(ip route|awk '/default/ {print $3}'):$SSH_AUTH_PROXY_PORT & bundle install
+RUN bundle install
 
 COPY . /usr/src/app
 RUN mkdir -p /usr/src/app/public/assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,15 @@ RUN apt-get update && apt-get install -y \
     echo 'install: --no-document' >> $HOME/.gemrc && \
     echo 'update: --no-document' >> $HOME/.gemrc
 
+# Pre-install gems with native code to reduce build times
+# Note these versions need to be in sync with gem versions in Gemfile.lock
+RUN gem install --conservative kgio -v 2.9.3 && \
+    gem install --conservative pg -v 0.18.1 && \
+    gem install --conservative raindrops -v 0.13.0 && \
+    gem install --conservative unf_ext -v 0.0.6 && \
+    gem install --conservative nokogiri -v 1.6.7.2 && \
+    gem install --conservative unicorn -v 4.8.3
+
 WORKDIR /usr/src/app
 
 COPY Gemfile /usr/src/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,6 @@ RUN bundle install
 
 COPY . /usr/src/app
 
-CMD ["bundle", "exec"]
-
 RUN bundle exec rake assets:precompile RAILS_ENV=assets
 
 ENTRYPOINT ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,53 @@
 FROM ruby:2.2
 
-RUN apt-get update && apt-get install -y apt-transport-https && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && rm -fr *Release* *Sources* *Packages* && \
-    truncate -s 0 /var/log/*log
-
-# Throw errors if Gemfile has been modified since Gemfile.lock
-RUN bundle config --global frozen 1
-# Don't use any gems installed into the system. This makes the gem tree standalone
-RUN bundle config --global disable_shared_gems 1
-
-# Add Githubs public keys into known_hosts
-RUN mkdir $HOME/.ssh && touch /root/.ssh/known_hosts && ssh-keyscan github.com >> /root/.ssh/known_hosts
-
 # https://github.com/ministryofjustice/docker-templates/issues/37
 # UTF 8 issue during bundle install
 ENV LC_ALL C.UTF-8
-
-# Add application user
 ENV APPUSER moj
-RUN adduser $APPUSER --home /usr/src/app --shell /bin/bash --disabled-password --gecos ""
+ENV UNICORN_PORT 3000
 
+EXPOSE $UNICORN_PORT
+
+# Add Githubs public keys into known_hosts
+# Add application user
 # add official nodejs repo
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-        echo 'deb https://deb.nodesource.com/node jessie main' > /etc/apt/sources.list.d/nodesource.list
-
 # install runit and nodejs
-RUN apt-get update && apt-get install -y runit nodejs && \
+# Throw errors if Gemfile has been modified since Gemfile.lock
+# Don't use any gems installed into the system. This makes the gem tree standalone
+# Don't install documentation with gems
+RUN apt-get update && apt-get install -y \
+                              apt-transport-https && \
+    mkdir $HOME/.ssh && \
+    touch /root/.ssh/known_hosts && \
+    ssh-keyscan github.com >> /root/.ssh/known_hosts && \
+    adduser $APPUSER --home /usr/src/app --shell /bin/bash --disabled-password --gecos "" && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    echo 'deb https://deb.nodesource.com/node jessie main' > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get install -y \
+            runit \
+            nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && rm -fr *Release* *Sources* *Packages* && \
-    truncate -s 0 /var/log/*log
+    truncate -s 0 /var/log/*log && \
+    mkdir -p /usr/src/app && \
+    mkdir -p /usr/src/app/public/assets && \
+    bundle config --global frozen 1 && \
+    bundle config --global disable_shared_gems 1 && \
+    bundle config --global without test:development && \
+    echo ':verbose: true' > $HOME/.gemrc && \
+    echo 'install: --no-document' >> $HOME/.gemrc && \
+    echo 'update: --no-document' >> $HOME/.gemrc
 
-RUN mkdir -p /usr/src/app
-RUN bundle config --global without test:development
 WORKDIR /usr/src/app
 
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
 
-# Don't install documentation with gems
-RUN echo ':verbose: true' > $HOME/.gemrc && echo 'install: --no-document' >> $HOME/.gemrc && echo 'update: --no-document' >> $HOME/.gemrc
-
-# Hack to install private gems
 RUN bundle install
 
 COPY . /usr/src/app
-RUN mkdir -p /usr/src/app/public/assets
 
 CMD ["bundle", "exec"]
-
-ENV UNICORN_PORT 3000
-
-EXPOSE $UNICORN_PORT
 
 RUN bundle exec rake assets:precompile RAILS_ENV=assets
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :development do
   gem 'mailcatcher'
   gem 'spring-commands-rspec'
   gem 'guard-rspec', require: false
-  gem 'rb-fsevent' if `uname` =~ /Darwin/
+  gem 'rb-fsevent', require: RUBY_PLATFORM[/darwin/i].to_s.size > 0
 end
 
 group :development, :test do


### PR DESCRIPTION
* Reduce number of images created when building application by reducing the number of RUN commands.
* Add .dockerignore file to avoid copying unnecessary files to docker containers.
* Do asset precompile before copying other application files to docker container.