### PR TITLE
Miscellaneous copy changes

### DIFF
--- a/app/views/groups/_detail.html.haml
+++ b/app/views/groups/_detail.html.haml
@@ -16,14 +16,14 @@
         - if @group.children.count > 0
           = link_to "View #{pluralize_with_delimiter @group.children.count, 'sub-team'}", '#teams', class: 'small link-left'
         = link_to 'Edit this team', edit_group_path(@group), class: 'small'
-      
+
 
 %div.grid-wrapper.details
   - if @group.leaderships.count > 0
     %div.grid.grid-1-3
-      
+
       %div.inner-block.group-leader{ class: (@group.leaderships.count > 1) ? 'multiple-leaders' : '' }
-        
+
         %h3 Team #{'leader'.pluralize(@group.leaderships.count)}
         - @group.leaderships_by_person.each do |person, leaderships|
           = render partial: 'leaderships', object: leaderships, locals: { person: person }
@@ -36,7 +36,7 @@
     %div.inner-block
       .team-links
         - if @all_people_count > 0 || @group.children.present?
-          = link_to "View organogram", organogram_group_path(@group)
+          = link_to "View printable organogram", organogram_group_path(@group)
         - unless @group.leaf_node?
           - if @all_people_count > 0 && @group.parent.present?
             = link_to "View #{ @all_people_count > 1 ? 'all' : '' } people", people_group_path(@group), class: 'view-all-people'

--- a/app/views/groups/organogram.html.haml
+++ b/app/views/groups/organogram.html.haml
@@ -10,8 +10,7 @@
   .group-title
     - if @group.acronym?
       %h1
-        = @group.acronym
-        team organogram
+        == #{@group.acronym}'s organogram
     - else
       %h1
         = @group.name

--- a/app/views/groups/organogram.html.haml
+++ b/app/views/groups/organogram.html.haml
@@ -10,17 +10,17 @@
   .group-title
     - if @group.acronym?
       %h1
-        = @group.acronym 
+        = @group.acronym
         team organogram
     - else
       %h1
-        = @group.name 
+        = @group.name
         team organogram
 
   - if @group.leaderships.present?
     %div.inner-block
       %div.grid-wrapper.leaders
-        %h2 Team leaders
+        %h2 Team #{'leader'.pluralize(@group.leaderships_by_person.size)}
         - @group.leaderships_by_person.each do |person, leaderships|
           %div.leader
             = render partial: 'leaderships', object: leaderships, locals: { person: person }

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -72,8 +72,6 @@
                   <td align="left" style="font-family:Arial, sans-serif;font-size:14px;font-weight:normal;line-height:22px;color:#373737;border-collapse:collapse;" valign="top" width="560">
                     If you're unsure an email is from the MOJ:
                     <br/>
-                    • do not reply to it or click any links
-                    <br/>
                     • forward it to
                     <a href="mailto:phishing@digital.justice.gov.uk" style="color:#097FC9;" target="_blank">phishing@digital.justice.gov.uk</a>
                   </td>

--- a/app/views/reminder_mailer/person_profile_update.html.haml
+++ b/app/views/reminder_mailer/person_profile_update.html.haml
@@ -71,6 +71,6 @@
                   The People Finder Team
 
                 %p
-                  This email is automatically generated. Do not reply.
+                  We welcome your feedback on People Finder. Please reply to this email if you'd like to share your thoughts.
 
       %td{style: "min-width:10px;border-collapse:collapse;", width: "20"}

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -55,7 +55,7 @@ feature 'Group browsing' do
     expect(page).not_to have_text("Teams within #{current_group.name}")
     expect(page).not_to have_link("View all 0 people in #{current_group.name}")
     expect(page).not_to have_link("View 0 people not assigned to a sub-team")
-    expect(page).not_to have_link("View organogram")
+    expect(page).not_to have_link("View printable organogram")
   end
 
   context 'A team with people and subteams with people' do
@@ -71,7 +71,7 @@ feature 'Group browsing' do
       visit group_path(department)
       expect(page).not_to have_link("View all 7 people in #{department.name}")
       expect(page).to have_link("View 1 person not assigned to a sub-team")
-      expect(page).to have_link("View organogram")
+      expect(page).to have_link("View printable organogram")
     end
 
     scenario 'viewing text on page' do
@@ -114,9 +114,9 @@ feature 'Group browsing' do
       end
     end
 
-    scenario 'following the view organogram link' do
+    scenario 'following the view printable organogram link' do
       visit group_path(team)
-      click_link("View organogram")
+      click_link("View printable organogram")
 
       expect(page).to have_title("#{team.name} Organogram - #{app_title}")
       within('.breadcrumbs') do


### PR DESCRIPTION
- Change copy on link to organogram
- Remove do not click any links text from email layout
- Replace reply instructions on email
- Correct pluralization of Team leader(s) heading
- Change organogram header text