### PR TITLE
separate and style csv uploader hint into partial

### DIFF
--- a/app/assets/stylesheets/peoplefinder/application.scss
+++ b/app/assets/stylesheets/peoplefinder/application.scss
@@ -560,6 +560,21 @@ textarea.form-control {
   margin: 30px 0;
 }
 
+.csv-formatted-text {
+  .csv-header {
+    font-weight: bold;
+  }
+
+  pre {
+    padding: 1em;
+  }
+
+  code {
+    white-space: nowrap;
+    border: 0px;
+  }
+}
+
 @import 'retinal_images';
 
 .no-desk {

--- a/app/helpers/upload_helper.rb
+++ b/app/helpers/upload_helper.rb
@@ -1,0 +1,27 @@
+module UploadHelper
+
+  def required_headers
+    headers(PersonCsvImporter::REQUIRED_COLUMNS, tag: :code, separator: ' ')
+  end
+
+  def optional_headers
+    headers(PersonCsvImporter::OPTIONAL_COLUMNS, tag: :code, separator: ' ')
+  end
+
+  def csv_headers
+    headers(PersonCsvImporter::REQUIRED_COLUMNS + PersonCsvImporter::OPTIONAL_COLUMNS, tag: nil, separator: ',')
+  end
+
+  private
+
+  def headers(header_collection, options = { tag: nil, separator: ',' })
+    return header_collection.join(options[:separator]) if options[:tag].nil?
+
+    header_collection.map do |column_name|
+      content_tag(options[:tag]) do
+        concat column_name.to_s
+      end
+    end.join(options[:separator]).html_safe
+  end
+
+end

--- a/app/views/admin/person_uploads/_form.html.haml
+++ b/app/views/admin/person_uploads/_form.html.haml
@@ -21,7 +21,7 @@
       - if f.object.errors.include?(:file)
         %span.error= f.object.errors[:file].first
     %p.form-hint
-      =info_text('hint_person_upload_file_html')
+      = render partial: 'hint'
     = f.file_field :file
 
   %fieldset

--- a/app/views/admin/person_uploads/_hint.html.haml
+++ b/app/views/admin/person_uploads/_hint.html.haml
@@ -1,0 +1,20 @@
+.panel.panel-border-wide.form-hint
+  %p
+    Row 1 of file must have comma separated column names following the naming below:
+    %br/
+  %ul.list.list-bullet
+    %li
+      required:
+      = required_headers
+    %li
+      optional:
+      = optional_headers
+  example:
+  %div.csv-formatted-text
+    %pre
+      %code
+        %span.csv-header
+          = csv_headers
+        %br
+        %span
+          Tom,O'Conner,tom.o.conner@example.gov.uk,020 7947 6666,102 Petty France,"Room 5.05, 5th Floor, Blue Core",London

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,18 +253,6 @@ en:
       hint_team_email_address: "Enter an email for people to get in touch with the team"
       hint_person_upload_group: |
         You can only upload people’s details to an existing team.
-      hint_person_upload_file_html: |
-        <div class="panel panel-border-wide form-hint">
-          <p>
-            Row 1 of file must have comma separated column names following the naming below: <br>
-            <ul class="list list-bullet">
-            <li>required: <code>given_name</code> <code>surname</code> <code>email</code></li>
-            <li>optional: <code>primary_phone_number</code> <code>building</code> <code>location_in_building</code> <code>city</code> </li>
-            </ul>
-            e.g. <br>
-            <code>given_name,surname,email,primary_phone_number,building,location_in_building,city</code>
-          </p>
-        </div>
       information_request_label: "Enter your message"
       location_in_building_hint: "(eg 10.30)"
       building_hint: "(eg 102 Petty France)"

--- a/spec/helpers/upload_helper_spec.rb
+++ b/spec/helpers/upload_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe UploadHelper, type: :helper do
+  describe 'required_headers' do
+    let(:html) do
+      '<code>given_name</code> ' \
+      '<code>surname</code> ' \
+      '<code>email</code>'
+    end
+    it "returns expected html wrapped list of optional columns" do
+      expect(required_headers).to eql(html)
+    end
+  end
+
+  describe 'optional_headers' do
+    let(:html) do
+      '<code>primary_phone_number</code> ' \
+      '<code>building</code> ' \
+      '<code>location_in_building</code> ' \
+      '<code>city</code>'
+    end
+    it "returns expected html wrapped list of optional columns" do
+      expect(optional_headers).to eql(html)
+    end
+  end
+end


### PR DESCRIPTION
The help text html was in a translator but was becoming
too verbose. additionally partialised so as to use helpers.