### PR TITLE
Return to person's team page when person profile deleted

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -68,7 +68,9 @@ class PeopleController < ApplicationController
     destroyer = PersonDestroyer.new(@person, current_user)
     destroyer.destroy!
     notice :profile_deleted, person: @person
-    redirect_to home_path
+    group = @person.groups.first
+
+    redirect_to group ? group_path(group) : home_path
   end
 
   def add_membership

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -267,6 +267,19 @@ RSpec.describe PeopleController, type: :controller do
       expect(response).to redirect_to(home_path)
     end
 
+    context 'when person member of teams' do
+      it 'redirects to first team page' do
+        person = create(:person, valid_attributes)
+        groups = create_list(:group, 2)
+        groups.each do |group|
+          create :membership, person: person, group: group
+        end
+
+        delete :destroy, id: person.to_param
+        expect(response).to redirect_to(group_path(groups.first))
+      end
+    end
+
     it 'sets a flash message' do
       person = create(:person, valid_attributes)
       delete :destroy, id: person.to_param


### PR DESCRIPTION
When a person's profile is deleted, and that person is a member of one or more teams, return browser to the first team page.