### PR TITLE
prevent single non-word characters raising 500 errors

### DIFF
--- a/app/services/group_search.rb
+++ b/app/services/group_search.rb
@@ -27,6 +27,7 @@ class GroupSearch
 
   def partial_matches
     words = words(@query)
+    return if words.empty?
     results = words.inject(Group) do |search, word|
       search.where('name ILIKE ?', "%#{word}%")
     end

--- a/spec/services/group_search_spec.rb
+++ b/spec/services/group_search_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe GroupSearch, elastic: true do
         expect(result_set('civil families')).to eq [civil_families_tribunal, civil_families_court]
         expect(result_set('civil tribunal')).to eq [civil_families_tribunal]
       end
+
+      it 'ignores non-word characters' do
+        expect { result_set('*') }.not_to raise_error
+        expect(result_set('\Team/name?')).to eq [team, another_team]
+      end
+
     end
   end
 


### PR DESCRIPTION
entering * in search was raising a 500. Any non-word
character entered as search term would cause this
error.