### PR TITLE
No exact results indicator

### DIFF
--- a/app/assets/stylesheets/peoplefinder/people.css.scss
+++ b/app/assets/stylesheets/peoplefinder/people.css.scss
@@ -74,6 +74,9 @@ ul.working_days {
     padding: 0 0 12px 0;
     border-bottom: 1px solid $blackish;
   }
+  .query-term {
+    font-weight: bold;
+  }
   .pagination {
     padding: 9px 0 0 0;
     margin-bottom: -5px;

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,7 +2,7 @@ class SearchController < ApplicationController
   def index
     @query = query
     @teams = GroupSearch.new(@query).perform_search
-    @people = PersonSearch.new(@query).perform_search
+    @people, @exact_match_exists = PersonSearch.new(@query).perform_search
   end
 
   private

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -8,19 +8,33 @@ class PersonSearch
     @max = 100
   end
 
+  # Returns a two element array, first element is the list of results, second
+  # element is a boolean which is true when the results contain an exact match
+  # for supplied query term and false otherwise.
+  #
+  # Example:
+  #
+  # PersonSearch.new('John Smith').perform_search
+  # #=> [ [#<Person given_name: "John", surname: "Smith"], true ]
+  #
+  # PersonSearch.new('John Zoolander').perform_search
+  # #=> [ [#<Person given_name: "John", surname: "Smith"], false ]
   def perform_search
-    return [] if @query.blank?
+    return [[], false] if @query.blank?
 
     email_match = email_search
-    return [email_match] if email_match
+    return [[email_match], true] if email_match
 
     @exact_name_matches, @exact_matches, @query_matches, @fuzzy_matches = perform_searches
 
-    [].push(*@exact_name_matches).
-      push(*@exact_matches).
-      push(*@query_matches).
-      push(*@fuzzy_matches).
-      uniq[0..@max - 1]
+    results = [].
+              push(*@exact_name_matches).
+              push(*@exact_matches).
+              push(*@query_matches).
+              push(*@fuzzy_matches).
+              uniq[0..@max - 1]
+
+    [results, false]
   end
 
   def email_search
@@ -96,4 +110,5 @@ class PersonSearch
   def search query
     Person.search_results(query, limit: @max).to_a
   end
+
 end

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -5,7 +5,12 @@
 #search_results
   %h1.noborder= @page_title = 'Search results'
   .search-hint Select a team or person's name to view more details.
-  .pagination= pluralize(@people.length, "result") + ' found'
+  .pagination
+    - if @exact_match_exists
+      = pluralize(@people.length, "result") + ' found'
+    - else
+      == <span class="query-term">#{@query}</span> not found —
+      == found #{pluralize(@people.length, "similiar result")}
 
   = render partial: 'search/team', collection: @teams
   = render partial: 'search/person', collection: @people, locals: { search_result: true }

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -55,121 +55,150 @@ RSpec.describe PersonSearch, elastic: true do
     end
 
     it 'searches by email' do
-      results = search_for(alice.email.upcase)
+      results, exact_match = search_for(alice.email.upcase)
       expect(results).to eq [alice]
+      expect(exact_match).to eq true
     end
 
     it 'searches by surname' do
-      results = search_for('Andrews')
+      results, exact_match = search_for('Andrews')
       expect(results).to include(alice)
       expect(results).to_not include(bob)
+      expect(exact_match).to eq true
     end
 
     it 'searches by given name' do
-      results = search_for('Alice')
+      results, exact_match = search_for('Alice')
       expect(results).to include(alice)
       expect(results).to_not include(bob)
+      expect(exact_match).to eq true
     end
 
     it 'searches by full name' do
-      results = search_for('Bob Browning')
+      results, exact_match = search_for('Bob Browning')
       expect(results).to_not include(alice)
       expect(results).to include(bob)
+      expect(exact_match).to eq true
     end
 
-    it 'puts exact match first for phrase "Assisted digital"' do
-      results = search_for('Digital Project')
+    it 'puts exact match first for phrase' do
+      results, exact_match = search_for('Digital Project')
       expect(results).to eq([alice, bob])
+      expect(exact_match).to eq true
+    end
+
+    it 'searches by single word non-name match' do
+      results, exact_match = search_for('Digital')
+      expect(results).to eq([alice, bob])
+      expect(exact_match).to eq true
     end
 
     it 'puts exact match first for "Alice Andrews"' do
-      results = search_for('Alice Andrews')
+      results, exact_match = search_for('Alice Andrews')
       expect(results).to eq([alice, andrew])
+      expect(exact_match).to eq true
     end
 
     it 'puts exact match first for "Andrew Alice"' do
-      results = search_for('Andrew Alice')
+      results, exact_match = search_for('Andrew Alice')
       expect(results).to eq([andrew, alice])
+      expect(exact_match).to eq true
     end
 
     it 'puts name synonym matches in results' do
-      results = search_for('Abe Kiehn')
+      results, exact_match = search_for('Abe Kiehn')
       expect(results).to include(abraham_kiehn)
       expect(results).to include(abe)
+      expect(exact_match).to eq false
     end
 
     it 'puts single name match at top of results when name synonym' do
-      results = search_for('Abe')
+      results, exact_match = search_for('Abe')
       expect(results.first).to eq(abe)
+      expect(exact_match).to eq true
     end
 
     it 'puts single name match at top of results when first name match' do
-      results = search_for('Andrew')
+      results, exact_match = search_for('Andrew')
       expect(results).to eq([andrew, alice])
+      expect(exact_match).to eq true
     end
 
     it 'searches by group name and membership role' do
-      results = search_for('Director at digiTAL Services')
+      results, exact_match = search_for('Director at digiTAL Services')
       expect(results).to eq([bob, alice])
+      expect(exact_match).to eq false
     end
 
     it 'searches by description and location' do
-      results = search_for('weekends at petty france office')
+      results, exact_match = search_for('weekends at petty france office')
       expect(results).to_not include(alice)
       expect(results).to include(bob)
+      expect(exact_match).to eq false
     end
 
     it 'searches ignoring * in search term' do
-      results = search_for('Alice *')
+      results, exact_match = search_for('Alice *')
       expect(results).to include(alice)
+      expect(exact_match).to eq true
     end
 
     it 'searches ignoring " at start of search term' do
-      results = search_for('"Alice ')
+      results, exact_match = search_for('"Alice ')
       expect(results).to include(alice)
+      expect(exact_match).to eq true
     end
 
     it 'searches ignoring " at end of search term' do
-      results = search_for('Alice"')
+      results, exact_match = search_for('Alice"')
       expect(results).to include(alice)
+      expect(exact_match).to eq true
     end
 
     it 'searches ignoring " in middle of search term' do
-      results = search_for('Alice" Andrews')
+      results, exact_match = search_for('Alice" Andrews')
       expect(results).to include(alice)
+      expect(exact_match).to eq true
     end
 
     it 'searches apostrophe in name' do
-      results = search_for("O'Leary")
+      results, exact_match = search_for("O'Leary")
       expect(results).to include(oleary)
+      expect(exact_match).to eq true
 
-      results = search_for("O’Leary")
+      results, exact_match = search_for("O’Leary")
       expect(results).to include(oleary2)
+      expect(exact_match).to eq true
     end
 
     it 'searches by current project' do
-      results = search_for(current_project)
+      results, exact_match = search_for(current_project)
       expect(results).to eq([bob, alice])
+      expect(exact_match).to eq true
     end
 
     it 'searches by partial match and orders by edit distance if edit distance 1 exists' do
-      results = search_for("John Collie")
+      results, exact_match = search_for("John Collie")
       expect(results).to eq([collier, miller, scotti])
+      expect(exact_match).to eq false
     end
 
     it 'searches by partial match and orders by edit distance if edit distance 2 exists' do
-      results = search_for("John Colli")
+      results, exact_match = search_for("John Colli")
       expect(results).to eq([collier, miller, scotti])
+      expect(exact_match).to eq false
     end
 
     it 'searches by partial match and orders by edit distance if edit distance 3 exists' do
-      results = search_for("John Coll")
+      results, exact_match = search_for("John Coll")
       expect(results).to eq([collier, miller, scotti])
+      expect(exact_match).to eq false
     end
 
     it 'returns [] for blank search' do
-      results = search_for('')
+      results, exact_match = search_for('')
       expect(results).to eq([])
+      expect(exact_match).to eq false
     end
   end
 
@@ -182,8 +211,9 @@ RSpec.describe PersonSearch, elastic: true do
     end
 
     it 'sorts results to put exact match first' do
-      results = search_for('John Smith')
+      results, exact_match = search_for('John Smith')
       expect(results).to eq [john_smith, jonathan_smith]
+      expect(exact_match).to eq true
     end
   end
 
@@ -202,16 +232,9 @@ RSpec.describe PersonSearch, elastic: true do
     end
   end
 
-  def perform_search(query)
-    described_class.new(query).perform_search
-  end
-
   def search_for(query)
-    perform_search(query)[0]
-  end
-
-  def exact_match_exists(query)
-    perform_search(query)[1]
+    search = described_class.new(query)
+    search.perform_search
   end
 
 end

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe PersonSearch, elastic: true do
 
     it 'searches by single word non-name match' do
       results, exact_match = search_for('Digital')
-      expect(results).to eq([alice, bob])
+      expect(results).to include(alice)
+      expect(results).to include(bob)
       expect(exact_match).to eq true
     end
 

--- a/spec/services/person_search_spec.rb
+++ b/spec/services/person_search_spec.rb
@@ -182,7 +182,8 @@ RSpec.describe PersonSearch, elastic: true do
     end
 
     it 'sorts results to put exact match first' do
-      expect(described_class.new('John Smith').perform_search).to eq [john_smith, jonathan_smith]
+      results = search_for('John Smith')
+      expect(results).to eq [john_smith, jonathan_smith]
     end
   end
 
@@ -201,7 +202,16 @@ RSpec.describe PersonSearch, elastic: true do
     end
   end
 
-  def search_for(query)
+  def perform_search(query)
     described_class.new(query).perform_search
   end
+
+  def search_for(query)
+    perform_search(query)[0]
+  end
+
+  def exact_match_exists(query)
+    perform_search(query)[1]
+  end
+
 end


### PR DESCRIPTION
To help users identify when there are no exact matches, show a message below the results heading when no exact person name matches have been found.