### PR TITLE
apply an upper limit to number of csv records

### DIFF
--- a/app/services/person_csv_importer.rb
+++ b/app/services/person_csv_importer.rb
@@ -83,7 +83,27 @@ class PersonCsvImporter
     too_many_columns_error + missing_column_errors + unrecognized_column_errors
   end
 
+  def too_many_rows_error
+    if too_many_rows?
+      [ErrorRow.new('-', '-', ["Too many rows - a maximum of #{max_row_upload} rows can be processed"])]
+    else
+      []
+    end
+  end
+
+  def max_row_upload
+    150
+  end
+
+  def too_many_rows?
+    people.size > max_row_upload
+  end
+
   def row_errors
+    too_many_rows_error + people_record_errors
+  end
+
+  def people_record_errors
     people.zip(records).map do |person, record|
       if person.valid?
         nil


### PR DESCRIPTION
There is a 14 second unicorn config timeout on the server
which if hit will result in a partial upload success. This
will set a modifiable limit to prevent this situation arising
but is a precursor to increasing the timeout and eventually
running data creation aspect as an asynchronous job.