### PR TITLE
copy entire app prior to assets:precompile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,16 +59,8 @@ COPY Gemfile.lock /usr/src/app/
 
 RUN bundle install
 
-# Copy files for assets precompile
-COPY config/application.rb config/boot.rb config/environment.rb config/database.yml /usr/src/app/config/
-COPY config/environments/assets.rb /usr/src/app/config/environments/
-COPY config/initializers/assets.rb /usr/src/app/config/initializers/
-COPY app/assets/ /usr/src/app/app/assets/
-COPY vendor/assets/ /usr/src/app/vendor/assets/
-COPY Rakefile /usr/src/app/
+COPY . /usr/src/app
 
 RUN bundle exec rake assets:precompile RAILS_ENV=assets SUPPORT_EMAIL=''
-
-COPY . /usr/src/app
 
 ENTRYPOINT ["./run.sh"]


### PR DESCRIPTION
previous dockerfile was copying only specific asset
files to app prior to precompile but this
meant changes to precompile file locations
(e.g. addition of initializers/assets.rb) were not
being picked up if dockerfile was not amended inline
with those changes.