### PR TITLE
Change query to find people to send reminder email to

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -74,9 +74,9 @@ class Person < ActiveRecord::Base
     where('last_reminder_email_at IS ? OR last_reminder_email_at < ?', nil, within)
   }
 
-  scope :updated_older_than, lambda { |within|
-    where('updated_at < ?', within)
-  }
+  scope :updated_older_than, -> (within) { where('updated_at < ?', within) }
+
+  scope :created_at_older_than, -> (within) { where('created_at < ?', within) }
 
   def self.namesakes(person)
     where(surname: person.surname, given_name: person.given_name).where.not(id: person.id)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -66,17 +66,9 @@ class Person < ActiveRecord::Base
 
   default_scope { order(surname: :asc, given_name: :asc) }
 
-  scope :never_logged_in, lambda { |limit = nil|
-    users = unscoped.where(login_count: 0).order('RANDOM()')
-    users = users.limit(limit) if limit
-    users
-  }
+  scope :never_logged_in, -> { where(login_count: 0) }
 
-  scope :logged_in_at_least_once, lambda { |limit = nil|
-    users = unscoped.where('people.login_count > 0').order('RANDOM()')
-    users = users.limit(limit) if limit
-    users
-  }
+  scope :logged_in_at_least_once, -> { where('people.login_count > 0') }
 
   scope :last_reminder_email_older_than, lambda { |within|
     where('last_reminder_email_at IS ? OR last_reminder_email_at < ?', nil, within)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -74,7 +74,7 @@ class Person < ActiveRecord::Base
     where('last_reminder_email_at IS ? OR last_reminder_email_at < ?', nil, within)
   }
 
-  scope :updated_older_than, -> (within) { where('updated_at < ?', within) }
+  scope :updated_at_older_than, -> (within) { where('updated_at < ?', within) }
 
   scope :created_at_older_than, -> (within) { where('created_at < ?', within) }
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -78,6 +78,14 @@ class Person < ActiveRecord::Base
     users
   }
 
+  scope :last_reminder_email_older_than, lambda { |within|
+    where('last_reminder_email_at IS ? OR last_reminder_email_at < ?', nil, within)
+  }
+
+  scope :updated_older_than, lambda { |within|
+    where('updated_at < ?', within)
+  }
+
   def self.namesakes(person)
     where(surname: person.surname, given_name: person.given_name).where.not(id: person.id)
   end

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -1,25 +1,31 @@
 module NeverLoggedInNotifier
 
-  def self.send_reminders
+  def self.send_reminders within: 30.days
     return unless Rails.configuration.send_reminder_emails
 
-    Person.never_logged_in.each do |person|
+    people_to_remind(within).each do |person|
       person.with_lock do # use db lock to allow cronjob to run on more than one instance
-        send_reminder person
+        send_reminder person, within
       end
     end
   end
 
-  def self.send_reminder person
+  def self.people_to_remind within
+    Person.
+      never_logged_in.
+      last_reminder_email_older_than(within.ago).
+      created_at_older_than(within.ago)
+  end
+
+  def self.send_reminder person, within
     person.reload
-    if NeverLoggedInNotifier.send_never_logged_in_reminder? person
+    if NeverLoggedInNotifier.send_never_logged_in_reminder? person, within
       ReminderMailer.never_logged_in(person).deliver_later
       person.update(last_reminder_email_at: Time.zone.now)
     end
   end
 
-  def self.send_never_logged_in_reminder? person
-    within = 30.days
+  def self.send_never_logged_in_reminder? person, within
     !person.reminder_email_sent?(within: within) &&
       person.login_count == 0 &&
       person.created_at.end_of_day < within.ago

--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -3,7 +3,7 @@ module NeverLoggedInNotifier
   def self.send_reminders
     return unless Rails.configuration.send_reminder_emails
 
-    Person.never_logged_in(25).each do |person|
+    Person.never_logged_in.each do |person|
       person.with_lock do # use db lock to allow cronjob to run on more than one instance
         send_reminder person
       end

--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -14,7 +14,7 @@ module PersonUpdateNotifier
     Person.
       logged_in_at_least_once.
       last_reminder_email_older_than(within.ago).
-      updated_older_than(within.ago)
+      updated_at_older_than(within.ago)
   end
 
   def self.send_reminder person, within

--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -13,8 +13,8 @@ module PersonUpdateNotifier
   def self.people_to_remind within
     Person.
       logged_in_at_least_once.
-      where('last_reminder_email_at IS ? OR last_reminder_email_at < ?', nil, within.ago).
-      where('updated_at < ?', within.ago)
+      last_reminder_email_older_than(within.ago).
+      updated_older_than(within.ago)
   end
 
   def self.send_reminder person, within

--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -1,29 +1,36 @@
 module PersonUpdateNotifier
 
-  def self.send_reminders
+  def self.send_reminders within: 6.months
     return unless Rails.configuration.send_reminder_emails
 
-    Person.logged_in_at_least_once(25).each do |person|
+    people_to_remind(within).each do |person|
       person.with_lock do # use db lock to allow cronjob to run on more than one instance
-        send_reminder person
+        send_reminder person, within
       end
     end
   end
 
-  def self.send_reminder person
+  def self.people_to_remind within
+    Person.
+      logged_in_at_least_once.
+      where('last_reminder_email_at IS ? OR last_reminder_email_at < ?', nil, within.ago).
+      where('updated_at < ?', within.ago)
+  end
+
+  def self.send_reminder person, within
     person.reload
-    if send_update_reminder? person
+    if send_update_reminder? person, within
       ReminderMailer.person_profile_update(person).deliver_later
       person.update(last_reminder_email_at: Time.zone.now)
     end
   end
 
-  def self.send_update_reminder? person
+  def self.send_update_reminder? person, within
     if person.login_count == 0
       false
     else
-      !person.reminder_email_sent?(within: 6.months) &&
-        person.updated_at.end_of_day < 6.months.ago
+      !person.reminder_email_sent?(within: within) &&
+        person.updated_at.end_of_day < within.ago
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Person, type: :model do
       expect(described_class.never_logged_in).to include(person)
     end
 
-    it 'is not returned by .never_logged_in with limit set to 0' do
-      expect(described_class.never_logged_in(0)).to be_empty
-    end
-
     it 'is not returned by .logged_in_at_least_once' do
       expect(described_class.logged_in_at_least_once).not_to include(person)
     end
@@ -48,10 +44,6 @@ RSpec.describe Person, type: :model do
 
     it 'is not returned by .never_logged_in' do
       expect(described_class.never_logged_in).not_to include(person)
-    end
-
-    it 'is not returned by .logged_in_at_least_once with limit set to 0' do
-      expect(described_class.logged_in_at_least_once(0)).to be_empty
     end
 
     it 'is returned by .logged_in_at_least_once' do

--- a/spec/services/never_logged_in_notifier_spec.rb
+++ b/spec/services/never_logged_in_notifier_spec.rb
@@ -9,11 +9,15 @@ RSpec.describe NeverLoggedInNotifier, type: :service do
   let(:person) { create(:person) }
   let(:mailer) { double(ReminderMailer) }
   let(:mailer_params) { [person] }
+  let(:more_than_30_days_ago) { Time.now - 31.days }
+  let(:less_than_30_days_ago) { Time.now - 30.days }
 
   describe 'send_reminders' do
     before do
+      person.update(last_reminder_email_at: nil)
+      person.update(created_at: more_than_30_days_ago)
       allow(described_class).to receive(:send_never_logged_in_reminder?).
-        with(person).and_return can_send
+        with(person, 30.days).and_return can_send
     end
 
     context 'when send_never_logged_in_reminder? is true' do
@@ -34,29 +38,29 @@ RSpec.describe NeverLoggedInNotifier, type: :service do
 
   describe 'send_never_logged_in_reminder?' do
     context 'when person created within last 30 days' do
-      before { person.update(created_at: Time.now - 30.days) }
+      before { person.update(created_at: less_than_30_days_ago) }
       it 'returns false' do
-        expect(described_class.send_never_logged_in_reminder?(person)).to be false
+        expect(described_class.send_never_logged_in_reminder?(person, 30.days)).to be false
       end
     end
 
     context 'when person created more than 30 days ago' do
-      before { person.update(created_at: Time.now - 31.days) }
+      before { person.update(created_at: more_than_30_days_ago) }
 
       it 'returns true when never logged in and no reminder sent within last 30 days' do
         allow(person).to receive(:reminder_email_sent?).and_return false
-        expect(described_class.send_never_logged_in_reminder?(person)).to be true
+        expect(described_class.send_never_logged_in_reminder?(person, 30.days)).to be true
       end
 
       it 'returns false when logged in before' do
         allow(person).to receive(:reminder_email_sent?).and_return false
         person.login_count = 1
-        expect(described_class.send_never_logged_in_reminder?(person)).to be false
+        expect(described_class.send_never_logged_in_reminder?(person, 30.days)).to be false
       end
 
       it 'returns false when reminder sent within last 30 days' do
         allow(person).to receive(:reminder_email_sent?).and_return true
-        expect(described_class.send_never_logged_in_reminder?(person)).to be false
+        expect(described_class.send_never_logged_in_reminder?(person, 30.days)).to be false
       end
     end
   end


### PR DESCRIPTION
Change initial query to find people to send reminders:
- Remove `limit` from initial query
- Use additional scopes to check additional criteria in initial query

Only return people that are eligible for a reminder email from the initial queries. This reduces the size of the number of people returned by these queries.