### PR TITLE
Remove team leaders from people outside of subteams list

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -79,11 +79,11 @@ class Group < ActiveRecord::Base
   end
 
   def people_outside_subteams
-    Person.all_in_groups([id]) - Person.all_in_groups(subteam_ids)
+    Person.all_in_groups([id]) - Person.all_in_groups(subteam_ids) - leaders
   end
 
   def people_outside_subteams_count
-    Person.count_in_groups([id], excluded_group_ids: subteam_ids)
+    Person.count_in_groups([id], excluded_group_ids: subteam_ids, excluded_ids: leaders.pluck(:id))
   end
 
   def leaderships_by_person

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -94,12 +94,10 @@ class Person < ActiveRecord::Base
     find_by_sql([query, group_ids])
   end
 
-  def self.count_in_groups(group_ids, excluded_group_ids: [])
-    excluded_ids = if excluded_group_ids.present?
-                     Person.in_groups(excluded_group_ids).pluck(:id)
-                   else
-                     []
-                   end
+  def self.count_in_groups(group_ids, excluded_group_ids: [], excluded_ids: [])
+    if excluded_group_ids.present?
+      excluded_ids += Person.in_groups(excluded_group_ids).pluck(:id)
+    end
 
     Person.in_groups(group_ids).where.not(id: excluded_ids).count
   end

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -202,6 +202,8 @@ feature 'Group maintenance' do
       within('.editable-fields') do
         click_link 'Done'
       end
+      expect(page).to have_selector('.show-editable-fields', visible: :visible)
+      expect(page).to have_selector('.parent-summary', text: /Test team/)
 
       click_button 'Save'
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe Group, type: :model do
         it 'has .leaderships_by_person return hash containing bob and his membership' do
           expect(team.leaderships_by_person[bob]).to eq [bob.memberships.first]
         end
+
+        it 'has people_outside_subteams_count of zero' do
+          expect(team.people_outside_subteams_count).to eq(0)
+        end
+
+        it 'has zero length people_outside_subteams array' do
+          expect(team.people_outside_subteams.length).to eq(0)
+        end
       end
 
       it 'has 1 in all_people array' do


### PR DESCRIPTION
Remove a team's leaders from the list of people outside of subteams.

Plus, try to fix intermittent failure in group parent editing spec - but it seems that isn't the complete fix.