### PR TITLE
reduce the number of times the Job in question is attempted

### DIFF
--- a/app/jobs/update_group_members_completion_score_job.rb
+++ b/app/jobs/update_group_members_completion_score_job.rb
@@ -9,4 +9,8 @@ class UpdateGroupMembersCompletionScoreJob < ActiveJob::Base
       UpdateGroupMembersCompletionScoreJob.perform_later(group.parent)
     end
   end
+
+  def max_attempts
+    3
+  end
 end

--- a/spec/jobs/update_group_members_completion_score_job_spec.rb
+++ b/spec/jobs/update_group_members_completion_score_job_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe UpdateGroupMembersCompletionScoreJob, type: :job do
   let(:parent) { nil }
   let(:group) { double(parent: parent) }
 
+  context 'config' do
+    subject(:job) { described_class.new }
+    it "enqueues with appropriate config settings" do
+      expect(job.queue_name).to eq 'low_priority'
+      expect(job.max_attempts).to eq 3
+    end
+  end
+
   context 'when called' do
     before do
       allow(group).to receive(:update_members_completion_score!)


### PR DESCRIPTION
sentry errors raised as a result of a group being deleted
before background jobs to update the groups score were run,
by which time of course the group did not exist.