### PR TITLE
Sort partial results by name Levenshtein distance from query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 ruby '2.2.4'
 gem 'rails', '~> 4.2.4'
-
+gem 'text'
 gem 'ancestry'
 gem 'delayed_job', git: 'https://github.com/collectiveidea/delayed_job.git',
     ref: '5f914105c1c38ca73a486d63de8ad62f254b3d72' # needed for queue_attributes configuration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,6 +553,7 @@ GEM
     sqlite3 (1.3.10)
     temple (0.7.6)
     terminal-table (1.5.2)
+    text (1.3.1)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -651,6 +652,7 @@ DEPENDENCIES
   simplecov-rcov
   site_prism
   spring-commands-rspec
+  text
   timecop
   uglifier (>= 2.7.2)
   unf

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -44,7 +44,7 @@ class PersonSearch
   end
 
   def query_search
-    search @query
+    sort_by_edit_distance search(@query)
   end
 
   def single_word_query?
@@ -52,7 +52,7 @@ class PersonSearch
   end
 
   def fuzziness_search
-    search(
+    sort_by_edit_distance search(
       size: @max,
       query: {
         multi_match: {
@@ -63,6 +63,19 @@ class PersonSearch
         }
       }
     )
+  end
+
+  def sort_by_edit_distance results
+    if any_close_by_edit_distance? results
+      results.sort_by { |x| Text::Levenshtein.distance(x.name, @query) }
+    else
+      results
+    end
+  end
+
+  def any_close_by_edit_distance? results
+    edit_distances = results.map { |x| Text::Levenshtein.distance(x.name, @query) }
+    edit_distances.any? { |e| e > 0 && e < 4 }
   end
 
   def fields_to_search

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe PersonSearch, elastic: true do
     create(:person, given_name: 'Denis', surname: "O’Leary")
   end
 
+  let!(:collier) do
+    create(:person, given_name: 'John', surname: "Collier")
+  end
+  let!(:miller) do
+    create(:person, given_name: 'John', surname: "Miller")
+  end
+  let!(:scotti) do
+    create(:person, given_name: 'John', surname: "Scotti")
+  end
+
   let!(:digital_services) { create(:group, name: 'Digital Services') }
   let!(:membership) { bob.memberships.create(group: digital_services, role: 'Digital Director') }
 
@@ -84,7 +94,8 @@ RSpec.describe PersonSearch, elastic: true do
 
     it 'puts name synonym matches in results' do
       results = search_for('Abe Kiehn')
-      expect(results).to eq([abraham_kiehn, abe])
+      expect(results).to include(abraham_kiehn)
+      expect(results).to include(abe)
     end
 
     it 'puts single name match at top of results when name synonym' do
@@ -139,6 +150,21 @@ RSpec.describe PersonSearch, elastic: true do
     it 'searches by current project' do
       results = search_for(current_project)
       expect(results).to eq([bob, alice])
+    end
+
+    it 'searches by partial match and orders by edit distance if edit distance 1 exists' do
+      results = search_for("John Collie")
+      expect(results).to eq([collier, miller, scotti])
+    end
+
+    it 'searches by partial match and orders by edit distance if edit distance 2 exists' do
+      results = search_for("John Colli")
+      expect(results).to eq([collier, miller, scotti])
+    end
+
+    it 'searches by partial match and orders by edit distance if edit distance 3 exists' do
+      results = search_for("John Coll")
+      expect(results).to eq([collier, miller, scotti])
     end
 
     it 'returns [] for blank search' do


### PR DESCRIPTION
When there is at least one result with a name that is a close Levenshtein edit distance from the query term, then sort the partial results by edit distance in order to get closer edit matches at the top of the results.