### PR TITLE
display error message for non-permitted domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ token authentication method relies upon the users access to their email
 account to authenticate them.
 
 Each time the user wishes to start a session, they need to generate an
-authentication token. This can be done by entering their email address on the
-login screen. They will be sent an email message containing a link with a
-unique random token. Clicking on the link will allow them to login.
+authentication token. This can be done by entering their email address
+(from a permitted domain) on the login screen. They will be sent an email
+message containing a link with a unique random token. Clicking on the link
+will allow them to login.
+
 
 ## E-mails
 

--- a/app/services/token_sender.rb
+++ b/app/services/token_sender.rb
@@ -4,7 +4,7 @@ class TokenSender
 
   attr_reader :user_email_error
 
-  REPORT_EMAIL_ERROR_REGEXP = %r{(not formatted correctly|reached the limit)}
+  REPORT_EMAIL_ERROR_REGEXP = %r{(not formatted correctly|reached the limit|access People)}
 
   def initialize(user_email)
     @user_email = user_email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,7 +196,7 @@ en:
     models:
       token:
         invalid_address: "Email address is not formatted correctly"
-        invalid_domain: "Email address is not valid"
+        invalid_domain: "Email address can’t be used to access People Finder"
         token_throttle_limit: "You’ve reached the limit of %{limit} tokens requested within an hour"
       group:
         attributes:


### PR DESCRIPTION
The request a link method of logging in was deliberatley
not displaying non-permitted domain errors. This is
pointless since the list of domains is available from
the code repo.