### PR TITLE
re-adds the @query variable as required by views

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,6 +3,7 @@ class SearchController < ApplicationController
   helper_method :matches_exist?
 
   def index
+    @query = query
     @team_results = search(GroupSearch)
     @people_results = search(PersonSearch)
   end
@@ -10,7 +11,7 @@ class SearchController < ApplicationController
   private
 
   def search(klass)
-    search = klass.new(query, SearchResults.new)
+    search = klass.new(@query, SearchResults.new)
     search.perform_search
   end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe SearchController, type: :controller do
       expect(controller).to receive(:matches_exist?)
       subject
     end
+
+    it 'assigns @query for use in view' do
+      subject
+      expect(assigns(:team_results)).to eq(team_results)
+    end
   end
 
   describe 'GET #index' do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -38,6 +38,9 @@ feature 'Searching feature', elastic: true do
       within('.pagination') do
         expect(page).to have_text(/\d+ result(s)? found/)
       end
+      within('.search-box') do
+        expect(page).to have_selector("input[value='Browne']")
+      end
       expect(page).to have_text('Jon Browne')
       expect(page).to have_text('jon.browne@digital.justice.gov.uk')
       expect(page).to have_text('0711111111')


### PR DESCRIPTION
This var had been removed in a previous refactor and meant the search results did not show
the original query