### PR TITLE
fix single character search bug

### DIFF
--- a/app/services/group_search.rb
+++ b/app/services/group_search.rb
@@ -12,7 +12,7 @@ class GroupSearch
   private
 
   def words query
-    query.gsub(/\W/, ' ').split.select { |x| x.length > 1 }
+    query.gsub(/\W/, ' ').split.select(&:present?)
   end
 
   def exact_matches


### PR DESCRIPTION
search on a single character was raising a 500
error via the Group search code.