### PR TITLE
Strip all punctuation except apostrophes from search term

### DIFF
--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -2,6 +2,7 @@ class PersonSearch
 
   def initialize query
     @query = clean_query query
+    @email_query = query.strip.downcase
     @max = 100
   end
 
@@ -24,7 +25,7 @@ class PersonSearch
   private
 
   def email_search
-    Person.find_by_email(@query.downcase)
+    Person.find_by_email(@email_query)
   end
 
   def perform_searches

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -54,6 +54,7 @@ class PersonSearch
 
   def clean_query query
     query.
+      gsub(/[^[[:alnum:]]’\']/, ' ').
       tr(',', ' ').
       squeeze(' ').
       strip

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe PersonSearch, elastic: true do
   let!(:abe) do
     create(:person, given_name: 'Abe', surname: 'Predovic')
   end
+  let!(:oleary) do
+    create(:person, given_name: 'Denis', surname: "O'Leary")
+  end
+  let!(:oleary2) do
+    create(:person, given_name: 'Denis', surname: "O’Leary")
+  end
 
   let!(:digital_services) { create(:group, name: 'Digital Services') }
   let!(:membership) { bob.memberships.create(group: digital_services, role: 'Cleaner') }
@@ -86,6 +92,34 @@ RSpec.describe PersonSearch, elastic: true do
       results = search_for('weekends at petty france office')
       expect(results).to_not include(alice)
       expect(results).to include(bob)
+    end
+
+    it 'searches ignoring * in search term' do
+      results = search_for('Alice *')
+      expect(results).to include(alice)
+    end
+
+    it 'searches ignoring " at start of search term' do
+      results = search_for('"Alice ')
+      expect(results).to include(alice)
+    end
+
+    it 'searches ignoring " at end of search term' do
+      results = search_for('Alice"')
+      expect(results).to include(alice)
+    end
+
+    it 'searches ignoring " in middle of search term' do
+      results = search_for('Alice" Andrews')
+      expect(results).to include(alice)
+    end
+
+    it 'searches apostrophe in name' do
+      results = search_for("O'Leary")
+      expect(results).to include(oleary)
+
+      results = search_for("O’Leary")
+      expect(results).to include(oleary2)
     end
 
     it 'searches by community' do


### PR DESCRIPTION
Avoid exceptions when searching by removing all punctuation except apostrophes from search term before using it in queries.

Leave in apostrophe so that names containing apostrophes can be searched, e.g. O'Leary.