### PR TITLE
Do exact phrase search and update name and fuzzy searches

### DIFF
--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -13,8 +13,8 @@ class PersonSearch
     if email_match
       [email_match]
     else
-      exact_matches, name_matches, query_matches, fuzzy_matches = perform_searches
-      exact_matches.
+      exact_name_matches, name_matches, query_matches, fuzzy_matches = perform_searches
+      exact_name_matches.
         push(*name_matches).
         push(*query_matches).
         push(*fuzzy_matches).
@@ -32,9 +32,9 @@ class PersonSearch
     name_matches = search "name:#{@query}"
     query_matches = search @query
     fuzzy_matches = fuzziness_search
-    exact_matches = name_matches.select { |p| p.name == @query }
+    exact_name_matches = name_matches.select { |p| p.name == @query }
 
-    [exact_matches, name_matches, query_matches, fuzzy_matches]
+    [exact_name_matches, name_matches, query_matches, fuzzy_matches]
   end
 
   def fuzziness_search

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -51,8 +51,8 @@ class PersonSearch
 
   def fields_to_search
     [
-      :name, :tags, :description, :location_in_building, :building,
-      :city, :role_and_group, :community_name, :current_project
+      :name, :description, :location_in_building, :building,
+      :city, :role_and_group, :current_project
     ]
   end
 

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -60,7 +60,9 @@ class PersonSearch
       query: {
         multi_match: {
           fields: fields_to_search,
-          query: @query, fuzziness: 'AUTO'
+          fuzziness: 1, # maximum allowed Levenshtein Edit Distance
+          prefix_length: 1, # number of initial characters which won't be "fuzzified"
+          query: @query
         }
       }
     )

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -31,25 +31,29 @@ class PersonSearch
   def perform_searches
     name_matches = search "name:#{@query}"
     query_matches = search @query
-    fuzzy_matches = fuzzy_search
+    fuzzy_matches = fuzziness_search
     exact_matches = name_matches.select { |p| p.name == @query }
 
     [exact_matches, name_matches, query_matches, fuzzy_matches]
   end
 
-  def fuzzy_search
+  def fuzziness_search
     search(
       size: @max,
       query: {
-        fuzzy_like_this: {
-          fields: [
-            :name, :tags, :description, :location_in_building, :building,
-            :city, :role_and_group, :community_name, :current_project
-          ],
-          like_text: @query, prefix_length: 3, ignore_tf: true
+        multi_match: {
+          fields: fields_to_search,
+          query: @query, fuzziness: 'AUTO'
         }
       }
     )
+  end
+
+  def fields_to_search
+    [
+      :name, :tags, :description, :location_in_building, :building,
+      :city, :role_and_group, :community_name, :current_project
+    ]
   end
 
   def clean_query query

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -33,8 +33,15 @@ class PersonSearch
     query_matches = search @query
     fuzzy_matches = fuzziness_search
     exact_name_matches = name_matches.select { |p| p.name == @query }
+    if single_word_query?
+      exact_name_matches += name_matches.select { |p| p.name[/^#{@query} /i] }.sort_by(&:name)
+    end
 
     [exact_name_matches, name_matches, exact_matches, query_matches, fuzzy_matches]
+  end
+
+  def single_word_query?
+    !@query[/\s/]
   end
 
   def name_search

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe PersonSearch, elastic: true do
 
     it 'puts single name match at top of results when name synonym' do
       results = search_for('Abe')
-      expect(results).to eq([abe, abraham_kiehn])
+      expect(results.first).to eq(abe)
     end
 
     it 'puts single name match at top of results when first name match' do

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -87,6 +87,16 @@ RSpec.describe PersonSearch, elastic: true do
       expect(results).to eq([abraham_kiehn, abe])
     end
 
+    it 'puts single name match at top of results when name synonym' do
+      results = search_for('Abe')
+      expect(results).to eq([abe, abraham_kiehn])
+    end
+
+    it 'puts single name match at top of results when first name match' do
+      results = search_for('Andrew')
+      expect(results).to eq([andrew, alice])
+    end
+
     it 'searches by group name and membership role' do
       results = search_for('Director at digiTAL Services')
       expect(results).to eq([bob, alice])
@@ -152,7 +162,7 @@ RSpec.describe PersonSearch, elastic: true do
 
   context 'with commas in search query' do
     it 'performs search without commas' do
-      expect(Person).to receive(:search_results).with({ query: { match: { name: "Smith Bill"}}}, limit: 100).and_return []
+      expect(Person).to receive(:search_results).with({ query: { match: { name: "Smith Bill" } } }, limit: 100).and_return []
       expect(Person).to receive(:search_results).with('"Smith Bill"', limit: 100).and_return []
       expect(Person).to receive(:search_results).with('Smith Bill', limit: 100).and_return []
       expect(Person).to receive(:search_results).with(

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PersonSearch, elastic: true do
   let(:current_project) { 'Current project' }
 
   let!(:alice) do
-    create(:person, given_name: 'Alice', surname: 'Andrews', community: community)
+    create(:person, given_name: 'Alice', surname: 'Andrews')
   end
   let!(:bob) do
     create(:person, given_name: 'Bob', surname: 'Browning',
@@ -36,7 +36,6 @@ RSpec.describe PersonSearch, elastic: true do
 
   let!(:digital_services) { create(:group, name: 'Digital Services') }
   let!(:membership) { bob.memberships.create(group: digital_services, role: 'Cleaner') }
-  let(:community) { create(:community, name: "Poetry") }
 
   context 'with some people' do
     before do
@@ -120,12 +119,6 @@ RSpec.describe PersonSearch, elastic: true do
 
       results = search_for("O’Leary")
       expect(results).to include(oleary2)
-    end
-
-    it 'searches by community' do
-      results = search_for(community.name)
-      expect(results).to include(alice)
-      expect(results).to_not include(bob)
     end
 
     it 'searches by current project' do

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe PersonSearch, elastic: true do
       expect(Person).to receive(:search_results).with(
         hash_including(
           query: {
-            fuzzy_like_this: hash_including(like_text: 'Smith Bill')
+            multi_match: hash_including(query: 'Smith Bill')
           }
         ), limit: 100).and_return []
 


### PR DESCRIPTION
- Do phrase search and fix name field search
- Change search from `fuzzy_like_this` to `multi_match`
- Put single word query first name matches at top of results
- Reduce number of matches when doing `multi_match` fuzziness search