### PR TITLE
render group search case-insensitive

### DIFF
--- a/app/services/group_search.rb
+++ b/app/services/group_search.rb
@@ -20,7 +20,7 @@ class GroupSearch
   end
 
   def exact_matches
-    results = Group.where('name = ? OR acronym = ?', @query, @query)
+    results = Group.where('lower(name) = :query OR lower(acronym) = :query', query: @query.downcase)
     @exact_match_found = results.present?
     hierarchy_ordered results
   end

--- a/spec/services/group_search_spec.rb
+++ b/spec/services/group_search_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe GroupSearch, elastic: true do
       expect(exact_match).to eq true
     end
 
+    it 'exact matches are case-insensitive' do
+      _results, exact_match = search('team name')
+      expect(exact_match).to eq true
+    end
+
     it 'returns exact_match as false if there is NOT a group with exact name or acronym' do
       _results, exact_match = search('Team name not')
       expect(exact_match).to eq false


### PR DESCRIPTION
The team/group search was returning exact team name matches
as "similar" results based on case alone.
e.g. ministry of magic was only considered similar to Ministry of Magic