### PR TITLE
Only send profile update emails if last update > 6 months ago

### DIFF
--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -3,7 +3,7 @@ module NeverLoggedInNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Person.never_logged_in(25).find_each do |person|
+    Person.never_logged_in(25).each do |person|
       person.with_lock do # use db lock to allow cronjob to run on more than one instance
         send_reminder person
       end

--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -3,7 +3,7 @@ module PersonUpdateNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Person.logged_in_at_least_once(25).find_each do |person|
+    Person.logged_in_at_least_once(25).each do |person|
       person.with_lock do # use db lock to allow cronjob to run on more than one instance
         send_reminder person
       end

--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -23,7 +23,7 @@ module PersonUpdateNotifier
       false
     else
       !person.reminder_email_sent?(within: 6.months) &&
-        person.updated_at.end_of_day > 6.months.ago
+        person.updated_at.end_of_day < 6.months.ago
     end
   end
 

--- a/app/services/team_description_notifier.rb
+++ b/app/services/team_description_notifier.rb
@@ -3,7 +3,7 @@ module TeamDescriptionNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Group.without_description.find_each do |group|
+    Group.without_description.each do |group|
       group.with_lock do # use db lock to allow cronjob to run on more than one instance
         send_reminder group
       end


### PR DESCRIPTION
- Only send profile update emails if last update > 6 months ago.
- Fix limit being ignored in reminder email db queries.