### PR TITLE
Change import to delayed job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -155,6 +155,10 @@ Style/ZeroLengthPredicate:
   Exclude:
     - 'Gemfile'
 
+Style/ColonMethodCall:
+  Enabled: false
+
+
 RSpec/NotToNot:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -155,10 +155,6 @@ Style/ZeroLengthPredicate:
   Exclude:
     - 'Gemfile'
 
-Style/ColonMethodCall:
-  Enabled: false
-
-
 RSpec/NotToNot:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,15 +57,14 @@ group :development do
   gem 'foreman'
   gem 'mailcatcher'
   gem 'spring-commands-rspec'
-  gem 'guard-rspec', require: false
   gem 'rb-fsevent', require: RUBY_PLATFORM[/darwin/i].to_s.size > 0
   gem 'meta_request'
   gem 'better_errors'
+  gem 'daemon' # for delayed job process manangement
 end
 
 group :test do
   gem 'codeclimate-test-reporter', require: nil
-  gem 'fuubar'
   gem 'database_cleaner'
   gem 'site_prism'
 end
@@ -80,15 +79,16 @@ group :development, :test do
   gem 'poltergeist'
   gem 'pry-rails'
   gem 'pry-byebug'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '>= 3.4'
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'simplecov-rcov'
   gem 'timecop'
-  gem 'jasmine-rails'
   gem 'guard-jasmine'
-  gem 'guard-rubocop', require: false
+  gem 'jasmine-rails'
+  gem 'rubocop'
   gem 'rubocop-rspec'
+  gem 'rspec-activejob'
   gem 'annotate'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'rb-fsevent', require: RUBY_PLATFORM[/darwin/i].to_s.size > 0
   gem 'meta_request'
+  gem 'better_errors'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group :development do
   gem 'rb-fsevent', require: RUBY_PLATFORM[/darwin/i].to_s.size > 0
   gem 'meta_request'
   gem 'better_errors'
-  gem 'daemon' # for delayed job process manangement
+  gem 'daemon'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
     coffee-script-source (1.9.1.1)
     css_parser (1.3.6)
       addressable
+    daemon (1.2.0)
     daemons (1.1.9)
     database_cleaner (1.5.1)
     delayed_job_active_record (4.1.0)
@@ -267,9 +268,6 @@ GEM
     formatador (0.2.5)
     friendly_id (5.0.5)
       activerecord (>= 4.0.0)
-    fuubar (2.0.0)
-      rspec (~> 3.0)
-      ruby-progressbar (~> 1.4)
     git-version-bump (0.15.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -301,13 +299,6 @@ GEM
       multi_json (~> 1.1)
       thor (~> 0.19)
       tilt
-    guard-rspec (4.6.4)
-      guard (~> 2.1)
-      guard-compat (~> 1.1)
-      rspec (>= 2.99.0, < 4.0)
-    guard-rubocop (1.2.0)
-      guard (~> 2.0)
-      rubocop (~> 0.20)
     haml (4.0.7)
       tilt
     haml-rails (0.9.0)
@@ -488,27 +479,26 @@ GEM
     recipient_interceptor (0.1.2)
       mail
     request_store (1.1.0)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    rspec-activejob (0.6.1)
+      activejob (>= 4.2)
+      rspec-mocks
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-rails (3.3.3)
+      rspec-support (~> 3.4.0)
+    rspec-rails (3.4.2)
       actionpack (>= 3.0, < 4.3)
       activesupport (>= 3.0, < 4.3)
       railties (>= 3.0, < 4.3)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     rubocop (0.37.2)
       parser (>= 2.3.0.4, < 3.0)
       powerpack (~> 0.1)
@@ -623,6 +613,7 @@ DEPENDENCIES
   carrierwave-bombshelter
   codeclimate-test-reporter
   coffee-rails
+  daemon
   database_cleaner
   delayed_job!
   delayed_job_active_record
@@ -634,13 +625,10 @@ DEPENDENCIES
   fog
   foreman
   friendly_id (~> 5.0.0)
-  fuubar
   govspeak
   govuk_frontend_toolkit
   govuk_template
   guard-jasmine
-  guard-rspec
-  guard-rubocop
   haml-rails
   jasmine-rails
   jbuilder (~> 2.0)
@@ -666,7 +654,9 @@ DEPENDENCIES
   rails (~> 4.2.4)
   rb-fsevent
   recipient_interceptor (~> 0.1.2)
-  rspec-rails
+  rspec-activejob
+  rspec-rails (>= 3.4)
+  rubocop
   rubocop-rspec
   sass-rails (~> 4.0.3)
   sentry-raven!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,10 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     brakeman (3.2.1)
       erubis (~> 2.6)
       haml (>= 3.0, < 5.0)
@@ -611,6 +615,7 @@ DEPENDENCIES
   ancestry (~> 2.1)
   annotate
   awesome_print
+  better_errors
   brakeman
   byebug
   capybara

--- a/app/controllers/admin/person_uploads_controller.rb
+++ b/app/controllers/admin/person_uploads_controller.rb
@@ -5,7 +5,7 @@ module Admin
     end
 
     def create
-      @upload = PersonUpload.new(filtered_params)
+      @upload = PersonUpload.new(person_upload_params)
       if @upload.save
         notice :upload_succeeded, count: @upload.import_count
         redirect_to action: :new
@@ -17,7 +17,7 @@ module Admin
 
     private
 
-    def filtered_params
+    def person_upload_params
       params.require(:person_upload).permit(:group_id, :file)
     end
   end

--- a/app/jobs/person_import_job.rb
+++ b/app/jobs/person_import_job.rb
@@ -5,9 +5,11 @@ class PersonImportJob < ActiveJob::Base
   #
   # The creation of people as initiated by the CSV uploader
   # '/admin/person_uploads/new', may exceed server timeout
-  # limits (set by WEB_TIMEOUT,RACK_TIMEOUT) and so needs
-  # to be performed asynchronously
+  # limits (set by WEB_TIMEOUT,RACK_TIMEOUT, 14 secs currently)
+  # and so needs to be performed asynchronously
   #
+
+  queue_as :person_import
 
   def perform(serialized_people, serialized_group_ids)
     @serialized_people = serialized_people
@@ -15,11 +17,8 @@ class PersonImportJob < ActiveJob::Base
     people.each do |person|
       PersonCreator.new(person, nil).create!
     end
-    people.length
-  end
 
-  def queue_name
-    'person_import'
+    people.length
   end
 
   def max_attempts
@@ -43,12 +42,8 @@ class PersonImportJob < ActiveJob::Base
   def people
     records = PersonCsvParser.new(@serialized_people).records
     @people ||= records.map do |record|
-      Person.new(creation_options.merge(clean_fields(record.fields)))
+      Person.new(creation_options.merge(PersonCsvImporter.clean_fields(record.fields)))
     end
-  end
-
-  def clean_fields(hash)
-    hash.merge(email: EmailExtractor.new.extract(hash[:email]))
   end
 
 end

--- a/app/jobs/person_import_job.rb
+++ b/app/jobs/person_import_job.rb
@@ -1,0 +1,52 @@
+class PersonImportJob < ActiveJob::Base
+
+  #
+  # The creation of people as initiated by the CSV uploader
+  # '/admin/person_uploads/new', may exceed server timeout
+  # limits (set by WEB_TIMEOUT,RACK_TIMEOUT) and so needs
+  # to be performed asynchronously
+  #
+
+  queue_as :high_priority
+
+  def queue_name
+    'person_import'
+  end
+
+  attr_reader :serialized_people
+
+  def perform(serialized_people, creation_options={})
+    @serialized_people = serialized_people
+    @creation_options = creation_options
+    people.each do |person|
+      PersonCreator.new(person, nil).create!
+    end
+    people.length
+  end
+
+  def max_run_time
+    20.minutes
+  end
+
+  def max_attempts
+    3
+  end
+
+  def destroy_failed_jobs?
+    false
+  end
+
+private
+
+  def people
+    records = PersonCsvParser.new(serialized_people).records
+    @people ||= records.map do |record|
+      Person.new(@creation_options.merge(clean_fields(record.fields)))
+    end
+  end
+
+  def clean_fields(hash)
+    hash.merge(email: EmailExtractor.new.extract(hash[:email]))
+  end
+
+end

--- a/app/services/person_creator.rb
+++ b/app/services/person_creator.rb
@@ -13,6 +13,7 @@ class PersonCreator
   end
 
   def create!
+    Rails.logger.info "Creating new person with email #{person.email}"
     person.save!
     send_create_email!
   end

--- a/app/services/person_csv_importer.rb
+++ b/app/services/person_csv_importer.rb
@@ -44,17 +44,17 @@ class PersonCsvImporter
     Group.where(id: group_ids)
   end
 
+  def self.clean_fields(hash)
+    hash.merge(email: EmailExtractor.new.extract(hash[:email]))
+  end
+
   private
 
   def_delegators :@parser, :records, :header
 
-  def clean_fields(hash)
-    hash.merge(email: EmailExtractor.new.extract(hash[:email]))
-  end
-
   def people
     @people ||= records.map do |record|
-      Person.new(@creation_options.merge(clean_fields(record.fields)))
+      Person.new(@creation_options.merge(self.class.clean_fields(record.fields)))
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require File.expand_path('../../config/initializers/host_env.rb', __FILE__)
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -44,6 +45,7 @@ module Peoplefinder
     }
 
     config.active_job.queue_adapter = :delayed_job
+    config.active_job.queue_name_prefix = Rails.host.env
 
     config.active_record.raise_in_transactional_callbacks = true
     config.active_record.schema_format = :sql
@@ -62,8 +64,8 @@ module Peoplefinder
 
     config.action_mailer.asset_host = ENV['ACTION_MAILER_DEFAULT_URL']
 
-    # Note: ENV is set to 'staging' on staging environment
-    config.send_reminder_emails = (ENV['ENV'] == 'production')
+    # Note: ENV is set to 'dev','staging','production' on dev,staging, production respectively
+    config.send_reminder_emails = Rails.host.production?
 
     # The following values are required by the phase banner
     config.phase = 'live'

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
-require File.expand_path('../../config/initializers/host_env.rb', __FILE__)
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -45,7 +44,6 @@ module Peoplefinder
     }
 
     config.active_job.queue_adapter = :delayed_job
-    config.active_job.queue_name_prefix = Rails.host.env
 
     config.active_record.raise_in_transactional_callbacks = true
     config.active_record.schema_format = :sql
@@ -65,7 +63,7 @@ module Peoplefinder
     config.action_mailer.asset_host = ENV['ACTION_MAILER_DEFAULT_URL']
 
     # Note: ENV is set to 'dev','staging','production' on dev,staging, production respectively
-    config.send_reminder_emails = Rails.host.production?
+    config.send_reminder_emails = (ENV['ENV'] == 'production')
 
     # The following values are required by the phase banner
     config.phase = 'live'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,4 +14,5 @@ Rails.application.configure do
     host: 'www.example.com',
     protocol: 'http'
   }
+  config.active_job.queue_adapter = :test
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -3,3 +3,5 @@ Delayed::Worker.queue_attributes = [
   { name: :mailers, priority: 0 },
   { name: :low_priority, priority: 10 }, # higher number = lower priority
 ]
+
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -2,6 +2,7 @@ Delayed::Worker.queue_attributes = [
   { name: :high_priority, priority: -10 }, # lower number = higher priority
   { name: :mailers, priority: 0 },
   { name: :low_priority, priority: 10 }, # higher number = lower priority
+  { name: :person_import, priority: -11 }
 ]
 
-Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log')) if Rails.env.development?

--- a/spec/features/csv_upload_spec.rb
+++ b/spec/features/csv_upload_spec.rb
@@ -45,6 +45,7 @@ feature 'Upload CSV' do
       tom.mason-buggs@digital.justice.gov.uk
     ).each do |email|
       person = Person.find_by(email: email)
+      expect(person.groups).to eq([group])
       expect(person.location).to eq "Room 5.02, 5th Floor, Blue Core, 102, Petty France, London"
       check_new_user_notification_email(email)
     end

--- a/spec/jobs/person_import_job_spec.rb
+++ b/spec/jobs/person_import_job_spec.rb
@@ -21,12 +21,13 @@ RSpec.describe PersonImportJob, type: :job do
 
   subject(:perform_later) { described_class.perform_later(serialized_people, serialized_group_ids) }
   subject(:perform_now)   { described_class.perform_now(serialized_people, serialized_group_ids) }
+  subject(:job) { described_class.new }
 
   it "enqueues with appropriate config settings" do
-    expect(described_class.new.queue_name).to eq 'person_import'
-    expect(described_class.new.max_run_time).to eq 10.minutes
-    expect(described_class.new.max_attempts).to eq 3
-    expect(described_class.new.destroy_failed_jobs?).to eq false
+    expect(job.queue_name).to eq 'person_import'
+    expect(job.max_run_time).to eq 10.minutes
+    expect(job.max_attempts).to eq 3
+    expect(job.destroy_failed_jobs?).to eq false
   end
 
   it 'enqueues job with expected arguments' do

--- a/spec/jobs/person_import_job_spec.rb
+++ b/spec/jobs/person_import_job_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe PersonImportJob, type: :job do
+
+  before(:each) do
+    allow(PermittedDomain).to receive(:pluck).with(:domain).and_return(['valid.gov.uk'])
+  end
+
+  let(:group) { create(:group) }
+
+  let(:serialized_people) do
+    <<-CSV.strip_heredoc
+      email,given_name,surname
+      peter.bly@valid.gov.uk,Peter,Bly
+      jon.o.carey@valid.gov.uk,Jon,O'Carey
+      "Jerde, Lelah (Lelah.Jerde@valid.gov.uk)",Lelah,Jerde
+    CSV
+  end
+
+  let(:serialized_group_ids) { YAML.dump([group.id]) }
+
+  subject(:perform_later) { described_class.perform_later(serialized_people, serialized_group_ids) }
+  subject(:perform_now)   { described_class.perform_now(serialized_people, serialized_group_ids) }
+
+  it "enqueues with appropriate config settings" do
+    expect(described_class.new.queue_name).to eq 'person_import'
+    expect(described_class.new.max_run_time).to eq 10.minutes
+    expect(described_class.new.max_attempts).to eq 3
+    expect(described_class.new.destroy_failed_jobs?).to eq false
+  end
+
+  it 'enqueues job with expected arguments' do
+    expect do
+      perform_later
+    end.to have_enqueued_job(described_class).with(serialized_people, serialized_group_ids)
+  end
+
+  it 'enqueues on named queue' do
+    expect do
+      perform_later
+    end.to have_enqueued_job(described_class).on_queue('person_import')
+  end
+
+  context 'when performed' do
+
+    context 'now' do
+      it 'uses the PersonCreator' do
+        expect(PersonCreator).to receive(:new).
+          with(instance_of(Person), nil).thrice.and_call_original
+        perform_now
+      end
+
+      it 'creates new people from the seralized data' do
+        perform_now
+        expect(Person.pluck(:email)).to include('peter.bly@valid.gov.uk', 'jon.o.carey@valid.gov.uk')
+      end
+
+      it 'cleans people\'s email addresses' do
+        perform_now
+        expect(Person.pluck(:given_name, :surname, :email)).to include ['Lelah', 'Jerde', 'lelah.jerde@valid.gov.uk']
+      end
+
+      it 'creates people as members of a group' do
+        perform_now
+        expect(Person.first.groups.map(&:slug)).to include group.slug
+      end
+
+      it 'returns the number of imported records' do
+        expect(perform_now).to eql 3
+      end
+
+      context 'with optional headers' do
+        let(:serialized_people) do
+          <<-END.strip_heredoc
+            given_name,surname,email,primary_phone_number,building,location_in_building,city
+            Tom,O'Carey,tom.o.carey@valid.gov.uk
+            Tom,Mason-Buggs,tom.mason-buggs@valid.gov.uk,020 7947 6743,"102, Petty France","Room 5.02, 5th Floor, Orange Core","London, England"
+          END
+        end
+        it 'creates records with and without optional fields' do
+          expect { perform_now }.to change(Person, :count).by 2
+          expect(Person.pluck(:email)).to match_array ['tom.o.carey@valid.gov.uk', 'tom.mason-buggs@valid.gov.uk']
+          expect(Person.pluck(:location_in_building)).to include 'Room 5.02, 5th Floor, Orange Core'
+        end
+      end
+    end
+  end
+
+end

--- a/spec/services/person_creator_spec.rb
+++ b/spec/services/person_creator_spec.rb
@@ -1,10 +1,10 @@
-require 'spec_helper'
-require 'person_creator'
+require 'rails_helper'
 
 RSpec.describe PersonCreator, type: :service do
   let(:person) do
     double(
       'Person',
+      email: 'example.user.1@digital.justice.gov.uk',
       save!: true,
       new_record?: false,
       notify_of_change?: false

--- a/spec/services/person_csv_importer_spec.rb
+++ b/spec/services/person_csv_importer_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe PersonCsvImporter, type: :service do
         CSV
       end
 
-      let(:serialized_group_ids) { YAML::dump([group.id]) }
+      let(:serialized_group_ids) { YAML.dump([group.id]) }
 
       it 'calls PersonImportJob' do
         expect(class_double('PersonImportJob').as_stubbed_const).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'rspec/active_job'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -12,4 +14,12 @@ RSpec.configure do |config|
   config.order = :random
 
   Kernel.srand config.seed
+
+  config.include(RSpec::ActiveJob)
+
+  # clean out the queue after each spec
+  config.after(:each) do
+    ActiveJob::Base.queue_adapter.enqueued_jobs = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+  end
 end


### PR DESCRIPTION
Import people using an asynchronous/background job. This is required because anymore than ~200 records per CSV file will cause a server timeout on any of the environments - see RACK_TIMEOUT and WEB_TIMEOUT env vars