### PR TITLE
prevent unnecessary Group completion score updates from bulk upload

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,9 +13,10 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 122
+  Max: 123
   Exclude:
     - 'app/controllers/people_controller.rb'
+    - 'app/models/person.rb'
 
 
 # Offense count: 259

--- a/app/jobs/update_group_members_completion_score_job.rb
+++ b/app/jobs/update_group_members_completion_score_job.rb
@@ -1,4 +1,5 @@
 class UpdateGroupMembersCompletionScoreJob < ActiveJob::Base
+
   queue_as :low_priority
 
   def perform(group)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,6 +4,7 @@ class Person < ActiveRecord::Base
   include Concerns::Completion
   include Concerns::WorkDays
   include Concerns::ExposeMandatoryFields
+
   belongs_to :profile_photo
 
   extend FriendlyId
@@ -38,13 +39,17 @@ class Person < ActiveRecord::Base
 
   attr_accessor :crop_x, :crop_y, :crop_w, :crop_h
   after_save :crop_profile_photo
+  after_save :enqueue_update_groups_job
 
-  after_save do |person|
-    groups_prior = person.groups
-    person.reload # updates groups
-    groups_present = person.groups
+  attr_accessor :bulk_upload
+  skip_callback :save, :after, :enqueue_update_groups_job, if: :bulk_upload
 
-    (groups_prior + groups_present).uniq.each do |group|
+  def enqueue_update_groups_job
+    groups_prior = groups
+    reload # updates groups
+    groups_current = groups
+
+    (groups_prior + groups_current).uniq.each do |group|
       UpdateGroupMembersCompletionScoreJob.perform_later(group)
     end
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -39,12 +39,12 @@ class Person < ActiveRecord::Base
 
   attr_accessor :crop_x, :crop_y, :crop_w, :crop_h
   after_save :crop_profile_photo
-  after_save :enqueue_update_groups_job
+  after_save :enqueue_group_completion_score_updates
 
-  attr_accessor :bulk_upload
-  skip_callback :save, :after, :enqueue_update_groups_job, if: :bulk_upload
+  attr_accessor :skip_group_completion_score_updates
+  skip_callback :save, :after, :enqueue_group_completion_score_updates, if: :skip_group_completion_score_updates
 
-  def enqueue_update_groups_job
+  def enqueue_group_completion_score_updates
     groups_prior = groups
     reload # updates groups
     groups_current = groups

--- a/spec/jobs/person_import_job_spec.rb
+++ b/spec/jobs/person_import_job_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe PersonImportJob, type: :job do
   context 'when performed' do
 
     context 'now' do
+      # TODO
+      # it 'sets person.bulk_upload attribute to true' do
+      #   expect_any_instance_of(Person).to receive(:bulk_upload=).with(true)
+      #   perform_now
+      # end
+
       it 'uses the PersonCreator' do
         expect(PersonCreator).to receive(:new).
           with(instance_of(Person), nil).thrice.and_call_original

--- a/spec/jobs/person_import_job_spec.rb
+++ b/spec/jobs/person_import_job_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe PersonImportJob, type: :job do
     allow(PermittedDomain).to receive(:pluck).with(:domain).and_return(['valid.gov.uk'])
   end
 
-  let(:group) { create(:group) }
+  let!(:group) do
+    group = create(:group)
+    ActiveJob::Base.queue_adapter.enqueued_jobs = []
+    group
+  end
 
   let(:serialized_people) do
     <<-CSV.strip_heredoc
@@ -45,11 +49,6 @@ RSpec.describe PersonImportJob, type: :job do
   context 'when performed' do
 
     context 'now' do
-      # TODO
-      # it 'sets person.bulk_upload attribute to true' do
-      #   expect_any_instance_of(Person).to receive(:bulk_upload=).with(true)
-      #   perform_now
-      # end
 
       it 'uses the PersonCreator' do
         expect(PersonCreator).to receive(:new).
@@ -63,7 +62,7 @@ RSpec.describe PersonImportJob, type: :job do
         perform_now
       end
 
-      it 'creates new people from the seralized data' do
+      it 'creates new people from the serialized data' do
         perform_now
         expect(Person.pluck(:email)).to include('peter.bly@valid.gov.uk', 'jon.o.carey@valid.gov.uk')
       end
@@ -80,6 +79,10 @@ RSpec.describe PersonImportJob, type: :job do
 
       it 'returns the number of imported records' do
         expect(perform_now).to eql 3
+      end
+
+      it 'enqeues group completion score updates job for the group, not for the individual people' do
+        expect { perform_now }.to have_enqueued_job(UpdateGroupMembersCompletionScoreJob)
       end
 
       context 'with optional headers' do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Person, type: :model do
   it { should have_many(:groups) }
 
   it { should respond_to(:pager_number) }
+  it { should respond_to(:bulk_upload) }
 
   describe '.email' do
     it 'is converted to lower case' do
@@ -368,6 +369,19 @@ RSpec.describe Person, type: :model do
     it 'is false when last_reminder_email_at is 31 days ago' do
       person.last_reminder_email_at = Time.now - 31.days
       expect(person.reminder_email_sent?(within: 30.days)).to be false
+    end
+  end
+
+  describe '#bulk_upload' do
+    before do
+      digital_services = create(:group, name: 'Digital Services')
+      person.memberships.build(group: digital_services)
+      person.bulk_upload = true
+    end
+
+    it 'prevents enqueuing of group completion score update job' do
+      expect(UpdateGroupMembersCompletionScoreJob).not_to receive(:perform_later)
+      person.save
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Person, type: :model do
   it { should have_many(:groups) }
 
   it { should respond_to(:pager_number) }
-  it { should respond_to(:bulk_upload) }
+  it { should respond_to(:skip_group_completion_score_updates) }
 
   describe '.email' do
     it 'is converted to lower case' do
@@ -372,14 +372,14 @@ RSpec.describe Person, type: :model do
     end
   end
 
-  describe '#bulk_upload' do
+  describe '#skip_group_completion_score_updates' do
     before do
       digital_services = create(:group, name: 'Digital Services')
       person.memberships.build(group: digital_services)
-      person.bulk_upload = true
+      person.skip_group_completion_score_updates = true
     end
 
-    it 'prevents enqueuing of group completion score update job' do
+    it 'prevents enqueuing of group completion score update job for bulk upload purposes' do
       expect(UpdateGroupMembersCompletionScoreJob).not_to receive(:perform_later)
       person.save
     end


### PR DESCRIPTION
bulk uploading was enqeuening thousands of low priority
updates of groupmembershipscompletion scores. It just needs
running once for the group specified by the bulk upload.