### PR TITLE
ensure search form field carriage return submits

### DIFF
--- a/app/assets/javascripts/peoplefinder/application.js
+++ b/app/assets/javascripts/peoplefinder/application.js
@@ -23,8 +23,8 @@
 (function() {
 
   // Prevent form submission caused by pressing 'Enter' key in text fields
-  // NOTE: we still want buttons and textareas to respond to CR/NL as expected
-  $('input:text').on('keypress', function(e) {
+  // NOTE: we still want buttons and textareas to respond to CR/NL as expected and the search form
+  $('.new_person input:text, .edit_person input:text, .new_group input:text, .edit_group input:text').on('keypress', function(e) {
     if (e.keyCode === 13) {
       return false;
     }


### PR DESCRIPTION
search form field Enter key press 

- default behaviour was deactivated by generic
deactivating of carriage return in previous
commit.