### PR TITLE
Show custom team lead question when 'Add another role' clicked

### DIFF
--- a/app/assets/javascripts/peoplefinder/team_selector.js
+++ b/app/assets/javascripts/peoplefinder/team_selector.js
@@ -11,6 +11,12 @@ var teamSelector = function teamSelector(isPerson, obj){
   /* Listen for events */
   this.initEvents = function(){
     var self = this;
+
+    if(this.isPerson){
+      teamName = this.selector.find('.editable-summary ol li:last-child').text();
+      self.setTeamName(teamName);
+    }
+
     /* Clicking the 'Edit' link to show the team selector */
     this.selector.on('click', '.show-editable-fields, .editable-summary .title', function (e){
       self.onClick(e);
@@ -373,10 +379,6 @@ $(function (){
   $(selector).each(function (i, obj){
     $(obj).addClass('index'+i);
     var team = new teamSelector(isPerson, obj);
-    if(isPerson){
-      teamName = $(obj).find('.editable-summary ol li:last-child').text();
-      team.setTeamName(teamName);
-    }
     team.initEvents();
   });
 });

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -146,6 +146,7 @@ feature "Person maintenance" do
     expect(page).to have_selector('.editable-fields', visible: :visible)
 
     within all('#memberships .membership').last do
+      expect(find('.team-leader fieldset legend').text).to eq('Are you the Permanent Secretary?')
       click_link 'Digital Justice'
       fill_in 'Job title', with: 'Master of None'
       check_leader


### PR DESCRIPTION
When user clicks 'Add another role' ensure custom team lead question text is set based on default team in selector.