### PR TITLE
ensure person import job checks existing people

### DIFF
--- a/app/services/person_creator.rb
+++ b/app/services/person_creator.rb
@@ -13,7 +13,6 @@ class PersonCreator
   end
 
   def create!
-    Rails.logger.info "Creating new person with email #{person.email}"
     person.save!
     send_create_email!
   end

--- a/spec/jobs/person_import_job_spec.rb
+++ b/spec/jobs/person_import_job_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe PersonImportJob, type: :job do
         perform_now
       end
 
+      # to avoid job retry and multi-worker instance errors
+      it 'double-checks person does not already exist' do
+        expect(Person).to receive(:find_by).thrice
+        perform_now
+      end
+
       it 'creates new people from the seralized data' do
         perform_now
         expect(Person.pluck(:email)).to include('peter.bly@valid.gov.uk', 'jon.o.carey@valid.gov.uk')


### PR DESCRIPTION
If job fails part way through we do not want subsequent attempts
to create people already created as this hides the original error.
This problem can also be encountered by multiple work instances
executing the job simultaneously.