### PR TITLE
Update group's parent members completion score in worker job

### DIFF
--- a/app/jobs/update_group_members_completion_score_job.rb
+++ b/app/jobs/update_group_members_completion_score_job.rb
@@ -3,5 +3,9 @@ class UpdateGroupMembersCompletionScoreJob < ActiveJob::Base
 
   def perform(group)
     group.update_members_completion_score!
+
+    if group.parent && group.parent != Group.department
+      UpdateGroupMembersCompletionScoreJob.perform_later(group.parent)
+    end
   end
 end

--- a/spec/jobs/update_group_members_completion_score_job_spec.rb
+++ b/spec/jobs/update_group_members_completion_score_job_spec.rb
@@ -2,13 +2,42 @@ require 'rails_helper'
 
 RSpec.describe UpdateGroupMembersCompletionScoreJob, type: :job do
 
-  let(:group) { double }
+  let(:parent) { nil }
+  let(:group) { double(parent: parent) }
 
   context 'when called' do
+    before do
+      allow(group).to receive(:update_members_completion_score!)
+    end
+
     it 'recalculates members average completion score' do
       expect(group).to receive(:update_members_completion_score!)
-
       described_class.perform_now(group)
+    end
+
+    context 'with group with nil parent' do
+      it 'does not create new job for parent' do
+        expect(described_class).not_to receive(:perform_later).with(parent)
+        described_class.perform_now(group)
+      end
+    end
+
+    context 'with group with a parent' do
+      let(:parent) { double }
+
+      it 'creates new job to update parent' do
+        expect(described_class).to receive(:perform_later).with(parent)
+        described_class.perform_now(group)
+      end
+    end
+
+    context 'with group with root department as parent' do
+      let(:parent) { Group.department }
+
+      it 'does not create new job for parent' do
+        expect(described_class).not_to receive(:perform_later).with(parent)
+        described_class.perform_now(group)
+      end
     end
   end
 end


### PR DESCRIPTION
When a group's members completion score is being updated in the worker job, create a new job to update that group's parent group unless the parent group is the root department group.

We don't display the root department group's members completion score so don't need to update it.