### PR TITLE
 Show custom team lead question when Ministry of Justice selected

### DIFF
--- a/app/assets/javascripts/peoplefinder/team_selector.js
+++ b/app/assets/javascripts/peoplefinder/team_selector.js
@@ -6,6 +6,7 @@ var teamSelector = function teamSelector(isPerson, obj){
   this.editButton = this.selector.find('a.show-editable-fields');
   this.newTeam = this.selector.find('.new-team');
   this.newTeamInput = this.newTeam.find('.new-team-name');
+  this.originalTeamLedQuestion = null;
 
   /* Listen for events */
   this.initEvents = function(){
@@ -222,7 +223,20 @@ var teamSelector = function teamSelector(isPerson, obj){
   /* Set the Team leader heading and hint spans with the given team name */
   this.setTeamName = function(teamName){
     if(this.isPerson){
+      if(this.originalTeamLedQuestion) {
+        this.selector.find('.team-leader legend').html(this.originalTeamLedQuestion);
+        this.originalTeamLedQuestion = null;
+      }
       this.selector.find('.team-led').text(teamName + ' team');
+      if(teamName === 'Ministry of Justice'){
+        var legend = this.selector.find('.team-leader legend');
+        this.originalTeamLedQuestion = legend.html();
+        if(legend.text().indexOf('you')) {
+          legend.text('Are you the Permanent Secretary?');
+        } else {
+          legend.text('Is this person the Permanent Secretary?');
+        }
+      }
     }
   };
 
@@ -358,11 +372,11 @@ $(function (){
   // For each element, set the team name on team leader text and create a new teamSelector
   $(selector).each(function (i, obj){
     $(obj).addClass('index'+i);
+    var team = new teamSelector(isPerson, obj);
     if(isPerson){
       teamName = $(obj).find('.editable-summary ol li:last-child').text();
-      $(obj).find('.team-led').text(teamName + ' team');
+      team.setTeamName(teamName);
     }
-    var team = new teamSelector(isPerson, obj);
     team.initEvents();
   });
 });

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -81,7 +81,7 @@
     #memberships
       %h2.line-above Role
       = f.fields_for :memberships do |membership_f|
-        = render 'membership_fields', membership_f: membership_f, org_structure: @org_structure
+        = render 'membership_fields', membership_f: membership_f, org_structure: @org_structure, person: @person
 
     = link_to 'Add another role', add_membership_people_path(id: @person.to_param),
       id: 'add_membership', class: 'button-secondary'

--- a/app/views/people/_membership_fields.html.haml
+++ b/app/views/people/_membership_fields.html.haml
@@ -1,5 +1,4 @@
 - membership = membership_f.object
-- person = membership.person
 .membership
   .form-group
     = membership_f.label :role, 'Job title', class: 'form-label-bold'

--- a/app/views/people/add_membership.html.haml
+++ b/app/views/people/add_membership.html.haml
@@ -1,7 +1,7 @@
-- @person = Person.new
-- @person.memberships.build
-- @person.memberships.last.group = Group.department
+- blank_person = Person.new
+- blank_person.memberships.build
+- blank_person.memberships.last.group = Group.department
 
-= form_for @person, authenticity_token: false do |f|
-  = f.fields_for :memberships, child_index: @person.object_id do |membership_f|
-    = render 'membership_fields', org_structure: @org_structure, membership_f: membership_f
+= form_for blank_person, authenticity_token: false do |f|
+  = f.fields_for :memberships, child_index: blank_person.object_id do |membership_f|
+    = render 'membership_fields', org_structure: @org_structure, membership_f: membership_f, person: @person

--- a/spec/javascripts/peoplefinder/team_selector_spec.js
+++ b/spec/javascripts/peoplefinder/team_selector_spec.js
@@ -1,9 +1,9 @@
 describe("Team Selector", function() {
-  
+
   var ts,
     obj = $('<div/>'),
     input = $('<input value="123" /><a href="">Technology</a>'),
-    teamName = $('<span class="team-led"></span>'),
+    teamLeadQuestion = $('<div class="team-leader"><fieldset><legend class="form-label-bold">Are you a leader of the <span class="team-led">above team</span>?</legend></fieldset></div>'),
     orgBrowser = $('<nav class="has-form org-browser"> \
       <div class="team visible"> \
         <h3><input type="radio" value="1" name="person[memberships_attributes][0][group_id]" id="person_memberships_attributes_0_group_id_1" /><a class="team-link" href="/teams/1" title="Ministry of Justice">Ministry of Justice</a></h3> \
@@ -44,13 +44,19 @@ describe("Team Selector", function() {
         <a class="button" href="#">Create</a> \
       </div>');
 
-  
+
   beforeEach(function(){
     obj.append(orgBrowser);
-    obj.append(teamName);
+    obj.append(teamLeadQuestion);
     obj.append(newTeam);
     ts = new teamSelector(true, obj);
     ts.initEvents();
+  });
+
+  afterEach(function(){
+    orgBrowser.remove();
+    teamLeadQuestion.remove();
+    newTeam.remove();
   });
 
   describe("Basic functions", function(){
@@ -80,7 +86,14 @@ describe("Team Selector", function() {
       });
       it("should set the team name to 'Digital'", function() {
         ts.setTeamName('Digital');
-        expect(teamName.text()).toBe('Digital team');
+        expect(teamLeadQuestion.find('.team-led').text()).toBe('Digital team');
+      });
+      it("sets the question to Are you the Permanent Secretary if team is MOJ", function() {
+        ts.setTeamName('Ministry of Justice');
+        expect(ts.selector.find('.team-leader legend').text()).toBe('Are you the Permanent Secretary?');
+
+        ts.setTeamName('Digital');
+        expect(ts.selector.find('.team-leader legend').text()).toBe('Are you a leader of the Digital team?');
       });
     });
   });

--- a/spec/models/concerns/activation_spec.rb
+++ b/spec/models/concerns/activation_spec.rb
@@ -61,8 +61,9 @@ RSpec.describe Concerns::Activation do
     end
 
     context 'when one person created yesterday who has logged in and completion score > 80%' do
+      let(:yesterday) { Date.today - 1.day }
       before do
-        create(:person, completed_attributes.merge(login_count: 1, created_at: Date.yesterday.to_time))
+        create(:person, completed_attributes.merge(login_count: 1, created_at: yesterday.to_time))
       end
 
       it 'returns 0 when from date is today' do
@@ -70,11 +71,11 @@ RSpec.describe Concerns::Activation do
       end
 
       it 'returns 100 when from date is yesterday' do
-        expect(Person.activated_percentage(from: Date.yesterday.to_s)).to eq(100)
+        expect(Person.activated_percentage(from: (yesterday - 1.hour).to_s)).to eq(100)
       end
 
       it 'returns 0 when before date is yesterday' do
-        expect(Person.activated_percentage(before: Date.yesterday.to_s)).to eq(0)
+        expect(Person.activated_percentage(before: (yesterday - 1.hour).to_s)).to eq(0)
       end
 
       it 'returns 100 when before date is today' do


### PR DESCRIPTION
When user has a membership team set to Ministry of Justice, then show custom team lead question text in order to mitigate the user selecting that they are a leader of that team when they are not.

