### PR TITLE
Add pager number

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -101,7 +101,8 @@ class PeopleController < ApplicationController
   def person_shared_params_list
     [
       :given_name, :surname, :location_in_building, :building, :city,
-      :primary_phone_number, :secondary_phone_number, :email, :secondary_email,
+      :primary_phone_number, :secondary_phone_number, :pager_number,
+      :email, :secondary_email,
       :profile_photo_id, :crop_x, :crop_y, :crop_w, :crop_h,
       :description, :current_project,
       *Person::DAYS_WORKED,

--- a/app/services/random_generator.rb
+++ b/app/services/random_generator.rb
@@ -70,6 +70,7 @@ class RandomGenerator
       email: "#{given_name}.#{surname}@#{@domain}",
       primary_phone_number: Faker::PhoneNumber.phone_number,
       secondary_phone_number: Faker::PhoneNumber.phone_number,
+      pager_number: [Faker::PhoneNumber.phone_number, nil].sample,
       description: Faker::Lorem.sentence
     }
   end
@@ -93,4 +94,5 @@ class RandomGenerator
       city: Faker::Address.city
     }
   end
+
 end

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -38,6 +38,9 @@
         = f.form_group :secondary_phone_number do
           = f.label :secondary_phone_number, 'Alternative phone number', class: 'form-label-bold'
           = f.text_field :secondary_phone_number, class: 'form-control'
+        = f.form_group :pager_number do
+          = f.label :pager_number, 'Pager number', class: 'form-label-bold'
+          = f.text_field :pager_number, class: 'form-control'
 
       .emails
         = f.form_group :email do

--- a/app/views/people/_profile.html.haml
+++ b/app/views/people/_profile.html.haml
@@ -58,6 +58,10 @@
           %dt Other phone number
           %dd= call_to(@person.secondary_phone_number)
 
+        - if @person.pager_number.present?
+          %dt Pager number
+          %dd= call_to(@person.pager_number)
+
       %dl.inline-labels
         - if @person.current_project.present?
           %dt Current project(s)

--- a/app/views/people/confirm.html.haml
+++ b/app/views/people/confirm.html.haml
@@ -22,6 +22,7 @@
     = f.hidden_field :city
     = f.hidden_field :primary_phone_number
     = f.hidden_field :secondary_phone_number
+    = f.hidden_field :pager_number
     = f.hidden_field :email
     = f.hidden_field :secondary_email
     = f.hidden_field :description

--- a/app/views/reminder_mailer/person_profile_update.html.haml
+++ b/app/views/reminder_mailer/person_profile_update.html.haml
@@ -57,6 +57,10 @@
                     %dt Other phone number
                     %dd= @person.secondary_phone_number
 
+                  - if @person.pager_number.present?
+                    %dt Pager number
+                    %dd= @person.pager_number
+
                   %dt Current project(s)
                   %dd= @person.current_project.presence || '-'
 

--- a/db/migrate/20160719084601_add_pager_number_to_people.rb
+++ b/db/migrate/20160719084601_add_pager_number_to_people.rb
@@ -1,0 +1,5 @@
+class AddPagerNumberToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :pager_number, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -191,7 +191,8 @@ CREATE TABLE people (
     secondary_email text,
     profile_photo_id integer,
     last_reminder_email_at timestamp without time zone,
-    current_project character varying
+    current_project character varying,
+    pager_number text
 );
 
 
@@ -629,4 +630,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160411134824');
 INSERT INTO schema_migrations (version) VALUES ('20160418124145');
 
 INSERT INTO schema_migrations (version) VALUES ('20160419131143');
+
+INSERT INTO schema_migrations (version) VALUES ('20160719084601');
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Person, type: :model do
   it { should validate_uniqueness_of(:email).case_insensitive }
   it { should have_many(:groups) }
 
+  it { should respond_to(:pager_number) }
+
   describe '.email' do
     it 'is converted to lower case' do
       person = create(:person, email: 'User.Example@digital.justice.gov.uk')

--- a/spec/support/profile.rb
+++ b/spec/support/profile.rb
@@ -7,6 +7,7 @@ module SpecSupport
         email: 'marco.polo@digital.justice.gov.uk',
         primary_phone_number: '+44-208-123-4567',
         secondary_phone_number: '07777777777',
+        pager_number: '07666666666',
         location_in_building: '10.999',
         building: '102 Petty France',
         city: 'London',
@@ -32,6 +33,7 @@ module SpecSupport
       fill_in 'Main email', with: person_attributes[:email]
       fill_in 'Main phone number', with: person_attributes[:primary_phone_number]
       fill_in 'Alternative phone number', with: person_attributes[:secondary_phone_number]
+      fill_in 'Pager number', with: person_attributes[:pager_number]
       fill_in 'Location in building', with: person_attributes[:location_in_building]
       fill_in 'Building', with: person_attributes[:building]
       fill_in 'City', with: person_attributes[:city]
@@ -49,6 +51,7 @@ module SpecSupport
       expect(page).to have_text(person_attributes[:email])
       expect(page).to have_text(person_attributes[:primary_phone_number])
       expect(page).to have_text(person_attributes[:secondary_phone_number])
+      expect(page).to have_text(person_attributes[:pager_number])
       expect(page).to have_text(person_attributes[:location_in_building])
       expect(page).to have_text(person_attributes[:building])
       expect(page).to have_text(person_attributes[:city])


### PR DESCRIPTION
For onboarding of NOMS generally and HMPS specifically it is useful to have a pager number field
as this is a common form of communication for the users.