### PR TITLE
Add pagination to all people view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,8 @@ gem 'unicorn', '~> 4.8.3'
 gem 'useragent', '~> 0.10.0'
 gem 'virtus'
 gem 'whenever'
-gem 'will_paginate', '~> 3.0'
+gem 'will_paginate', '~> 3.0', '>=3.0.3'
+gem 'will_paginate-bootstrap', '~> 1.0', '>= 1.0.1'
 
 gem 'carrierwave',
   git: 'https://github.com/carrierwaveuploader/carrierwave.git',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -602,6 +602,8 @@ GEM
     whenever (0.9.4)
       chronic (>= 0.6.3)
     will_paginate (3.0.7)
+    will_paginate-bootstrap (1.0.1)
+      will_paginate (>= 3.0.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -681,7 +683,8 @@ DEPENDENCIES
   useragent (~> 0.10.0)
   virtus
   whenever
-  will_paginate (~> 3.0)
+  will_paginate (~> 3.0, >= 3.0.3)
+  will_paginate-bootstrap (~> 1.0, >= 1.0.1)
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/app/assets/stylesheets/peoplefinder/people.css.scss
+++ b/app/assets/stylesheets/peoplefinder/people.css.scss
@@ -339,22 +339,36 @@ form {
 }
 
 .all-people-pagination {
-  ul, li {
-    margin: 15px 0;
+  div {
+    float: left;
+    clear: none;
     display: inline;
-    border: 1px solid $border-color;
+  }
+  .page-information {
+    color: grey;
     padding: 4px 6px;
   }
-  .active {
-    background-color: $grey-bg;
-    color: grey;
+  .page-navigation {
+    /*display: inline;*/
   }
-  .disabled {
-    border: 0px;
-  }
-  .next, .prev {
-    border: 1px solid $grey-bg;
+  .page-nav-list {
+    ul, li {
+      margin: 15px 0;
+      display: inline;
+      border: 1px solid $border-color;
+      padding: 4px 6px;
+    }
+    .active {
+      background-color: $grey-bg;
+      color: grey;
+    }
     .disabled {
+      border: 0px;
+    }
+    .next, .prev {
+      border: 1px solid $grey-bg;
+      .disabled {
+      }
     }
   }
 }

--- a/app/assets/stylesheets/peoplefinder/people.css.scss
+++ b/app/assets/stylesheets/peoplefinder/people.css.scss
@@ -337,3 +337,24 @@ form {
     outline: 3px solid #ffbf47;
   }
 }
+
+.all-people-pagination {
+  ul, li {
+    margin: 15px 0;
+    display: inline;
+    border: 1px solid $border-color;
+    padding: 4px 6px;
+  }
+  .active {
+    background-color: $grey-bg;
+    color: grey;
+  }
+  .disabled {
+    border: 0px;
+  }
+  .next, .prev {
+    border: 1px solid $grey-bg;
+    .disabled {
+    }
+  }
+}

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -29,7 +29,7 @@ class GroupsController < ApplicationController
 
   # GET /teams/slug/people
   def all_people
-    @people_in_subtree = Person.all_in_subtree(@group).paginate(:page => params[:page], :per_page => 1000)
+    @people_in_subtree = Person.all_in_subtree(@group).paginate(:page => params[:page], :per_page => 500)
   end
 
   # GET /groups/new

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -27,6 +27,11 @@ class GroupsController < ApplicationController
     end
   end
 
+  # GET /teams/slug/people
+  def all_people
+    @people_in_subtree = Person.all_in_subtree(@group).paginate(:page => params[:page], :per_page => 1000)
+  end
+
   # GET /groups/new
   def new
     @group = collection.new

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -29,7 +29,7 @@ class GroupsController < ApplicationController
 
   # GET /teams/slug/people
   def all_people
-    @people_in_subtree = Person.all_in_subtree(@group).paginate(:page => params[:page], :per_page => 500)
+    @people_in_subtree = @group.all_people.paginate(page: params[:page], per_page: 500)
   end
 
   # GET /groups/new

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -76,7 +76,6 @@ class Group < ActiveRecord::Base
 
   def all_people
     Person.all_in_subtree(self)
-    # Person.all_in_groups(subtree_ids)
   end
 
   def all_people_count

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -75,7 +75,8 @@ class Group < ActiveRecord::Base
   end
 
   def all_people
-    Person.all_in_groups(subtree_ids)
+    Person.all_in_subtree(self)
+    # Person.all_in_groups(subtree_ids)
   end
 
   def all_people_count

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -97,6 +97,16 @@ class Person < ActiveRecord::Base
     where(surname: person.surname, given_name: person.given_name).where.not(id: person.id)
   end
 
+  scope :all_in_subtree, -> (group) {joins(:memberships) \
+                                      .where(memberships: { group_id: group.subtree_ids }) \
+                                      .select("people.*,
+                                              string_agg(CASE role WHEN '' THEN NULL ELSE role END, ', ' ORDER BY role) AS role_names"
+                                              ) \
+                                      .group(:id) \
+                                      .uniq
+                                     }
+
+  # last resort - should be a scope
   def self.all_in_groups(group_ids)
     query = <<-SQL
       SELECT DISTINCT p.*,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -106,7 +106,7 @@ class Person < ActiveRecord::Base
                                       .uniq
                                      }
 
-  # last resort - should be a scope
+  # last resort - see all_in_subtree scope
   def self.all_in_groups(group_ids)
     query = <<-SQL
       SELECT DISTINCT p.*,

--- a/app/views/groups/_all_people_pagination.html.haml
+++ b/app/views/groups/_all_people_pagination.html.haml
@@ -1,0 +1,6 @@
+.all-people-pagination.grid-wrapper
+  .page-information.inner-block.grid.grid-1-3
+    = page_entries_info(@people_in_subtree)
+  .page-navigation.inner-block.grid.grid-2-3
+    = will_paginate(@people_in_subtree, renderer: BootstrapPagination::Rails, class: 'page-nav-list')
+  

--- a/app/views/groups/all_people.html.haml
+++ b/app/views/groups/all_people.html.haml
@@ -2,9 +2,9 @@
   = breadcrumbs(Home.path + @group.path + ['All people'])
 
 %h1= @page_title = "People in #{ @group.name }"
-= will_paginate(@people_in_subtree, renderer: BootstrapPagination::Rails, class: 'all-people-pagination')
+= render partial: "all_people_pagination"
 
 .grid-wrapper
   = render partial: "people/summary", collection: @people_in_subtree
 
-= will_paginate(@people_in_subtree, renderer: BootstrapPagination::Rails, class: 'all-people-pagination')
+= render partial: "all_people_pagination"

--- a/app/views/groups/all_people.html.haml
+++ b/app/views/groups/all_people.html.haml
@@ -2,9 +2,9 @@
   = breadcrumbs(Home.path + @group.path + ['All people'])
 
 %h1= @page_title = "People in #{ @group.name }"
-= will_paginate @people_in_subtree
+= will_paginate(@people_in_subtree, renderer: BootstrapPagination::Rails, class: 'all-people-pagination')
 
 .grid-wrapper
   = render partial: "people/summary", collection: @people_in_subtree
 
-= will_paginate @people_in_subtree
+= will_paginate(@people_in_subtree, renderer: BootstrapPagination::Rails, class: 'all-people-pagination')

--- a/app/views/groups/all_people.html.haml
+++ b/app/views/groups/all_people.html.haml
@@ -2,5 +2,9 @@
   = breadcrumbs(Home.path + @group.path + ['All people'])
 
 %h1= @page_title = "People in #{ @group.name }"
+= will_paginate @people_in_subtree
+
 .grid-wrapper
-  = render partial: "people/summary", collection: @group.all_people
+  = render partial: "people/summary", collection: @people_in_subtree
+
+= will_paginate @people_in_subtree

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,12 @@ en:
       file: Upload CSV file
 
   will_paginate:
+    models:
+      person:
+        zero:  people
+        one:   person
+        few:   people
+        other: people
     page_entries_info:
       single_page:
         zero:  "No %{model} found"
@@ -312,12 +318,3 @@ en:
 
       multi_page: "Displaying %{model} %{from} - %{to} of %{count}"
       multi_page_html: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{count}</b>"
-
-  # needed for will_paginate at least 
-  activerecord:
-    models:
-      person:
-        zero:  people
-        one:   person
-        few:   people
-        other: people

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,3 +298,26 @@ en:
     person_uploads:
       group_id: Choose your team
       file: Upload CSV file
+
+  will_paginate:
+    page_entries_info:
+      single_page:
+        zero:  "No %{model} found"
+        one:   "Displaying 1 %{model}"
+        other: "Displaying all %{count} %{model}"
+      single_page_html:
+        zero:  "No %{model} found"
+        one:   "Displaying <b>1</b> %{model}"
+        other: "Displaying <b>all&nbsp;%{count}</b> %{model}"
+
+      multi_page: "Displaying %{model} %{from} - %{to} of %{count}"
+      multi_page_html: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{count}</b>"
+
+  # needed for will_paginate at least 
+  activerecord:
+    models:
+      person:
+        zero:  people
+        one:   person
+        few:   people
+        other: people

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -70,6 +70,35 @@ RSpec.describe GroupsController, type: :controller do
     end
   end
 
+  describe 'GET all_people' do
+    let(:group) { create(:group, valid_attributes) }
+
+    subject { get :all_people, { id: group.to_param, page: 2 }, valid_session }
+
+    it 'assigns all_people in group and subtree to @people_in_subtree' do
+      subject
+      expect(assigns(:people_in_subtree)).to be_an(Person::ActiveRecord_Relation)
+    end
+
+    it 'calls scope on Person model class' do
+      allow(Person).to receive_message_chain(:all_in_subtree, :paginate)
+      expect(Person).to receive(:all_in_subtree).with(group)
+      subject
+    end
+
+    it 'paginates to 500 people per page to avoid server timeouts' do
+      people = instance_double(Person::ActiveRecord_Relation)
+      expect_any_instance_of(Group).to receive(:all_people).and_return people
+      expect(people).to receive(:paginate).with(page: "2", per_page: 500)
+      subject
+    end
+
+    it 'assigns a group object' do
+      subject
+      expect(assigns(:group)).to be_a(Group)
+    end
+  end
+
   describe 'GET new' do
     it 'assigns a new group as @group' do
       get :new, {}, valid_session

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -72,31 +72,26 @@ RSpec.describe GroupsController, type: :controller do
 
   describe 'GET all_people' do
     let(:group) { create(:group, valid_attributes) }
+    let!(:people) { instance_double(Person::ActiveRecord_Relation) }
 
     subject { get :all_people, { id: group.to_param, page: 2 }, valid_session }
 
-    it 'assigns all_people in group and subtree to @people_in_subtree' do
-      subject
-      expect(assigns(:people_in_subtree)).to be_an(Person::ActiveRecord_Relation)
-    end
-
-    it 'calls scope on Person model class' do
-      allow(Person).to receive_message_chain(:all_in_subtree, :paginate)
-      expect(Person).to receive(:all_in_subtree).with(group)
-      subject
-    end
-
-    it 'paginates to 500 people per page to avoid server timeouts' do
-      people = instance_double(Person::ActiveRecord_Relation)
-      expect_any_instance_of(Group).to receive(:all_people).and_return people
-      expect(people).to receive(:paginate).with(page: "2", per_page: 500)
-      subject
-    end
-
-    it 'assigns a group object' do
+    it 'assigns @group to a Group instance' do
       subject
       expect(assigns(:group)).to be_a(Group)
     end
+
+    it 'assigns @people_in_subtree to a Person AR relation' do
+      subject
+      expect(assigns(:people_in_subtree)).to be_a(Person::ActiveRecord_Relation)
+    end
+
+    it 'sends all_people message to instance of group and paginates people results to 500 (to avoid server timeouts)' do
+      expect_any_instance_of(Group).to receive(:all_people).and_return people
+      expect(people).to receive(:paginate).with(page: "2", per_page: 500).and_return people
+      subject
+    end
+
   end
 
   describe 'GET new' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -172,8 +172,8 @@ RSpec.describe Group, type: :model do
         expect(team.all_people.length).to eq(1)
       end
 
-      it 'has items in all_people array that have role_names' do
-        expect(team.all_people.first.respond_to?(:role_names)).to be true
+      it 'has items in all_people Person relation that have role_names' do
+        expect(team.all_people.first).to respond_to :role_names
       end
 
       it "has all_people_count of 1" do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -65,17 +65,17 @@ RSpec.describe Group, type: :model do
   describe '.deletable?' do
     let(:group) { create(:group) }
 
-    it 'is only detable when there are no memberships' do
+    it 'is only deletable when there are no memberships' do
       group.memberships.create(person: create(:person))
       expect(group).not_to be_deletable
     end
 
-    it 'is not detable when there are memberships' do
+    it 'is not deletable when there are memberships' do
       group.memberships.create(person: create(:person))
       expect(group).not_to be_deletable
     end
 
-    it 'is not detable when there are children' do
+    it 'is not deletable when there are children' do
       create(:group, parent: group)
       expect(group.reload).not_to be_deletable
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -84,12 +84,12 @@ RSpec.describe Person, type: :model do
     let!(:team) { create(:group) }
     let!(:subteam) { create(:group, parent: team) }
 
-    it 'calls subquery scope with groups IDs of parent group and any children' do
+    it 'calls subquery scope with groups IDs of parent group and any children (a subtree)' do
       expect(described_class).to receive(:all_in_groups_from_clause).with(team.subtree_ids)
       described_class.all_in_subtree(team)
     end
 
-    it 'is chainable' do
+    it 'returns a Person::ActiveRecord_Relation' do
       expect(described_class.all_in_subtree(team).class).to be Person::ActiveRecord_Relation
     end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe '.all_in_subtree' do
+    let!(:team) { create(:group) }
+    let!(:subteam) { create(:group, parent: team) }
+
+    it 'calls subquery scope with groups IDs of parent group and any children' do
+      expect(described_class).to receive(:all_in_groups_from_clause).with(team.subtree_ids)
+      described_class.all_in_subtree(team)
+    end
+
+    it 'is chainable' do
+      expect(described_class.all_in_subtree(team).class).to be Person::ActiveRecord_Relation
+    end
+
+    it 'returns relation that includes aggregate role_names column' do
+      expect { described_class.all_in_subtree(team).pluck(:role_names) }.not_to raise_error
+    end
+
+  end
+
   describe '.all_in_groups' do
     let(:groups) { create_list(:group, 3) }
     let(:people) { create_list(:person, 3) }


### PR DESCRIPTION
the all_people view was encountering a preamture termination from the upstream unicorn server. This is almost certainly caused by 18000 profiles in a particular parent team (noms). 

This PR adds pagination to the view to prevent this issue.