### PR TITLE
add demo data re/loading task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,8 +15,7 @@ AllCops:
     - 'config/initializers/simple_form.rb'
     - 'config/unicorn.rb'
     - 'spec/rails_helper.rb'
-    - 'lib/tasks/brakeman.rake'
-    - 'lib/tasks/elasticsearch.rake'
+    - 'lib/tasks/**/*'
     - 'spec/dummy/db/**/*'
     - 'smoke_test'
   TargetRubyVersion: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 ruby '2.3.1'
 gem 'rails', '~> 4.2.4'
 gem 'text'
-gem 'ancestry'
+gem 'ancestry', '~> 2.1'
+gem 'awesome_print'
 gem 'delayed_job', git: 'https://github.com/collectiveidea/delayed_job.git',
     ref: '5f914105c1c38ca73a486d63de8ad62f254b3d72' # needed for queue_attributes configuration
 gem 'delayed_job_active_record'
@@ -86,7 +87,7 @@ group :development, :test do
   gem 'guard-jasmine'
   gem 'guard-rubocop', require: false
   gem 'rubocop-rspec'
-  gem 'awesome_print'
+  gem 'annotate'
 end
 
 group :development, :test, :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     addressable (2.3.8)
     ancestry (2.1.0)
       activerecord (>= 3.0.0)
+    annotate (2.7.1)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 12.0)
     arel (6.0.3)
     ast (2.2.0)
     awesome_print (1.6.1)
@@ -596,7 +599,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ancestry
+  ancestry (~> 2.1)
+  annotate
   awesome_print
   brakeman
   byebug

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ gem install eventmachine -v 1.0.5 -- --with-cppflags=-I/usr/local/opt/openssl/in
 
 bundle
 bundle exec rake db:setup
+bundle exec rake peoplefinder:db:reload # includes demo data
 bundle exec rake # runs tests
 bundle exec rails s -b 0.0.0.0
 ```
@@ -265,6 +266,20 @@ Usage:
   generator.generate(groups_levels, groups_per_level, people_per_group, domain)
 ```
 
+You can also generate semi-random data using the rake task `peoplefinder:data:demo` which is called as part of `peoplefinder:db:reload`. Repeatedly running `peoplefinder:demo:data` will add members to the example groups it creates.
+
+### Useful rake tasks
+
+Run `rake -T | grep people` for latest list:
+
+```
+rake peoplefinder:data:demo                    # create basic demonstration data
+rake peoplefinder:db:clear                     # drop all tables
+rake peoplefinder:db:reload                    # clear DB and repopulate with basic data for development purposes
+rake peoplefinder:db:reset_column_information  # reset all column information
+rake peoplefinder:import:csv_check[path]       # Check validity of CSV file before import
+rake peoplefinder:import:csv_import[path]      # Import valid CSV file
+```
 ### Development tools
 
 CI by [Travis](https://travis-ci.org/ministryofjustice/peoplefinder).

--- a/app/models/concerns/hierarchical.rb
+++ b/app/models/concerns/hierarchical.rb
@@ -7,5 +7,26 @@ module Concerns::Hierarchical
     def leaf_node?
       children.blank?
     end
+
+    # NOTE: ancestry gem does not work with find_or_create_by[!].
+    # see https://github.com/stefankroes/ancestry#organising-records-into-a-tree
+    # So we extend the model with find_or_create_by! to apply the ancestry
+    # gem's logic for parent attributes
+    # e.g. The following would only ever create one child of the parent:
+    # Group.find_or_create_by!(name: 'Content', parent: digital_services )
+    # Group.find_or_create_by!(name: 'Content', parent: technology )
+    def self.find_or_create_by! attributes, &block
+      return super unless attributes.include?(:parent) || attributes.include?(:parent_id)
+      parent = attributes.delete(:parent) if attributes.include?(:parent)
+      parent_id = attributes.delete(:parent_id) if attributes.include?(:parent_id)
+      parent_id = parent.id if parent_id.nil?
+
+      if find_by(attributes) && (find_by(attributes).parent_id == parent_id || find_by(attributes).parent == parent)
+        find_by(attributes)
+      else
+        create!(attributes.merge(parent_id: parent_id), &block)
+      end
+    end
+
   end
 end

--- a/app/models/concerns/hierarchical.rb
+++ b/app/models/concerns/hierarchical.rb
@@ -17,15 +17,19 @@ module Concerns::Hierarchical
     # Group.find_or_create_by!(name: 'Content', parent: technology )
     def self.find_or_create_by! attributes, &block
       return super unless attributes.include?(:parent) || attributes.include?(:parent_id)
-      parent = attributes.delete(:parent) if attributes.include?(:parent)
-      parent_id = attributes.delete(:parent_id) if attributes.include?(:parent_id)
-      parent_id = parent.id if parent_id.nil?
+      parent_id = sanitize_and_get_parent_id(attributes)
 
       if find_by(attributes) && (find_by(attributes).parent_id == parent_id || find_by(attributes).parent == parent)
         find_by(attributes)
       else
         create!(attributes.merge(parent_id: parent_id), &block)
       end
+    end
+
+    def self.sanitize_and_get_parent_id attributes
+      parent = attributes.delete(:parent) if attributes.include?(:parent)
+      parent_id = attributes.delete(:parent_id) if attributes.include?(:parent_id)
+      parent_id.nil? ? parent.id : parent_id
     end
 
   end

--- a/app/services/random_generator.rb
+++ b/app/services/random_generator.rb
@@ -13,8 +13,7 @@ class RandomGenerator
     @group.descendants.each(&:delete)
   end
 
-  def generate(groups_levels=1, groups_per_level=2, people_per_group=3, domain=Faker::Internet.domain_name)
-
+  def generate(groups_levels = 1, groups_per_level = 2, people_per_group = 3, domain = Faker::Internet.domain_name)
     @groups_levels = groups_levels
     @groups_per_level = groups_per_level
     @people_per_group = people_per_group
@@ -24,7 +23,7 @@ class RandomGenerator
     generate_level(@group, 0)
   end
 
-  def generate_members(no_of_people=3, domain=Faker::Internet.domain_name)
+  def generate_members(no_of_people = 3, domain = Faker::Internet.domain_name)
     @domain = domain
     permit_domain(@domain)
     no_of_people.times { create_person @group }

--- a/app/services/random_generator.rb
+++ b/app/services/random_generator.rb
@@ -13,16 +13,28 @@ class RandomGenerator
     @group.descendants.each(&:delete)
   end
 
-  def generate(groups_levels, groups_per_level, people_per_group, domain)
+  def generate(groups_levels=1, groups_per_level=2, people_per_group=3, domain=Faker::Internet.domain_name)
+
     @groups_levels = groups_levels
     @groups_per_level = groups_per_level
     @people_per_group = people_per_group
     @domain = domain
 
+    permit_domain(@domain)
     generate_level(@group, 0)
   end
 
+  def generate_members(no_of_people=3, domain=Faker::Internet.domain_name)
+    @domain = domain
+    permit_domain(@domain)
+    no_of_people.times { create_person @group }
+  end
+
   private
+
+  def permit_domain(domain)
+    PermittedDomain.find_or_create_by!(domain: domain)
+  end
 
   def generate_level(group, level)
     if level == @groups_levels
@@ -37,14 +49,14 @@ class RandomGenerator
   end
 
   def create_group(parent)
-    parent.children.create(
+    parent.children.create!(
       name: Faker::Commerce.department,
       description: Faker::Lorem.paragraph
     )
   end
 
   def create_person(group)
-    group.people.create(
+    group.people.create!(
       person_attributes.merge(work_days_attributes).merge(location_attributes)
     )
   end
@@ -70,8 +82,8 @@ class RandomGenerator
       works_wednesday: [true, false].sample,
       works_thursday: [true, false].sample,
       works_friday: [true, false].sample,
-      works_saturday: [true, false].sample,
-      works_sunday: [true, false].sample
+      works_saturday: [true, false, false, false].sample,
+      works_sunday: [true, false, false, false].sample
     }
   end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,12 +2,16 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.3.4
+-- Dumped by pg_dump version 9.5.1
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -44,7 +48,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE delayed_jobs (
@@ -83,7 +87,7 @@ ALTER SEQUENCE delayed_jobs_id_seq OWNED BY delayed_jobs.id;
 
 
 --
--- Name: groups; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: groups; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE groups (
@@ -121,7 +125,7 @@ ALTER SEQUENCE groups_id_seq OWNED BY groups.id;
 
 
 --
--- Name: memberships; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: memberships; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE memberships (
@@ -156,7 +160,7 @@ ALTER SEQUENCE memberships_id_seq OWNED BY memberships.id;
 
 
 --
--- Name: people; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: people; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE people (
@@ -211,7 +215,7 @@ ALTER SEQUENCE people_id_seq OWNED BY people.id;
 
 
 --
--- Name: permitted_domains; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: permitted_domains; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE permitted_domains (
@@ -242,7 +246,7 @@ ALTER SEQUENCE permitted_domains_id_seq OWNED BY permitted_domains.id;
 
 
 --
--- Name: profile_photos; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: profile_photos; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE profile_photos (
@@ -273,7 +277,7 @@ ALTER SEQUENCE profile_photos_id_seq OWNED BY profile_photos.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE schema_migrations (
@@ -282,7 +286,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tokens; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE tokens (
@@ -315,7 +319,7 @@ ALTER SEQUENCE tokens_id_seq OWNED BY tokens.id;
 
 
 --
--- Name: versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: versions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE versions (
@@ -408,7 +412,7 @@ ALTER TABLE ONLY versions ALTER COLUMN id SET DEFAULT nextval('versions_id_seq':
 
 
 --
--- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY delayed_jobs
@@ -416,7 +420,7 @@ ALTER TABLE ONLY delayed_jobs
 
 
 --
--- Name: groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY groups
@@ -424,7 +428,7 @@ ALTER TABLE ONLY groups
 
 
 --
--- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY memberships
@@ -432,7 +436,7 @@ ALTER TABLE ONLY memberships
 
 
 --
--- Name: people_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: people_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY people
@@ -440,7 +444,7 @@ ALTER TABLE ONLY people
 
 
 --
--- Name: permitted_domains_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: permitted_domains_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY permitted_domains
@@ -448,7 +452,7 @@ ALTER TABLE ONLY permitted_domains
 
 
 --
--- Name: profile_photos_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: profile_photos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY profile_photos
@@ -456,7 +460,7 @@ ALTER TABLE ONLY profile_photos
 
 
 --
--- Name: tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tokens
@@ -464,7 +468,7 @@ ALTER TABLE ONLY tokens
 
 
 --
--- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY versions
@@ -472,63 +476,63 @@ ALTER TABLE ONLY versions
 
 
 --
--- Name: delayed_jobs_priority; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: delayed_jobs_priority; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX delayed_jobs_priority ON delayed_jobs USING btree (priority, run_at);
 
 
 --
--- Name: index_groups_on_ancestry; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_groups_on_ancestry; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_groups_on_ancestry ON groups USING btree (ancestry);
 
 
 --
--- Name: index_groups_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_groups_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_groups_on_slug ON groups USING btree (slug);
 
 
 --
--- Name: index_memberships_on_group_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_memberships_on_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_memberships_on_group_id ON memberships USING btree (group_id);
 
 
 --
--- Name: index_memberships_on_person_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_memberships_on_person_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_memberships_on_person_id ON memberships USING btree (person_id);
 
 
 --
--- Name: index_people_on_lowercase_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_people_on_lowercase_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_people_on_lowercase_email ON people USING btree (lower(email));
 
 
 --
--- Name: index_people_on_slug; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_people_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_people_on_slug ON people USING btree (slug);
 
 
 --
--- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (item_type, item_id);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);

--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -1,0 +1,41 @@
+namespace :peoplefinder do
+  namespace :data do
+
+    # peoplefinder:data:demo
+    #
+    # idempotent for groups but will add members
+    # when run repeatedly.
+    #
+    # Group demo data structure is as below (left to right):
+    #
+    # moj > csg > digital services > content
+    #           |                  |
+    #           |                  |
+    #           > technology       > development
+    #                              |
+    #                              |
+    #                              > webops
+    #
+    desc 'create basic demonstration data'
+    task :demo => :environment do
+      puts '...find/create department'
+      moj = Group.where(ancestry_depth: 0).first_or_create!(name: 'Ministry of Justice', acronym: 'MoJ')
+
+      puts '...find/create sub departments/groups/teams'
+      csg = Group.find_or_create_by!(name: 'Corporate Services Group', acronym: 'CSG', parent: moj)
+      tech = Group.find_or_create_by!(name: 'Technology', acronym: 'Tech', parent: csg )
+      ds = Group.find_or_create_by!(name: 'Digital Services', acronym: 'DS', parent: csg )
+      cn = Group.find_or_create_by!(name: 'Content', parent: ds )
+      dev = Group.find_or_create_by!(name: 'Development', parent: ds )
+      ops = Group.find_or_create_by!(name: 'Webops', parent: ds )
+
+      DOMAIN = 'fake-moj.justice.gov.uk'.freeze
+      puts '...creating fake members of subteams'
+      group_membership = [[moj,1],[csg,1],[tech,2],[ds,2],[cn,1],[dev,3],[ops,2]]
+      group_membership.each do |group,member_count|
+        RandomGenerator.new(group).generate_members(member_count,DOMAIN)
+      end
+    end
+
+  end
+end

--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -23,17 +23,17 @@ namespace :peoplefinder do
 
       puts '...find/create sub departments/groups/teams'
       csg = Group.find_or_create_by!(name: 'Corporate Services Group', acronym: 'CSG', parent: moj)
-      tech = Group.find_or_create_by!(name: 'Technology', acronym: 'Tech', parent: csg )
-      ds = Group.find_or_create_by!(name: 'Digital Services', acronym: 'DS', parent: csg )
-      cn = Group.find_or_create_by!(name: 'Content', parent: ds )
-      dev = Group.find_or_create_by!(name: 'Development', parent: ds )
-      ops = Group.find_or_create_by!(name: 'Webops', parent: ds )
+      tech = Group.find_or_create_by!(name: 'Technology', acronym: 'Tech', parent: csg)
+      ds = Group.find_or_create_by!(name: 'Digital Services', acronym: 'DS', parent: csg)
+      cn = Group.find_or_create_by!(name: 'Content', parent: ds)
+      dev = Group.find_or_create_by!(name: 'Development', parent: ds)
+      ops = Group.find_or_create_by!(name: 'Webops', parent: ds)
 
       DOMAIN = 'fake-moj.justice.gov.uk'.freeze
       puts '...creating fake members of subteams'
-      group_membership = [[moj,1],[csg,1],[tech,2],[ds,2],[cn,1],[dev,3],[ops,2]]
-      group_membership.each do |group,member_count|
-        RandomGenerator.new(group).generate_members(member_count,DOMAIN)
+      group_membership = [[moj, 1], [csg, 1], [tech, 2], [ds, 2], [cn, 1], [dev, 3], [ops, 2]]
+      group_membership.each do |group, member_count|
+        RandomGenerator.new(group).generate_members(member_count, DOMAIN)
       end
     end
 

--- a/lib/tasks/peoplefinder/db.rake
+++ b/lib/tasks/peoplefinder/db.rake
@@ -1,0 +1,37 @@
+namespace :peoplefinder do
+  namespace :db do
+
+    desc "drop all tables"
+    task :clear => :environment do
+      conn = ActiveRecord::Base.connection
+      tables = conn.tables
+      tables.each do |table|
+        puts "...dropping #{table}"
+        conn.drop_table(table, force: :cascade)
+      end
+    end
+
+    desc "reset all column information"
+    task :reset_column_information => :environment do
+      conn = ActiveRecord::Base.connection
+      tables = conn.tables
+      tables.each do |table|
+        next if ['schema_migrations','delayed_jobs'].include? table
+        table.classify.constantize.reset_column_information
+      end
+    end
+
+    desc "drop tables, migrate, seed and populate with demonstration data for development purposes"
+    task :reload => [:environment, :clear] do
+      puts '...migrating'
+      Rake::Task['db:migrate'].invoke
+      puts '...resetting column information' # required due to schema changes from migrations not being reflected in models
+      Rake::Task['peoplefinder:db:reset_column_information'].invoke
+      puts '...seeding'
+      Rake::Task['db:seed'].invoke
+      puts '...creating demonstration data'
+      Rake::Task['peoplefinder:data:demo'].invoke
+    end
+
+  end
+end

--- a/lib/tasks/peoplefinder/db.rake
+++ b/lib/tasks/peoplefinder/db.rake
@@ -1,7 +1,7 @@
 namespace :peoplefinder do
   namespace :db do
 
-    desc "drop all tables"
+    desc 'drop all tables'
     task :clear => :environment do
       conn = ActiveRecord::Base.connection
       tables = conn.tables
@@ -11,24 +11,28 @@ namespace :peoplefinder do
       end
     end
 
-    desc "reset all column information"
+    desc 'reset all column information'
     task :reset_column_information => :environment do
       conn = ActiveRecord::Base.connection
       tables = conn.tables
       tables.each do |table|
-        next if ['schema_migrations','delayed_jobs'].include? table
+        next if %w{ schema_migrations delayed_jobs }.include? table
         table.classify.constantize.reset_column_information
       end
     end
 
-    desc "drop tables, migrate, seed and populate with demonstration data for development purposes"
+    desc 'drop tables, migrate, seed and populate with demonstration data for development purposes'
     task :reload => [:environment, :clear] do
       puts '...migrating'
       Rake::Task['db:migrate'].invoke
-      puts '...resetting column information' # required due to schema changes from migrations not being reflected in models
+
+      # col reset required due to schema changes from migrations not being reflected in models
+      puts '...resetting column information'
       Rake::Task['peoplefinder:db:reset_column_information'].invoke
+
       puts '...seeding'
       Rake::Task['db:seed'].invoke
+
       puts '...creating demonstration data'
       Rake::Task['peoplefinder:data:demo'].invoke
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require 'shoulda-matchers'
 require 'capybara/rspec'
 require 'capybara/poltergeist'
 require 'site_prism'
+require 'awesome_print'
 
 unless ENV['SKIP_SIMPLECOV']
   require 'simplecov'

--- a/spec/services/random_generator_spec.rb
+++ b/spec/services/random_generator_spec.rb
@@ -33,11 +33,23 @@ RSpec.describe RandomGenerator do
       subject.generate(groups_levels, groups_per_level, people_per_group, domain)
     end
 
-    it 'generate all levels of groups' do
+    it 'should add permitted domain' do
+      expect(PermittedDomain.pluck(:domain)).to include domain
+    end
+
+    it 'should generate all levels of groups' do
       expect(group.descendants.count).to eq(6)
     end
-    it 'generate people for the leaf groups' do
+
+    it 'should generate people for the leaf groups' do
       expect(Person.all_in_groups(group.descendants.pluck(:id)).count).to eq(30)
     end
   end
+
+  describe '#generate_members' do
+    it 'generates people for the specified leaf group' do
+      expect{ subject.generate_members(3) }.to change(group.people,:count).by 3
+    end
+  end
+
 end

--- a/spec/services/random_generator_spec.rb
+++ b/spec/services/random_generator_spec.rb
@@ -33,22 +33,22 @@ RSpec.describe RandomGenerator do
       subject.generate(groups_levels, groups_per_level, people_per_group, domain)
     end
 
-    it 'should add permitted domain' do
+    it 'adds permitted domain' do
       expect(PermittedDomain.pluck(:domain)).to include domain
     end
 
-    it 'should generate all levels of groups' do
+    it 'generates all levels of groups' do
       expect(group.descendants.count).to eq(6)
     end
 
-    it 'should generate people for the leaf groups' do
+    it 'generates people for the leaf groups' do
       expect(Person.all_in_groups(group.descendants.pluck(:id)).count).to eq(30)
     end
   end
 
   describe '#generate_members' do
     it 'generates people for the specified leaf group' do
-      expect{ subject.generate_members(3) }.to change(group.people,:count).by 3
+      expect { subject.generate_members(3) }.to change(group.people, :count).by 3
     end
   end
 


### PR DESCRIPTION
for use in QA on dev enviroment it is useful
to have some demo data to play around with.

NOTE: set row security to off. This is added by pg_dump
when a migration is run at any point: see
https://www.postgresql.org/docs/current/static/runtime-config-client.html#GUC-ROW-SECURITY