### PR TITLE
Send profile update email six months after last update

### DIFF
--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -1,4 +1,13 @@
 module PeopleHelper
+
+  def days_worked person
+    days = []
+    Person::DAYS_WORKED.each do |day|
+      days.push day_name(day) if person.send(day)
+    end
+    days.to_sentence
+  end
+
   def day_name(symbol)
     I18n.t(symbol, scope: [:people, :day_names])
   end

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -1,11 +1,11 @@
 class ReminderMailer < ActionMailer::Base
   include FeatureHelper
   layout 'email'
+  add_template_helper PeopleHelper
 
   def never_logged_in(person)
     @person = person
-    token = Token.for_person(person)
-    @token_url = token_url(token)
+    @token_url = token_url_for(person)
     mail to: @person.email_address_with_name
   end
 
@@ -13,5 +13,18 @@ class ReminderMailer < ActionMailer::Base
     @group = group
     @person = person
     mail to: @person.email_address_with_name
+  end
+
+  def person_profile_update(person)
+    @person = person
+    @token_url = token_url_for(person)
+    mail to: @person.email_address_with_name
+  end
+
+  private
+
+  def token_url_for person
+    token = Token.for_person(person)
+    token_url(token)
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -115,10 +115,6 @@ class Group < ActiveRecord::Base
       description_reminder_email_at.end_of_day >= within_days.day.ago
   end
 
-  def send_description_reminder?
-    !description_reminder_email_sent?(within_days: 30)
-  end
-
   private
 
   def not_second_root_group

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -140,13 +140,6 @@ class Person < ActiveRecord::Base
       last_reminder_email_at.end_of_day >= within.ago
   end
 
-  def send_never_logged_in_reminder?
-    within = 30.days
-    !reminder_email_sent?(within: within) &&
-      login_count == 0 &&
-      created_at.end_of_day < within.ago
-  end
-
   def email_address_with_name
     address = Mail::Address.new email
     address.display_name = name

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -135,16 +135,16 @@ class Person < ActiveRecord::Base
     at_permitted_domain? && person_responsible.try(:email) != email
   end
 
-  def reminder_email_sent? within_days:
+  def reminder_email_sent? within:
     last_reminder_email_at.present? &&
-      last_reminder_email_at.end_of_day >= within_days.day.ago
+      last_reminder_email_at.end_of_day >= within.ago
   end
 
   def send_never_logged_in_reminder?
-    within_days = 30
-    !reminder_email_sent?(within_days: within_days) &&
+    within = 30.days
+    !reminder_email_sent?(within: within) &&
       login_count == 0 &&
-      created_at.end_of_day < within_days.day.ago
+      created_at.end_of_day < within.ago
   end
 
   def email_address_with_name

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -72,7 +72,11 @@ class Person < ActiveRecord::Base
     users
   }
 
-  scope :logged_in_at_least_once, -> { where('people.login_count > 0') }
+  scope :logged_in_at_least_once, lambda { |limit = nil|
+    users = unscoped.where('people.login_count > 0').order('RANDOM()')
+    users = users.limit(limit) if limit
+    users
+  }
 
   def self.namesakes(person)
     where(surname: person.surname, given_name: person.given_name).where.not(id: person.id)

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -3,7 +3,7 @@ module NeverLoggedInNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Person.never_logged_in(25).each do |person|
+    Person.never_logged_in(25).find_each do |person|
       person.with_lock do # use db lock to allow cronjob to run on more than one instance
         send_reminder person
       end

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -12,10 +12,17 @@ module NeverLoggedInNotifier
 
   def self.send_reminder person
     person.reload
-    if person.send_never_logged_in_reminder?
+    if NeverLoggedInNotifier.send_never_logged_in_reminder? person
       ReminderMailer.never_logged_in(person).deliver_later
       person.update(last_reminder_email_at: Time.zone.now)
     end
+  end
+
+  def self.send_never_logged_in_reminder? person
+    within = 30.days
+    !person.reminder_email_sent?(within: within) &&
+      person.login_count == 0 &&
+      person.created_at.end_of_day < within.ago
   end
 
   private_class_method :send_reminder

--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -3,7 +3,7 @@ module PersonUpdateNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Person.logged_in_at_least_once.find_each do |person|
+    Person.logged_in_at_least_once(25).find_each do |person|
       person.with_lock do # use db lock to allow cronjob to run on more than one instance
         send_reminder person
       end

--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -1,0 +1,32 @@
+module PersonUpdateNotifier
+
+  def self.send_reminders
+    return unless Rails.configuration.send_reminder_emails
+
+    Person.logged_in_at_least_once.find_each do |person|
+      person.with_lock do # use db lock to allow cronjob to run on more than one instance
+        send_reminder person
+      end
+    end
+  end
+
+  def self.send_reminder person
+    person.reload
+    if send_update_reminder? person
+      ReminderMailer.person_profile_update(person).deliver_later
+      person.update(last_reminder_email_at: Time.zone.now)
+    end
+  end
+
+  def self.send_update_reminder? person
+    if person.login_count == 0
+      false
+    else
+      !person.reminder_email_sent?(within: 6.months) &&
+        person.updated_at.end_of_day > 6.months.ago
+    end
+  end
+
+  private_class_method :send_reminder
+
+end

--- a/app/services/team_description_notifier.rb
+++ b/app/services/team_description_notifier.rb
@@ -3,7 +3,7 @@ module TeamDescriptionNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Group.without_description.each do |group|
+    Group.without_description.find_each do |group|
       group.with_lock do # use db lock to allow cronjob to run on more than one instance
         send_reminder group
       end

--- a/app/services/team_description_notifier.rb
+++ b/app/services/team_description_notifier.rb
@@ -12,7 +12,7 @@ module TeamDescriptionNotifier
 
   def self.send_reminder group
     group.reload
-    if group.send_description_reminder?
+    if send_description_reminder? group
       group.leaders.each do |leader|
         ReminderMailer.team_description_missing(leader, group).deliver_later
       end
@@ -20,6 +20,10 @@ module TeamDescriptionNotifier
     end
   end
 
-  private_class_method :send_reminder
+  def self.send_description_reminder? group
+    !group.description_reminder_email_sent?(within_days: 30)
+  end
+
+  private_class_method :send_reminder, :send_description_reminder?
 
 end

--- a/app/views/reminder_mailer/person_profile_update.html.haml
+++ b/app/views/reminder_mailer/person_profile_update.html.haml
@@ -34,7 +34,10 @@
 
                   - @person.memberships.group_by(&:group).each do |group, memberships|
                     %dt Team
-                    %dd= group.name
+                    %dd
+                      = group.name
+                      - if memberships.any?(&:leader)
+                        = '- you are a team leader'
 
                     - roles = memberships.map(&:role).select(&:present?).sort.join(', ')
                     %dt Role

--- a/app/views/reminder_mailer/person_profile_update.html.haml
+++ b/app/views/reminder_mailer/person_profile_update.html.haml
@@ -1,0 +1,73 @@
+%table{align: "center", border: "0", cellpadding: "0", cellspacing: "0", style: "border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;"}
+  %tbody
+    %tr
+      %td{style: "min-width:10px;border-collapse:collapse;", width: "20"}
+      %td{align: "center", style: "border-collapse:collapse;", valign: "top", width: "560"}
+        %table.body{align: "center", border: "0", cellpadding: "0", cellspacing: "0", style: "border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;"}
+          %tbody
+            %tr
+              %td{align: "left", style: "font-family:Arial, sans-serif;font-size:22px;font-weight:normal;line-height:normal;color:#434343;padding-bottom:30px;border-collapse:collapse;", valign: "top", width: "560"}
+            %tr
+              %td{align: "left", style: "font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:30px;color:#434343;padding-bottom:20px;border-collapse:collapse;", valign: "top", width: "560"}
+                Hello #{@person.given_name},
+            %tr
+              %td{align: "left", style: "font-family:Arial, sans-serif;font-size:16px;font-weight:normal;line-height:30px;color:#434343;padding-bottom:20px;border-collapse:collapse;", valign: "top", width: "560"}
+                %p
+                  We’ve noticed that you’ve not updated #{link_to 'your People Finder page', @token_url, target: '_blank'} recently.
+                %style{ type: "text/css" }
+                  :plain
+                    dt {
+                      float:left;
+                      margin-right:0.4em;
+                      font-weight: bold;
+                    }
+                    dt:after {
+                      content:':'
+                    }
+                %p You can see the information that visitors to your page are viewing below:
+                %dl
+                  %dt Name
+                  %dd= @person.name
+
+                  %dt Days worked
+                  %dd= days_worked @person
+
+                  - @person.memberships.group_by(&:group).each do |group, memberships|
+                    %dt Team
+                    %dd= group.name
+
+                    - roles = memberships.map(&:role).select(&:present?).sort.join(', ')
+                    %dt Role
+                    %dd= roles.presence || '-'
+
+                  %dt Location
+                  %dd= @person.location.presence || '-'
+
+                  - if @person.secondary_email.present?
+                    %dt= t(:secondary_email, scope: 'activerecord.attributes.person')
+                    %dd= @person.secondary_email
+
+                  %dt Primary phone number
+                  %dd= @person.primary_phone_number.presence || '-'
+
+                  - if @person.secondary_phone_number.present?
+                    %dt Other phone number
+                    %dd= @person.secondary_phone_number
+
+                  %dt Current project(s)
+                  %dd= @person.current_project.presence || '-'
+
+                  - if @person.description.present?
+                    %dt Extra information:
+                    %dd= @person.description
+
+                %p
+                  If anything’s changed over recent months, why not help your co-workers stay in touch and #{link_to 'update your details', @token_url, target: '_blank'} now.
+
+                %p
+                  The People Finder Team
+
+                %p
+                  This email is automatically generated. Do not reply.
+
+      %td{style: "min-width:10px;border-collapse:collapse;", width: "20"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,9 +156,9 @@ en:
     information_request:
       subject: "Request to update your People Finder profile"
     never_logged_in:
-      subject: 'Reminder: update your profile today'
-    reported_profile:
-      subject: "A People Finder profile has been reported"
+      subject: 'Are your People Finder details up to date?'
+    person_profile_update:
+      subject: 'Are your People Finder details up to date?'
     team_description_missing:
       subject: 'Improve your team’s profile on People Finder'
   suggestion_mailer:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,3 +9,7 @@ end
 every :weekday, at: '8:10am' do
   rails_script 'TeamDescriptionNotifier.send_reminders'
 end
+
+every :weekday, at: '8:15am' do
+  rails_script 'PersonUpdateNotifier.send_reminders'
+end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -89,13 +89,11 @@ RSpec.describe ReminderMailer do
     include_examples 'includes link to token login'
 
     it 'includes profile details' do
-      team_name = group.name
-
+      team_name = group.name # also creates group
       %w(html plain).each do |type|
         text = get_message_part(mail, type)
-        expect(text).to have_text(team_name)
         expect(text).to have_text('Name John Coe')
-        expect(text).to have_text('Team Group-0001')
+        expect(text).to have_text("Team #{team_name} - you are a team leader")
         expect(text).to have_text('Role -')
         expect(text).to have_text('Location -')
         expect(text).to have_text('Primary phone number -')

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -58,9 +58,7 @@ RSpec.describe ReminderMailer do
 
   shared_examples 'includes link to token login' do
     it 'includes the token login url' do
-      %w(plain html).each do |part_type|
-        expect(get_message_part(mail, part_type)).to have_text('http://www.example.com/tokens/')
-      end
+      expect(get_message_part(mail, 'text')).to have_text('http://www.example.com/tokens/')
     end
   end
 
@@ -68,11 +66,8 @@ RSpec.describe ReminderMailer do
     let(:mail) { described_class.never_logged_in(person).deliver_now }
 
     include_examples 'sets email to and from correctly'
-
-    include_examples 'subject contains', 'Reminder: update your profile today'
-
+    include_examples 'subject contains', 'Are your People Finder details up to date?'
     include_examples 'body contains', 'Hello John'
-
     include_examples 'includes link to token login'
   end
 
@@ -80,12 +75,33 @@ RSpec.describe ReminderMailer do
     let(:mail) { described_class.team_description_missing(person, group).deliver_now }
 
     include_examples 'sets email to and from correctly'
-
     include_examples 'subject contains', 'Improve your team’s profile on People Finder'
-
     include_examples 'body contains', 'Hello John'
-
     include_examples 'includes link to edit group'
+  end
+
+  describe '.person_profile_update' do
+    let(:mail) { described_class.person_profile_update(person).deliver_now }
+
+    include_examples 'sets email to and from correctly'
+    include_examples 'subject contains', 'Are your People Finder details up to date?'
+    include_examples 'body contains', 'Hello John'
+    include_examples 'includes link to token login'
+
+    it 'includes profile details' do
+      team_name = group.name
+
+      %w(html plain).each do |type|
+        text = get_message_part(mail, type)
+        expect(text).to have_text(team_name)
+        expect(text).to have_text('Name John Coe')
+        expect(text).to have_text('Team Group-0001')
+        expect(text).to have_text('Role -')
+        expect(text).to have_text('Location -')
+        expect(text).to have_text('Primary phone number -')
+        expect(text).to have_text('Current project(s) -')
+      end
+    end
   end
 
 end

--- a/spec/models/concerns/acquisition_spec.rb
+++ b/spec/models/concerns/acquisition_spec.rb
@@ -32,8 +32,10 @@ RSpec.describe Concerns::Acquisition do
     end
 
     context 'when one person created yesterday who has logged in' do
+      let(:yesterday) { Date.today - 1.day }
+
       before do
-        create(:person, login_count: 1, created_at: Date.yesterday.to_time)
+        create(:person, login_count: 1, created_at: yesterday)
       end
 
       it 'returns 0 when from date is today' do
@@ -41,11 +43,11 @@ RSpec.describe Concerns::Acquisition do
       end
 
       it 'returns 100 when from date is yesterday' do
-        expect(Person.acquired_percentage(from: Date.yesterday.to_s)).to eq(100)
+        expect(Person.acquired_percentage(from: yesterday.to_s)).to eq(100)
       end
 
       it 'returns 0 when before date is yesterday' do
-        expect(Person.acquired_percentage(before: Date.yesterday.to_s)).to eq(0)
+        expect(Person.acquired_percentage(before: yesterday.to_s)).to eq(0)
       end
 
       it 'returns 100 when before date is today' do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -369,33 +369,4 @@ RSpec.describe Person, type: :model do
     end
   end
 
-  describe 'send_never_logged_in_reminder?' do
-    context 'when person created within last 30 days' do
-      before { person.update(created_at: Time.now - 30.days) }
-      it 'returns false' do
-        expect(person.send_never_logged_in_reminder?).to be false
-      end
-    end
-
-    context 'when person created more than 30 days ago' do
-      before { person.update(created_at: Time.now - 31.days) }
-
-      it 'returns true when never logged in and no reminder sent within last 30 days' do
-        allow(person).to receive(:reminder_email_sent?).and_return false
-        expect(person.send_never_logged_in_reminder?).to be true
-      end
-
-      it 'returns false when logged in before' do
-        allow(person).to receive(:reminder_email_sent?).and_return false
-        person.login_count = 1
-        expect(person.send_never_logged_in_reminder?).to be false
-      end
-
-      it 'returns false when reminder sent within last 30 days' do
-        allow(person).to receive(:reminder_email_sent?).and_return true
-        expect(person.send_never_logged_in_reminder?).to be false
-      end
-    end
-  end
-
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Person, type: :model do
       expect(described_class.never_logged_in).not_to include(person)
     end
 
+    it 'is not returned by .logged_in_at_least_once with limit set to 0' do
+      expect(described_class.logged_in_at_least_once(0)).to be_empty
+    end
+
     it 'is returned by .logged_in_at_least_once' do
       expect(described_class.logged_in_at_least_once).to include(person)
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -350,22 +350,22 @@ RSpec.describe Person, type: :model do
 
   describe 'reminder_email_sent? within 30 days' do
     it 'is false on create' do
-      expect(person.reminder_email_sent?(within_days: 30)).to be false
+      expect(person.reminder_email_sent?(within: 30.days)).to be false
     end
 
     it 'is true when last_reminder_email_at is today' do
       person.last_reminder_email_at = Time.now
-      expect(person.reminder_email_sent?(within_days: 30)).to be true
+      expect(person.reminder_email_sent?(within: 30.days)).to be true
     end
 
     it 'is true when last_reminder_email_at is 30 days ago' do
       person.last_reminder_email_at = Time.now - 30.days
-      expect(person.reminder_email_sent?(within_days: 30)).to be true
+      expect(person.reminder_email_sent?(within: 30.days)).to be true
     end
 
     it 'is false when last_reminder_email_at is 31 days ago' do
       person.last_reminder_email_at = Time.now - 31.days
-      expect(person.reminder_email_sent?(within_days: 30)).to be false
+      expect(person.reminder_email_sent?(within: 30.days)).to be false
     end
   end
 

--- a/spec/services/never_logged_in_notifier_spec.rb
+++ b/spec/services/never_logged_in_notifier_spec.rb
@@ -10,32 +10,55 @@ RSpec.describe NeverLoggedInNotifier, type: :service do
   let(:mailer) { double(ReminderMailer) }
   let(:mailer_params) { [person] }
 
-  before do
-    person.update(last_reminder_email_at: last_reminder_email_at)
-    person.update(created_at: Time.now - 31.days)
-  end
-
   describe 'send_reminders' do
-    context 'when never-logged-in person created more than 30 days ago has' do
+    before do
+      allow(described_class).to receive(:send_never_logged_in_reminder?).
+        with(person).and_return can_send
+    end
 
-      context 'no reminder email sent' do
-        let(:last_reminder_email_at) { nil }
-        include_examples 'sends reminder email', :never_logged_in
-      end
+    context 'when send_never_logged_in_reminder? is true' do
+      let(:can_send) { true }
 
-      context 'reminder email sent over 30 days ago' do
-        let(:last_reminder_email_at) { 31.days.ago }
-        include_examples 'sends reminder email', :never_logged_in
-      end
+      include_examples 'sends reminder email', :never_logged_in
+    end
 
-      context 'reminder email sent within last 30 days' do
-        let(:last_reminder_email_at) { 30.days.ago }
+    context 'when send_never_logged_in_reminder? is false' do
+      let(:can_send) { false }
 
-        it 'does not send email to person' do
-          expect(ReminderMailer).not_to receive(:never_logged_in)
-          subject.send_reminders
-        end
+      it 'does not send email to person' do
+        expect(ReminderMailer).not_to receive(:never_logged_in)
+        subject.send_reminders
       end
     end
   end
+
+  describe 'send_never_logged_in_reminder?' do
+    context 'when person created within last 30 days' do
+      before { person.update(created_at: Time.now - 30.days) }
+      it 'returns false' do
+        expect(described_class.send_never_logged_in_reminder?(person)).to be false
+      end
+    end
+
+    context 'when person created more than 30 days ago' do
+      before { person.update(created_at: Time.now - 31.days) }
+
+      it 'returns true when never logged in and no reminder sent within last 30 days' do
+        allow(person).to receive(:reminder_email_sent?).and_return false
+        expect(described_class.send_never_logged_in_reminder?(person)).to be true
+      end
+
+      it 'returns false when logged in before' do
+        allow(person).to receive(:reminder_email_sent?).and_return false
+        person.login_count = 1
+        expect(described_class.send_never_logged_in_reminder?(person)).to be false
+      end
+
+      it 'returns false when reminder sent within last 30 days' do
+        allow(person).to receive(:reminder_email_sent?).and_return true
+        expect(described_class.send_never_logged_in_reminder?(person)).to be false
+      end
+    end
+  end
+
 end

--- a/spec/services/person_update_notifier_spec.rb
+++ b/spec/services/person_update_notifier_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+require_relative 'shared_examples_for_notifiers'
+
+RSpec.describe PersonUpdateNotifier, type: :service do
+  include PermittedDomainHelper
+
+  subject { described_class }
+
+  let(:person) { create(:person, login_count: 1) }
+  let(:mailer) { double(ReminderMailer) }
+  let(:mailer_params) { [person] }
+
+  describe 'send_reminders' do
+    before do
+      allow(described_class).to receive(:send_update_reminder?).
+        with(person).and_return can_send
+    end
+
+    context 'when send_update_reminder?(person) is true' do
+      let(:can_send) { true }
+
+      include_examples 'sends reminder email', :person_profile_update
+    end
+
+    context 'when send_update_reminder?(person) is false' do
+      let(:can_send) { false }
+
+      it 'does not send email to person' do
+        expect(ReminderMailer).not_to receive(:person_profile_update)
+        subject.send_reminders
+      end
+    end
+  end
+
+  describe 'send_update_reminder?' do
+    context 'when person has never logged in' do
+      it 'returns false' do
+        allow(person).to receive(:login_count).and_return 0
+        expect(described_class.send_update_reminder?(person)).to be false
+      end
+    end
+
+    context 'when person has logged in before' do
+
+      before do
+        allow(person).to receive(:login_count).and_return 1
+      end
+
+      it 'returns false when last login more than 6 months ago' do
+        person.update(updated_at: Time.now - (6.months + 1.day))
+        expect(described_class.send_update_reminder?(person)).to be false
+      end
+
+      it 'returns false when last login within last 6 months and last reminder sent within 6 months' do
+        person.update(created_at: Time.now - 6.months)
+        person.update(last_reminder_email_at: Time.now - 6.months)
+        expect(described_class.send_update_reminder?(person)).to be false
+      end
+
+      it 'returns true when last login within last 6 months and last reminder sent more than 6 months ago' do
+        person.update(created_at: Time.now - 6.months)
+        person.update(last_reminder_email_at: Time.now - (6.months + 1.day))
+        expect(described_class.send_update_reminder?(person)).to be true
+      end
+
+      it 'returns true when last login within last 6 months and no last reminder sent' do
+        person.update(created_at: Time.now - 6.months)
+        person.update(last_reminder_email_at: nil)
+        expect(described_class.send_update_reminder?(person)).to be true
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
- Add to cron schedule to trigger sending updates on weekdays.
- Render profile details in reminder email copy.
- Put token login link in reminder email.
- Set the person's `last_reminder_email_at` field when email is sent.
- Throttle emails to 25 per instance per day. So 2 instances will send 50 emails a day.