### PR TITLE
Use job to update group's members completion score and store in database

### DIFF
--- a/app/jobs/update_group_members_completion_score_job.rb
+++ b/app/jobs/update_group_members_completion_score_job.rb
@@ -1,0 +1,7 @@
+class UpdateGroupMembersCompletionScoreJob < ActiveJob::Base
+  queue_as :low_priority
+
+  def perform(group)
+    group.update_members_completion_score!
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,7 +6,8 @@ class Group < ActiveRecord::Base
 
   has_paper_trail class_name: 'Version',
                   ignore: [:updated_at, :created_at, :slug, :id,
-                           :description_reminder_email_at]
+                           :description_reminder_email_at,
+                           :members_completion_score]
 
   extend FriendlyId
   friendly_id :slug_candidates, use: :slugged

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -16,4 +16,7 @@ class Membership < ActiveRecord::Base
   concatenated_field :to_s, :group_name, :role, join_with: ', '
 
   scope :subscribing, -> { where(subscribed: true) }
+
+  before_destroy { |m| UpdateGroupMembersCompletionScoreJob.perform_later(m.group) }
+
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -39,6 +39,16 @@ class Person < ActiveRecord::Base
   attr_accessor :crop_x, :crop_y, :crop_w, :crop_h
   after_save :crop_profile_photo
 
+  after_save do |person|
+    groups_prior = person.groups
+    person.reload # updates groups
+    groups_present = person.groups
+
+    (groups_prior + groups_present).uniq.each do |group|
+      UpdateGroupMembersCompletionScoreJob.perform_later(group)
+    end
+  end
+
   def crop_profile_photo
     profile_photo.crop crop_x, crop_y, crop_w, crop_h if crop_x.present?
   end

--- a/app/views/groups/_subgroup.html.haml
+++ b/app/views/groups/_subgroup.html.haml
@@ -1,9 +1,10 @@
 %div.grid.grid-1-3.subgroup
   %a.subgroup-link-block.inner-block{ href: url_for(subgroup) }
     %h3= subgroup
-    .subgroup-completion
-      %span.score< #{subgroup.members_completion_score}%
-      of profile information completed
+    - if subgroup.members_completion_score
+      .subgroup-completion
+        %span.score< #{subgroup.members_completion_score}%
+        of profile information completed
     %div.about-subgroup
       .formatted-text
         = govspeak(truncate(subgroup.with_placeholder_default(:description), length: 350))

--- a/app/views/groups/_subgroup.html.haml
+++ b/app/views/groups/_subgroup.html.haml
@@ -2,7 +2,7 @@
   %a.subgroup-link-block.inner-block{ href: url_for(subgroup) }
     %h3= subgroup
     .subgroup-completion
-      %span.score< #{subgroup.completion_score}%
+      %span.score< #{subgroup.members_completion_score}%
       of profile information completed
     %div.about-subgroup
       .formatted-text

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,4 +1,5 @@
 Delayed::Worker.queue_attributes = [
   { name: :high_priority, priority: -10 }, # lower number = higher priority
-  { name: :mailers, priority: 0 }
+  { name: :mailers, priority: 0 },
+  { name: :low_priority, priority: 10 }, # higher number = lower priority
 ]

--- a/db/migrate/20160418124145_add_members_completion_score_to_groups.rb
+++ b/db/migrate/20160418124145_add_members_completion_score_to_groups.rb
@@ -1,0 +1,5 @@
+class AddMembersCompletionScoreToGroups < ActiveRecord::Migration
+  def change
+    add_column :groups, :members_completion_score, :integer
+  end
+end

--- a/db/migrate/20160419131143_populate_group_members_completion_score.rb
+++ b/db/migrate/20160419131143_populate_group_members_completion_score.rb
@@ -1,0 +1,7 @@
+class PopulateGroupMembersCompletionScore < ActiveRecord::Migration
+  def up
+    Group.where(members_completion_score: nil).each do |group|
+      UpdateGroupMembersCompletionScoreJob.perform_later(group)
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -96,7 +96,8 @@ CREATE TABLE groups (
     ancestry text,
     ancestry_depth integer DEFAULT 0 NOT NULL,
     acronym text,
-    description_reminder_email_at timestamp without time zone
+    description_reminder_email_at timestamp without time zone,
+    members_completion_score integer
 );
 
 
@@ -620,4 +621,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160308105233');
 INSERT INTO schema_migrations (version) VALUES ('20160407145602');
 
 INSERT INTO schema_migrations (version) VALUES ('20160411134824');
+
+INSERT INTO schema_migrations (version) VALUES ('20160418124145');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -624,3 +624,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160411134824');
 
 INSERT INTO schema_migrations (version) VALUES ('20160418124145');
 
+INSERT INTO schema_migrations (version) VALUES ('20160419131143');
+

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -4,8 +4,16 @@ feature 'Group browsing' do
   include PermittedDomainHelper
 
   let!(:department) { create(:department) }
-  let!(:team) { create(:group, name: 'A Team', parent: department) }
-  let!(:subteam) { create(:group, name: 'A Subteam', parent: team) }
+  let!(:team) do
+    team = create(:group, name: 'A Team', parent: department)
+    team.update_members_completion_score!
+    team
+  end
+  let!(:subteam) do
+    subteam = create(:group, name: 'A Subteam', parent: team)
+    subteam.update_members_completion_score!
+    subteam
+  end
   let!(:leaf_node) { create(:group, name: 'A Leaf Node', parent: subteam) }
 
   before do
@@ -79,7 +87,7 @@ feature 'Group browsing' do
       expect(page).to have_text("Teams within #{team.name}")
       expect(page).to have_link("View all people")
       expect(page).to have_link("View 3 people not assigned to a sub-team")
-      expect(page).to have_text("#{subteam.completion_score}% of profile information completed")
+      expect(page).to have_text("#{subteam.members_completion_score}% of profile information completed")
     end
 
     scenario 'following the view all people link' do

--- a/spec/jobs/update_group_members_completion_score_job_spec.rb
+++ b/spec/jobs/update_group_members_completion_score_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe UpdateGroupMembersCompletionScoreJob, type: :job do
+
+  let(:group) { double }
+
+  context 'when called' do
+    it 'recalculates members average completion score' do
+      expect(group).to receive(:update_members_completion_score!)
+
+      described_class.perform_now(group)
+    end
+  end
+end

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -102,9 +102,11 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
           primary_phone_number: generate(:phone_number)
               )
       end
+      expect(UpdateGroupMembersCompletionScoreJob).to receive(:perform_later).exactly(5).times
       2.times do
         create(:membership, person: people[0])
       end
+      people.each(&:reload)
       expect(people[0].completion_score).to eq(66)
       expect(people[1].completion_score).to eq(55)
       expect(Person.overall_completion).to be_within(1).of(61)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -173,6 +173,10 @@ RSpec.describe Person, type: :model do
       expect(person.reload.memberships.first.leader).to be true
     end
 
+    it 'fires UpdateGroupMembersCompletionScoreJob for group on save' do
+      expect(UpdateGroupMembersCompletionScoreJob).to receive(:perform_later).with(person.groups.first)
+      person.save
+    end
   end
 
   context 'path' do

--- a/spec/services/login_spec.rb
+++ b/spec/services/login_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Login, type: :service do
     end
     it 'stores the current time of login' do
       Timecop.freeze(current_time) do
-        expect { subject }.to change { person.last_login_at }.to(current_time)
+        expect { subject }.to change { person.last_login_at }
+        expect(person.last_login_at.change(usec: 0)).to eq(current_time.change(usec: 0))
       end
     end
     it 'stores the person id in the session' do


### PR DESCRIPTION
The current approach of storing the group's members completion score in the Rails cache with an expiry, was causing delays in page load time when the score cache had expired and needed recalculating.

Instead now store the completeness score in the database. And use a worker job to do any updates to the value.