### PR TITLE
add pager number to incorrect suggestion mailer

### DIFF
--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -22,6 +22,7 @@ class Suggestion
     location_of_work
     working_days
     phone_number
+    pager_number
     image
   ).freeze
 

--- a/app/views/suggestions/new.html.haml
+++ b/app/views/suggestions/new.html.haml
@@ -53,6 +53,10 @@
         =f.label :incorrect_phone_number, 'Phone number'
 
       .form-group
+        =f.check_box :incorrect_pager_number
+        =f.label :incorrect_pager_number, 'Pager number'
+
+      .form-group
         =f.check_box :incorrect_image
         =f.label :incorrect_image, 'Profile image'
       &nbsp;

--- a/spec/models/suggestion_spec.rb
+++ b/spec/models/suggestion_spec.rb
@@ -50,14 +50,12 @@ RSpec.describe Suggestion, type: :model do
   end
 
   describe '#incorrect_fields_info' do
+    let(:fields) { %w( first_name last_name roles location_of_work working_days phone_number pager_number image ) }
     let(:suggestion) do
-      described_class.new(
-        incorrect_first_name: true,
-        incorrect_location_of_work: true
-      )
+      incorrect_fields = fields.each_with_object({}) { |v, h| h["incorrect_#{v}".to_sym] = true }
+      described_class.new(incorrect_fields)
     end
-
-    let(:expected_incorrect_fields) { ['First name', 'Location of work'] }
+    let(:expected_incorrect_fields) { fields.map(&:humanize) }
 
     it 'lists names of incorrect fields' do
       expect(suggestion.incorrect_fields_info).to eql expected_incorrect_fields


### PR DESCRIPTION
allow users to suggestion pager number corrections. with a predicated increased uptake of users requiring pager numbers this is likely to be useful.