### PR TITLE
add new 365 rollout domain access

### DIFF
--- a/db/seeds/data/permitted_domains.yml
+++ b/db/seeds/data/permitted_domains.yml
@@ -16,6 +16,7 @@
 - jac.gsi.gov.uk
 - jaco.gsi.gov.uk
 - judiciary.gsi.gov.uk
+- justice.gov.uk
 - justice.gsi.gov.uk
 - lawcommission.gsi.gov.uk
 - legalaid.gsi.gov.uk


### PR DESCRIPTION
As part of 365 rollout a new email address domain is to be used
and will therefore need access to peoplefinder.