### PR TITLE
prevent form submission on carriage return in text inout fields (only)

### DIFF
--- a/app/assets/javascripts/peoplefinder/application.js
+++ b/app/assets/javascripts/peoplefinder/application.js
@@ -19,3 +19,15 @@
 //= require_tree .
 //= require bind
 //= require selection-buttons
+
+(function() {
+
+  // Prevent form submission caused by pressing 'Enter' key in text fields
+  // NOTE: we still want buttons and textareas to respond to CR/NL as expected
+  $('input:text').on('keypress', function(e) {
+    if (e.keyCode === 13) {
+      return false;
+    }
+  });
+
+}());

--- a/spec/javascripts/peoplefinder/team_selector_spec.js
+++ b/spec/javascripts/peoplefinder/team_selector_spec.js
@@ -69,7 +69,7 @@ describe("Team Selector", function() {
         last = obj.find('.visible').last().html();
       expect(el).toEqual(last);
     });
-    describe("should set '.exapnded' class", function(){
+    describe("should set '.expanded' class", function(){
       beforeEach(function(){
         ts.setExpanded();
       });


### PR DESCRIPTION
hitting 'Enter' (carriage return) in input text fields
defaults to submission of form. This can lead to premature
submission of group and person forms and negatively impact
user experience.

Note that text areas and buttons should still respond to
carriage returns for accessibility and functionality purposes