### PR TITLE
Fix "Last updated" time to be the last audit version time

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -132,8 +132,10 @@ class GroupsController < ApplicationController
   end
 
   def load_versions
+    versions = @group.versions
+    @last_updated_at = versions.last ? versions.last.created_at : nil
     if super_admin?
-      @versions = AuditVersionPresenter.wrap(@group.versions)
+      @versions = AuditVersionPresenter.wrap(versions)
     end
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -143,8 +143,10 @@ class PeopleController < ApplicationController
   end
 
   def load_versions
+    versions = @person.versions
+    @last_updated_at = versions.last ? versions.last.created_at : nil
     if super_admin?
-      @versions = AuditVersionPresenter.wrap(@person.versions)
+      @versions = AuditVersionPresenter.wrap(versions)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,8 +6,8 @@ module ApplicationHelper
 
   def last_update
     current_object = @person || @group
-    if current_object && current_object.updated_at.present?
-      "#{updated_at(current_object)}#{updated_by(current_object)}."
+    if current_object && @last_updated_at.present?
+      "#{updated_at(@last_updated_at)}#{updated_by(current_object)}."
     end
   end
 
@@ -108,8 +108,8 @@ module ApplicationHelper
 
   private
 
-  def updated_at(obj)
-    "Last updated: #{l(obj.updated_at)}"
+  def updated_at(datetime)
+    "Last updated: #{l(datetime)}"
   end
 
   def updated_by(obj)

--- a/app/presenters/audit_version_presenter.rb
+++ b/app/presenters/audit_version_presenter.rb
@@ -13,7 +13,8 @@ class AuditVersionPresenter
 
   def changes
     YAML.load(@version.object_changes).map do |field, (_, new)|
-      "#{field} => #{new}"
+      value = new.blank? ? '(deleted)' : new
+      [field, value]
     end
   end
 

--- a/app/views/shared/_audit.html.haml
+++ b/app/views/shared/_audit.html.haml
@@ -1,26 +1,34 @@
 %table.audit
   %thead
     %tr
-      %th Event
-      %th By
+      %th{ style: 'width: 150px' } Event at
+      %th{ style: 'width: 150px' } By
       %th IP address
       %th Browser
-      %th At
       %th Change
   %tbody
     -versions.reverse.each do |v|
       %tr
-        %td= v.event
+        %td
+          = l(v.created_at)
         -if v.whodunnit.is_a?(Person)
           %td= link_to v.whodunnit.to_s, v.whodunnit
         - else
           %td= v.whodunnit
         %td= v.ip_address
         %td{title: v.user_agent}=v.user_agent_summary
-        %td= v.created_at
         %td
           %ul
             - v.changes.each do |change|
-              %li=change
+              - field = change[/^(\w+) =>/, 1]
+              - value = change[/^\w+ => (.+)$/, 1]
+              %li
+                = succeed ':' do
+                  %strong<
+                    = field
+                - if value.blank?
+                  (deleted)
+                - else
+                  = value
 
 

--- a/app/views/shared/_audit.html.haml
+++ b/app/views/shared/_audit.html.haml
@@ -7,7 +7,7 @@
       %th Browser
       %th Change
   %tbody
-    -versions.reverse.each do |v|
+    - versions.reverse.each do |v|
       %tr
         %td
           = l(v.created_at)
@@ -19,16 +19,9 @@
         %td{title: v.user_agent}=v.user_agent_summary
         %td
           %ul
-            - v.changes.each do |change|
-              - field = change[/^(\w+) =>/, 1]
-              - value = change[/^\w+ => (.+)$/, 1]
+            - v.changes.each do |field, value|
               %li
                 = succeed ':' do
                   %strong<
                     = field
-                - if value.blank?
-                  (deleted)
-                - else
-                  = value
-
-
+                = value

--- a/spec/features/group_audit_spec.rb
+++ b/spec/features/group_audit_spec.rb
@@ -31,8 +31,8 @@ feature 'View group audit' do
 
       expect(group_page).to have_audit
       group_page.audit.versions.tap do |v|
-        expect(v[0]).to have_text "description => #{description}"
-        expect(v[1]).to have_text "name => #{name}"
+        expect(v[0]).to have_text "description: #{description}"
+        expect(v[1]).to have_text "name: #{name}"
       end
     end
 

--- a/spec/features/person_audit_spec.rb
+++ b/spec/features/person_audit_spec.rb
@@ -35,10 +35,10 @@ feature 'View person audit' do
 
         expect(profile_page).to have_audit
         profile_page.audit.versions.tap do |v|
-          expect(v[0]).to have_text "profile_photo_id => #{profile_photo.id}"
-          expect(v[1]).to have_text "primary_phone_number => #{phone_number}"
-          expect(v[2]).to have_text "description => #{description}"
-          expect(v[3]).to have_text "email => #{person.email}"
+          expect(v[0]).to have_text "profile_photo_id: #{profile_photo.id}"
+          expect(v[1]).to have_text "primary_phone_number: #{phone_number}"
+          expect(v[2]).to have_text "description: #{description}"
+          expect(v[3]).to have_text "email: #{person.email}"
         end
       end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -15,23 +15,28 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   context '#last_update' do
+    before do
+      @last_updated_at = stubbed_time
+    end
+
     it 'shows last_update for a person by a system generated user' do
-      @person = double(:person, updated_at: stubbed_time, originator: originator)
+      @person = double(:person, originator: originator)
       expect(last_update).to eql('Last updated: 31 Oct 2012 02:02.')
     end
 
     it 'shows last_update for a person by someone who is not the system user' do
-      @person = double(:person, updated_at: stubbed_time, originator: 'Bob')
+      @person = double(:person, originator: 'Bob')
       expect(last_update).to eql('Last updated: 31 Oct 2012 02:02 by Bob.')
     end
 
     it 'shows last_update for a group' do
-      @group = double(:group, updated_at: stubbed_time, originator: originator)
+      @group = double(:group, originator: originator)
       expect(last_update).to eql('Last updated: 31 Oct 2012 02:02.')
     end
 
     it 'does not show last_update for a new person' do
-      @person = double(:group, updated_at: nil, originator: originator)
+      @person = double(:group, originator: originator)
+      @last_updated_at = nil
       expect(last_update).to be_blank
     end
   end

--- a/spec/presenters/audit_version_presenter_spec.rb
+++ b/spec/presenters/audit_version_presenter_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe AuditVersionPresenter, type: :presenter do
 
   describe '#changes' do
     it 'contains expected strings' do
-      expect(changes).to include("email => #{new_email}")
-      expect(changes).to include("given_name => #{new_given_name}")
-      expect(changes).to include("surname => #{new_surname}")
+      expect(changes).to include(['email', new_email])
+      expect(changes).to include(['given_name', new_given_name])
+      expect(changes).to include(['surname', new_surname])
     end
   end
 


### PR DESCRIPTION
Change from showing object `updated_at` time to last audit version `created_at` time for "Last updated" display.

We set last reminder email time on the object, which changes the object `updated_at` time, even though there is no user edit. So it is no longer correct to show object `updated_at` time for the "Last updated" display.

Also format changes to audit log table

- Make field names bold in changes column
- Remove event type
- Format time of event
- Place time in first column
- Show '(deleted)' when new value is blank