### PR TITLE
Exclude gemfile from a rubocop style rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,6 +148,10 @@ Performance/TimesMap:
   Exclude:
     - 'spec/**/*'
 
+Style/ZeroLengthPredicate:
+  Exclude:
+    - 'Gemfile'
+
 RSpec/NotToNot:
   Enabled: false
 


### PR DESCRIPTION
Fixes rubocop failure.