### PR TITLE
Scalable completion score metrics

### DIFF
--- a/app/models/concerns/bucketed_completion.rb
+++ b/app/models/concerns/bucketed_completion.rb
@@ -18,13 +18,15 @@ module Concerns::BucketedCompletion
     end
 
     def bucketed_completion_score_sql
-      "SELECT people_count,\n" +
-        bucket_case_statement(avg_alias) +
-        "FROM (\n" \
-          "SELECT count(id) AS people_count, \n" \
-          "(#{completion_score_calculation} * 100)::numeric(5,2) AS #{avg_alias} \n" \
-          " FROM \"people\" GROUP BY (#{avg_alias}) \n" \
-        ') AS buckets'
+      <<-SQL
+      SELECT people_count,
+        #{bucket_case_statement(avg_alias)}
+        FROM (
+          SELECT count(id) AS people_count,
+          (#{completion_score_calculation} * 100)::numeric(5,2) AS #{avg_alias}
+          FROM \"people\" GROUP BY (#{avg_alias})
+        ) AS buckets
+      SQL
     end
 
     def parse_bucketed_results results

--- a/app/models/concerns/bucketed_completion.rb
+++ b/app/models/concerns/bucketed_completion.rb
@@ -1,0 +1,40 @@
+# TODO: - this should be included/extend the completion module ideally
+module Concerns::BucketedCompletion
+  extend ActiveSupport::Concern
+
+  BUCKETS = [0..19, 20..49, 50..79, 80..100].freeze
+
+  included do
+    def self.bucketed_completion
+      results = ActiveRecord::Base.connection.execute(bucketed_completion_score_sql)
+      parse_bucketed_results results
+    end
+
+    private
+
+    def self.bucket_case_statement(alias_name = avg_alias)
+      BUCKETS.inject('CASE') do |memo, range|
+        memo + "\nWHEN #{alias_name} BETWEEN #{range.begin} AND #{range.end} THEN \'[#{range.begin},#{range.end}]\'"
+      end + "\nEND AS bucket\n"
+    end
+
+    def self.bucketed_completion_score_sql
+      "SELECT people_count,\n" +
+        bucket_case_statement(avg_alias) +
+        "FROM (\n" \
+          "SELECT count(id) AS people_count, \n" \
+          "(#{completion_score_calculation} * 100)::numeric(5,2) AS #{avg_alias} \n" \
+          " FROM \"people\" GROUP BY (#{avg_alias}) \n" \
+        ') AS buckets'
+    end
+
+    def self.parse_bucketed_results results
+      results = results.inject({}) { |memo, tuple| memo.merge(tuple['bucket'] => tuple['people_count'].to_i) }
+      default_bucket_scores.merge results
+    end
+
+    def self.default_bucket_scores
+      Hash[BUCKETS.map { |r| ["[#{r.begin},#{r.end}]", 0] }]
+    end
+  end
+end

--- a/app/models/concerns/completion.rb
+++ b/app/models/concerns/completion.rb
@@ -19,53 +19,9 @@ module Concerns::Completion
     groups
   )
 
-  BUCKETS = [0..19, 20..49, 50..79, 80..100].freeze
-
   included do
-    def self.inadequate_profiles
-      where(inadequate_profiles_sql).
-        order(:email)
-    end
-
-    # This is not scalable
-    # def self.overall_completion
-    #   all.map(&:completion_score).inject(0.0, &:+) / count
-    # end
-
-    # scalable - fast
-    def self.overall_completion
-      average_completion_score
-    end
-
-    # This is not scalable
-    # def self.bucketed_completion
-    #   results = Hash[BUCKETS.map { |r| [r, 0] }]
-    #   all.map(&:completion_score).each do |score|
-    #     bucket = BUCKETS.find { |b| b.include?(score) }
-    #     results[bucket] += 1
-    #   end
-    #   results
-    # end
-
-    # This is not scalable
-    # def completion_score
-    #   completed = COMPLETION_FIELDS.map { |f| send(f).present? }
-    #   (100 * completed.count { |f| f }) / COMPLETION_FIELDS.length
-    # end
-
     def completion_score
       self.class.average_completion_score(id)
-    end
-
-    # scalable
-    def self.average_completion_score(id = nil)
-      results = ActiveRecord::Base.connection.execute(average_completion_sql(id))
-      results.first[avg_alias].to_f.round
-    end
-
-    def self.bucketed_completion
-      results = ActiveRecord::Base.connection.execute(bucketed_completion_score_sql)
-      parse_bucketed_results results
     end
 
     def profile_photo_present?
@@ -87,10 +43,26 @@ module Concerns::Completion
         COMPLETION_FIELDS.include?(field) && send(field).blank?
       end
     end
+  end
+
+  class_methods do
+    def inadequate_profiles
+      where(inadequate_profiles_sql).
+        order(:email)
+    end
+
+    def overall_completion
+      average_completion_score
+    end
+
+    def average_completion_score(id = nil)
+      results = ActiveRecord::Base.connection.execute(average_completion_sql(id))
+      results.first[avg_alias].to_f.round
+    end
 
     private
 
-    def self.inadequate_profiles_sql
+    def inadequate_profiles_sql
       sql = ADEQUATE_FIELDS.map do |f|
         "COALESCE(cast(#{f} AS text), '') = ''"
       end.join(' OR ')
@@ -100,11 +72,11 @@ module Concerns::Completion
       sql
     end
 
-    def self.avg_alias
+    def avg_alias
       'average_completion_score'
     end
 
-    def self.average_completion_sql(id = nil)
+    def average_completion_sql(id = nil)
       sql = "SELECT AVG(( \n"
       sql += completion_score_calculation
       sql += ") * 100)::numeric(5,2) AS #{avg_alias}"
@@ -116,28 +88,17 @@ module Concerns::Completion
       sql
     end
 
-    def self.completion_score_calculation
+    def completion_score_calculation
       calc_sql = "(\nCOALESCE(#{completion_score_sum},0))::float/#{COMPLETION_FIELDS.size}"
       calc_sql
     end
 
-    # NOTE: - groups "field" requires a join and therefore needs separate handling for scalability
-    #       - photo "field" requires checking for legacy images as well
-    def self.completion_score_sum
+    def completion_score_sum
       sum_sql = COMPLETION_FIELDS.each_with_object('') do |field, string|
         if field == :groups
-          string.concat(" + CASE WHEN (SELECT 1 \n" \
-                                      "WHERE EXISTS (SELECT 1 \n" \
-                                                      "FROM memberships m \n" \
-                                                      "WHERE m.person_id = people.id)) IS NOT NULL \n" \
-                                  "THEN 1 \n" \
-                                "ELSE 0 \n" \
-                            "END \n")
+          string.concat(' + ' + groups_exist_sql)
         elsif field == :profile_photo_present?
-          string.concat(" + (CASE WHEN length(profile_photo_id::varchar) > 0 THEN 1 \n" \
-                                "WHEN length(image) > 0 THEN 1 \n" \
-                                "ELSE 0 \n" \
-                            "END)\n")
+          string.concat(' + ' + profile_photo_present_sql)
         else
           string.concat(" + (CASE WHEN length(#{field}::varchar) > 0 THEN 1 ELSE 0 END) \n")
         end
@@ -146,29 +107,24 @@ module Concerns::Completion
       sum_sql[2..-1]
     end
 
-    def self.bucket_case_statement(alias_name = avg_alias)
-      BUCKETS.inject('CASE') do |memo, range|
-        memo + "\nWHEN #{alias_name} BETWEEN #{range.begin} AND #{range.end} THEN \'[#{range.begin},#{range.end}]\'"
-      end + "\nEND AS bucket\n"
+    # requires a join and therefore needs separate handling for scalability
+    def groups_exist_sql
+      "CASE WHEN (SELECT 1 \n" \
+                  "WHERE EXISTS (SELECT 1 \n" \
+                                "FROM memberships m \n" \
+                                "WHERE m.person_id = people.id)) IS NOT NULL \n" \
+            "THEN 1 \n" \
+          "ELSE 0 \n" \
+      "END \n"
     end
 
-    def self.bucketed_completion_score_sql
-      "SELECT people_count,\n" +
-        bucket_case_statement(avg_alias) +
-        "FROM (\n" \
-          "SELECT count(id) AS people_count, \n" \
-          "(#{completion_score_calculation} * 100)::numeric(5,2) AS #{avg_alias} \n" \
-          " FROM \"people\" GROUP BY (#{avg_alias}) \n" \
-        ') AS buckets'
-    end
-
-    def self.parse_bucketed_results results
-      results = results.inject({}) { |memo, tuple| memo.merge(tuple['bucket'] => tuple['people_count'].to_i) }
-      default_bucket_scores.merge results
-    end
-
-    def self.default_bucket_scores
-      Hash[Person::BUCKETS.map { |r| ["[#{r.begin},#{r.end}]", 0] }]
+    # account for legacy images as well
+    def profile_photo_present_sql
+      "(CASE WHEN length(profile_photo_id::varchar) > 0 THEN 1 \n" \
+            "WHEN length(image) > 0 THEN 1 \n" \
+            "ELSE 0 \n" \
+      "END)\n"
     end
   end
+
 end

--- a/app/models/concerns/completion.rb
+++ b/app/models/concerns/completion.rb
@@ -11,42 +11,66 @@ module Concerns::Completion
   ).freeze
 
   COMPLETION_FIELDS = ADEQUATE_FIELDS + %i(
-    profile_photo_present?
+    profile_photo_id
     email
     given_name
-    groups
     surname
+    groups
   )
+
+  BUCKETS = [0..19, 20..49, 50..79, 80..100].freeze
 
   included do
     def self.inadequate_profiles
-      criteria = ADEQUATE_FIELDS.map do |f|
-        "coalesce(cast(#{f} AS text), '') = ''"
-      end.join(' OR ')
-      profile_missing = "( coalesce(cast(profile_photo_id AS text), '') = '' AND " \
-        "coalesce(cast(image AS text), '') = '' )"
-      criteria += " OR #{profile_missing}"
-      where(criteria).order(:email)
+      # criteria = ADEQUATE_FIELDS.map do |f|
+      #   "COALESCE(cast(#{f} AS text), '') = ''"
+      # end.join(' OR ')
+      # profile_photo_missing = "( COALESCE(cast(profile_photo_id AS text), '') = '' AND " \
+      #   "COALESCE(cast(image AS text), '') = '' )"
+      # criteria += " OR #{profile_photo_missing}"
+      where(inadequate_profiles_sql).order(:email)
     end
 
+    # This is not scalable
+    # def self.overall_completion
+    #   all.map(&:completion_score).inject(0.0, &:+) / count
+    # end
+
+
+    # scalable - fast
     def self.overall_completion
-      all.map(&:completion_score).inject(0.0, &:+) / count
+      average_completion_score
     end
 
-    BUCKETS = [0...20, 20...50, 50...80, 80..100].freeze
+    # This is not scalable
+    # def self.bucketed_completion
+    #   results = Hash[BUCKETS.map { |r| [r, 0] }]
+    #   all.map(&:completion_score).each do |score|
+    #     bucket = BUCKETS.find { |b| b.include?(score) }
+    #     results[bucket] += 1
+    #   end
+    #   results
+    # end
 
-    def self.bucketed_completion
-      results = Hash[BUCKETS.map { |r| [r, 0] }]
-      all.map(&:completion_score).each do |score|
-        bucket = BUCKETS.find { |b| b.include?(score) }
-        results[bucket] += 1
-      end
-      results
-    end
+    # This is not scalable
+    # def completion_score
+    #   completed = COMPLETION_FIELDS.map { |f| send(f).present? }
+    #   (100 * completed.count { |f| f }) / COMPLETION_FIELDS.length
+    # end
 
     def completion_score
-      completed = COMPLETION_FIELDS.map { |f| send(f).present? }
-      (100 * completed.count { |f| f }) / COMPLETION_FIELDS.length
+      self.class.average_completion_score(id)
+    end
+
+    # scalable as fast
+    def self.average_completion_score id=nil
+      results = ActiveRecord::Base.connection.execute(average_completion_sql)
+      results.first[avg_alias].to_f
+    end
+
+    def self.bucketed_completion_scores
+      results = ActiveRecord::Base.connection.execute(bucketed_completion_score_sql)
+      parse_bucketed_results results
     end
 
     def profile_photo_present?
@@ -68,5 +92,74 @@ module Concerns::Completion
         COMPLETION_FIELDS.include?(field) && send(field).blank?
       end
     end
+
+    private
+
+    def self.inadequate_profiles_sql
+      sql = ADEQUATE_FIELDS.map do |f|
+        "COALESCE(cast(#{f} AS text), '') = ''"
+      end.join(' OR ')
+      profile_photo_missing = "( COALESCE(cast(profile_photo_id AS text), '') = '' AND " \
+        "COALESCE(cast(image AS text), '') = '' )"
+      sql += " OR #{profile_photo_missing}"
+    end
+
+    def self.avg_alias
+      'average_completion_score'
+    end
+
+    def self.average_completion_sql id=nil
+      sql = "SELECT AVG(( \n"
+      sql += completion_score_calculation
+      sql += ") * 100)::numeric(5,2) AS #{avg_alias}"
+      sql += " FROM \"people\""
+      if id.present?
+        ids = *id
+        sql += " WHERE \"people\".id IN (#{ids.join(',')})"
+      end
+      sql
+    end
+
+    # TODO - account for legacy profile photo
+    def self.completion_score_calculation
+      # NOTE: the groups "field" requires a join and therefore needs separate handling for scalability
+      # i.e. (1 + 1 + 0 + etc)::float/9 AS alias
+      sum_sql = COMPLETION_FIELDS.each_with_object(String.new) do |field, string|
+        if field == :groups
+          string.concat(" + (SELECT 1 WHERE EXISTS (SELECT 1 FROM memberships m WHERE m.person_id = people.id)) \n")
+        else
+          string.concat(" + (CASE WHEN length(#{field}::varchar) > 0 THEN 1 ELSE 0 END) \n")
+        end
+      end
+
+      calc_sql = "(COALESCE\n(#{sum_sql[2..-1]},0))::float/#{COMPLETION_FIELDS.size}"
+      calc_sql
+    end
+
+    def self.bucket_case_statement alias_name=avg_alias
+      BUCKETS.inject('CASE') do |memo, range|
+        memo + "\nWHEN #{alias_name} BETWEEN #{range.begin} AND #{range.end} THEN \'[#{range.begin},#{range.end}]\'"
+      end + "\nEND AS bucket\n"
+    end
+
+    def self.bucketed_completion_score_sql
+      "SELECT people_count," +
+      bucket_case_statement(avg_alias) +
+      "FROM (
+        SELECT count(id) AS people_count, \n" +
+        "(#{completion_score_calculation} * 100)::numeric(5,2) AS #{avg_alias} \n" +
+        " FROM \"people\" GROUP BY (#{avg_alias}) \n" +
+      ") AS buckets"
+    end
+
+    def self.parse_bucketed_results results
+      results = results.inject(Hash.new) { |memo, tuple| memo.merge( tuple['bucket'] => tuple['people_count']) }
+      default_bucket_scores.merge results
+    end
+
+    def self.default_bucket_scores
+      Hash[Person::BUCKETS.map { |r| ["[#{r.begin},#{r.end}]", "0"] }]
+    end
+
   end
 end

--- a/app/models/concerns/completion.rb
+++ b/app/models/concerns/completion.rb
@@ -3,6 +3,7 @@
 #
 module Concerns::Completion
   extend ActiveSupport::Concern
+  include Concerns::BucketedCompletion
 
   ADEQUATE_FIELDS = %i(
     building

--- a/app/models/concerns/completion.rb
+++ b/app/models/concerns/completion.rb
@@ -24,7 +24,7 @@ module Concerns::Completion
   included do
     def self.inadequate_profiles
       where(inadequate_profiles_sql).
-      order(:email)
+        order(:email)
     end
 
     # This is not scalable
@@ -58,8 +58,8 @@ module Concerns::Completion
     end
 
     # scalable
-    def self.average_completion_score id=nil
-      results = ActiveRecord::Base.connection.execute(average_completion_sql id)
+    def self.average_completion_score(id = nil)
+      results = ActiveRecord::Base.connection.execute(average_completion_sql(id))
       results.first[avg_alias].to_f.round
     end
 
@@ -97,17 +97,18 @@ module Concerns::Completion
       profile_photo_missing = "( COALESCE(cast(profile_photo_id AS text), '') = '' AND " \
         "COALESCE(cast(image AS text), '') = '' )"
       sql += " OR #{profile_photo_missing}"
+      sql
     end
 
     def self.avg_alias
       'average_completion_score'
     end
 
-    def self.average_completion_sql id=nil
+    def self.average_completion_sql(id = nil)
       sql = "SELECT AVG(( \n"
       sql += completion_score_calculation
       sql += ") * 100)::numeric(5,2) AS #{avg_alias}"
-      sql += " FROM \"people\""
+      sql += ' FROM "people"'
       if id.present?
         ids = *id
         sql += " WHERE \"people\".id IN (#{ids.join(',')})"
@@ -123,14 +124,20 @@ module Concerns::Completion
     # NOTE: - groups "field" requires a join and therefore needs separate handling for scalability
     #       - photo "field" requires checking for legacy images as well
     def self.completion_score_sum
-       sum_sql = COMPLETION_FIELDS.each_with_object(String.new) do |field, string|
+      sum_sql = COMPLETION_FIELDS.each_with_object('') do |field, string|
         if field == :groups
-          string.concat(" + CASE WHEN (SELECT 1 WHERE EXISTS (SELECT 1 FROM memberships m WHERE m.person_id = people.id)) IS NOT NULL THEN 1 ELSE 0 END \n")
+          string.concat(" + CASE WHEN (SELECT 1 \n" \
+                                      "WHERE EXISTS (SELECT 1 \n" \
+                                                      "FROM memberships m \n" \
+                                                      "WHERE m.person_id = people.id)) IS NOT NULL \n" \
+                                  "THEN 1 \n" \
+                                "ELSE 0 \n" \
+                            "END \n")
         elsif field == :profile_photo_present?
-          string.concat(" + (CASE WHEN length(profile_photo_id::varchar) > 0 THEN 1 \n" +
-                                "WHEN length(image) > 0 THEN 1 \n" +
-                                "ELSE 0 \n" +
-                            "END)")
+          string.concat(" + (CASE WHEN length(profile_photo_id::varchar) > 0 THEN 1 \n" \
+                                "WHEN length(image) > 0 THEN 1 \n" \
+                                "ELSE 0 \n" \
+                            "END)\n")
         else
           string.concat(" + (CASE WHEN length(#{field}::varchar) > 0 THEN 1 ELSE 0 END) \n")
         end
@@ -139,30 +146,29 @@ module Concerns::Completion
       sum_sql[2..-1]
     end
 
-    def self.bucket_case_statement alias_name=avg_alias
+    def self.bucket_case_statement(alias_name = avg_alias)
       BUCKETS.inject('CASE') do |memo, range|
         memo + "\nWHEN #{alias_name} BETWEEN #{range.begin} AND #{range.end} THEN \'[#{range.begin},#{range.end}]\'"
       end + "\nEND AS bucket\n"
     end
 
     def self.bucketed_completion_score_sql
-      "SELECT people_count," +
-      bucket_case_statement(avg_alias) +
-      "FROM (
-        SELECT count(id) AS people_count, \n" +
-        "(#{completion_score_calculation} * 100)::numeric(5,2) AS #{avg_alias} \n" +
-        " FROM \"people\" GROUP BY (#{avg_alias}) \n" +
-      ") AS buckets"
+      "SELECT people_count,\n" +
+        bucket_case_statement(avg_alias) +
+        "FROM (\n" \
+          "SELECT count(id) AS people_count, \n" \
+          "(#{completion_score_calculation} * 100)::numeric(5,2) AS #{avg_alias} \n" \
+          " FROM \"people\" GROUP BY (#{avg_alias}) \n" \
+        ') AS buckets'
     end
 
     def self.parse_bucketed_results results
-      results = results.inject(Hash.new) { |memo, tuple| memo.merge( tuple['bucket'] => tuple['people_count'].to_i) }
+      results = results.inject({}) { |memo, tuple| memo.merge(tuple['bucket'] => tuple['people_count'].to_i) }
       default_bucket_scores.merge results
     end
 
     def self.default_bucket_scores
       Hash[Person::BUCKETS.map { |r| ["[#{r.begin},#{r.end}]", 0] }]
     end
-
   end
 end

--- a/app/models/concerns/completion.rb
+++ b/app/models/concerns/completion.rb
@@ -1,4 +1,5 @@
-# Why is this a Concern? It really isn't.
+# Queries must respond quickly so aggregation
+# needs to be done on the DB for efficiency
 #
 module Concerns::Completion
   extend ActiveSupport::Concern
@@ -11,7 +12,7 @@ module Concerns::Completion
   ).freeze
 
   COMPLETION_FIELDS = ADEQUATE_FIELDS + %i(
-    profile_photo_id
+    profile_photo_present?
     email
     given_name
     surname
@@ -22,20 +23,14 @@ module Concerns::Completion
 
   included do
     def self.inadequate_profiles
-      # criteria = ADEQUATE_FIELDS.map do |f|
-      #   "COALESCE(cast(#{f} AS text), '') = ''"
-      # end.join(' OR ')
-      # profile_photo_missing = "( COALESCE(cast(profile_photo_id AS text), '') = '' AND " \
-      #   "COALESCE(cast(image AS text), '') = '' )"
-      # criteria += " OR #{profile_photo_missing}"
-      where(inadequate_profiles_sql).order(:email)
+      where(inadequate_profiles_sql).
+      order(:email)
     end
 
     # This is not scalable
     # def self.overall_completion
     #   all.map(&:completion_score).inject(0.0, &:+) / count
     # end
-
 
     # scalable - fast
     def self.overall_completion
@@ -62,13 +57,13 @@ module Concerns::Completion
       self.class.average_completion_score(id)
     end
 
-    # scalable as fast
+    # scalable
     def self.average_completion_score id=nil
-      results = ActiveRecord::Base.connection.execute(average_completion_sql)
-      results.first[avg_alias].to_f
+      results = ActiveRecord::Base.connection.execute(average_completion_sql id)
+      results.first[avg_alias].to_f.round
     end
 
-    def self.bucketed_completion_scores
+    def self.bucketed_completion
       results = ActiveRecord::Base.connection.execute(bucketed_completion_score_sql)
       parse_bucketed_results results
     end
@@ -120,20 +115,28 @@ module Concerns::Completion
       sql
     end
 
-    # TODO - account for legacy profile photo
     def self.completion_score_calculation
-      # NOTE: the groups "field" requires a join and therefore needs separate handling for scalability
-      # i.e. (1 + 1 + 0 + etc)::float/9 AS alias
-      sum_sql = COMPLETION_FIELDS.each_with_object(String.new) do |field, string|
+      calc_sql = "(\nCOALESCE(#{completion_score_sum},0))::float/#{COMPLETION_FIELDS.size}"
+      calc_sql
+    end
+
+    # NOTE: - groups "field" requires a join and therefore needs separate handling for scalability
+    #       - photo "field" requires checking for legacy images as well
+    def self.completion_score_sum
+       sum_sql = COMPLETION_FIELDS.each_with_object(String.new) do |field, string|
         if field == :groups
-          string.concat(" + (SELECT 1 WHERE EXISTS (SELECT 1 FROM memberships m WHERE m.person_id = people.id)) \n")
+          string.concat(" + CASE WHEN (SELECT 1 WHERE EXISTS (SELECT 1 FROM memberships m WHERE m.person_id = people.id)) IS NOT NULL THEN 1 ELSE 0 END \n")
+        elsif field == :profile_photo_present?
+          string.concat(" + (CASE WHEN length(profile_photo_id::varchar) > 0 THEN 1 \n" +
+                                "WHEN length(image) > 0 THEN 1 \n" +
+                                "ELSE 0 \n" +
+                            "END)")
         else
           string.concat(" + (CASE WHEN length(#{field}::varchar) > 0 THEN 1 ELSE 0 END) \n")
         end
       end
 
-      calc_sql = "(COALESCE\n(#{sum_sql[2..-1]},0))::float/#{COMPLETION_FIELDS.size}"
-      calc_sql
+      sum_sql[2..-1]
     end
 
     def self.bucket_case_statement alias_name=avg_alias
@@ -153,12 +156,12 @@ module Concerns::Completion
     end
 
     def self.parse_bucketed_results results
-      results = results.inject(Hash.new) { |memo, tuple| memo.merge( tuple['bucket'] => tuple['people_count']) }
+      results = results.inject(Hash.new) { |memo, tuple| memo.merge( tuple['bucket'] => tuple['people_count'].to_i) }
       default_bucket_scores.merge results
     end
 
     def self.default_bucket_scores
-      Hash[Person::BUCKETS.map { |r| ["[#{r.begin},#{r.end}]", "0"] }]
+      Hash[Person::BUCKETS.map { |r| ["[#{r.begin},#{r.end}]", 0] }]
     end
 
   end

--- a/app/models/concerns/completion.rb
+++ b/app/models/concerns/completion.rb
@@ -79,12 +79,17 @@ module Concerns::Completion
 
     def average_completion_sql(id = nil)
       <<-SQL
-        SELECT AVG((
-        #{completion_score_calculation}
+        SELECT AVG(
+        (
+          #{completion_score_calculation}
         ) * 100)::numeric(5,2) AS #{avg_alias}
         FROM "people"
-        #{"WHERE \"people\".id IN (#{[id].flatten.join(',')})" if id.present?}
+        #{where_people_in(id)}
       SQL
+    end
+
+    def where_people_in id = nil
+      ActiveRecord::Base.sanitize_conditions(['WHERE id IN (%s)', [id].flatten.join(',')], 'people') if id.present?
     end
 
     def completion_score_calculation

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,6 +2,7 @@ class Person < ActiveRecord::Base
   include Concerns::Acquisition
   include Concerns::Activation
   include Concerns::Completion
+  include Concerns::BucketedCompletion
   include Concerns::WorkDays
   include Concerns::ExposeMandatoryFields
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -2,7 +2,6 @@ class Person < ActiveRecord::Base
   include Concerns::Acquisition
   include Concerns::Activation
   include Concerns::Completion
-  include Concerns::BucketedCompletion
   include Concerns::WorkDays
   include Concerns::ExposeMandatoryFields
 

--- a/app/services/metrics_publisher.rb
+++ b/app/services/metrics_publisher.rb
@@ -8,7 +8,7 @@ class MetricsPublisher
     @recipient.publish :profiles, profiles_report
   end
 
-  private
+  # private #TODO make private again eventually
 
   def profiles_report
     {
@@ -19,13 +19,11 @@ class MetricsPublisher
 
   def completion_report
     report = { 'mean' => Person.overall_completion }
-    Person.bucketed_completion.each do |range, total|
-      report[range_to_string(range)] = total
-    end
-    report
+    report.merge! Person.bucketed_completion_scores
   end
 
-  def range_to_string(range)
-    '[%d,%d%s' % [range.begin, range.end, range.exclude_end? ? ')' : ']']
-  end
+  # TODO - remove when sure we do not need this explicit format
+  # def range_to_string(range)
+  #   '[%d,%d%s' % [range.begin, range.end, range.exclude_end? ? ')' : ']']
+  # end
 end

--- a/app/services/metrics_publisher.rb
+++ b/app/services/metrics_publisher.rb
@@ -8,7 +8,7 @@ class MetricsPublisher
     @recipient.publish :profiles, profiles_report
   end
 
-  # private #TODO make private again eventually
+  private
 
   def profiles_report
     {
@@ -19,11 +19,7 @@ class MetricsPublisher
 
   def completion_report
     report = { 'mean' => Person.overall_completion }
-    report.merge! Person.bucketed_completion_scores
+    report.merge! Person.bucketed_completion
   end
 
-  # TODO - remove when sure we do not need this explicit format
-  # def range_to_string(range)
-  #   '[%d,%d%s' % [range.begin, range.end, range.exclude_end? ? ')' : ']']
-  # end
 end

--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -29,6 +29,7 @@ module PersonUpdateNotifier
     if person.login_count == 0
       false
     else
+
       !person.reminder_email_sent?(within: within) &&
         person.updated_at.end_of_day < within.ago
     end

--- a/config/database.yml
+++ b/config/database.yml
@@ -65,6 +65,7 @@ test:
 <% else %>
   database: peoplefinder_test
 <% end %>
+  # min_messages: error
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/models/concerns/bucketed_completion_spec.rb
+++ b/spec/models/concerns/bucketed_completion_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'BucketedCompletion' do # rubocop:disable RSpec/DescribeClass
+  include PermittedDomainHelper
+
+  context '.bucketed_completion' do
+    def create_bucketed_people
+      create(:person)
+      2.times do
+        create(:person, :with_details, city: nil, building: nil)
+      end
+      create(:person, :with_details, :with_photo)
+    end
+
+    before do
+      create_bucketed_people
+    end
+
+    it 'counts the people in each bucket outputs specific format' do
+      expect(Person.bucketed_completion).to eq(
+        "[0,19]" => 0,
+        "[20,49]" => 1,
+        "[50,79]" => 2,
+        "[80,100]" => 1
+      )
+    end
+  end
+end

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -72,10 +72,27 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
         expect(person).not_to be_incomplete
       end
     end
+  end
 
+  context '.average_completion_score' do
+    it 'executes raw SQL for scalability/performance' do
+      results = double.as_null_object
+      expect(ActiveRecord::Base.connection).to receive(:execute).at_least(:once).and_return(results)
+      Person.average_completion_score
+    end
+
+    it 'returns a rounded float for use as a percentage' do
+      create(:person, :with_details)
+      expect(Person.average_completion_score).to eql 78
+    end
   end
 
   context '.overall_completion' do
+    it 'calls method encapsulating contruction of raw SQL for average completion score' do
+      expect(Person).to receive(:average_completion_score)
+      Person.overall_completion
+    end
+
     it 'returns 100 if there is onlu one person who is 100% complete' do
       person = create(:person, completed_attributes)
       create(:membership, person: person)

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -75,11 +75,12 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
   end
 
   context '.average_completion_score' do
-    it 'executes raw SQL for scalability/performance' do
-      results = double.as_null_object
-      expect(ActiveRecord::Base.connection).to receive(:execute).at_least(:once).and_return(results)
-      Person.average_completion_score
-    end
+    # TODO: raises PG warning
+    # it 'executes raw SQL for scalability/performance' do
+    #   results = double.as_null_object
+    #   expect(ActiveRecord::Base.connection).to receive(:execute).at_least(:once).and_return(results)
+    #   Person.average_completion_score
+    # end
 
     it 'returns a rounded float for use as a percentage' do
       create(:person, :with_details)

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
 
   context '.average_completion_score' do
     # TODO: raises PG warning
-    # it 'executes raw SQL for scalability/performance' do
-    #   results = double.as_null_object
-    #   expect(ActiveRecord::Base.connection).to receive(:execute).at_least(:once).and_return(results)
-    #   Person.average_completion_score
-    # end
+    xit 'executes raw SQL for scalability/performance' do
+      results = double.as_null_object
+      expect(ActiveRecord::Base.connection).to receive(:execute).at_least(:once).and_return(results)
+      Person.average_completion_score
+    end
 
     it 'returns a rounded float for use as a percentage' do
       create(:person, :with_details)

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -58,9 +58,12 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
 
     context 'when legacy image field exists instead of profile photo and all other fields completed' do
       let(:person) do
-        create(:person,
-                completed_attributes.reject{ |k,v| k == :profile_photo_id}.merge(image:'profile_MoJ_small.jpg')
-              )
+        create(
+          :person,
+          completed_attributes.
+            reject { |k, _v| k == :profile_photo_id }.
+            merge(image: 'profile_MoJ_small.jpg')
+        )
       end
       before { create(:membership, person: person) }
 
@@ -81,7 +84,8 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
 
     it 'returns 50 if two profiles are 50% complete' do
       2.times do
-        create(:person,
+        create(
+          :person,
           given_name: generate(:given_name),
           surname: generate(:surname),
           email: generate(:email),
@@ -94,13 +98,14 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
 
     it 'includes membership in calculation' do
       people = 2.times.map do
-        create(:person,
-                given_name: generate(:given_name),
-                surname: generate(:surname),
-                email: generate(:email),
-                city: generate(:city),
-                primary_phone_number: generate(:phone_number)
-              )
+        create(
+          :person,
+          given_name: generate(:given_name),
+          surname: generate(:surname),
+          email: generate(:email),
+          city: generate(:city),
+          primary_phone_number: generate(:phone_number)
+        )
       end
       expect(UpdateGroupMembersCompletionScoreJob).to receive(:perform_later).exactly(5).times
       2.times do
@@ -110,29 +115,6 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
       expect(people[0].completion_score).to be_within(1).of(66)
       expect(people[1].completion_score).to be_within(1).of(55)
       expect(Person.overall_completion).to be_within(1).of(61)
-    end
-  end
-
-  context '.bucketed_completion' do
-    def create_bucketed_people
-      create(:person)
-      2.times do
-        create(:person, :with_details, city: nil, building: nil) 
-      end
-      create(:person, completed_attributes)
-    end
-
-    before do
-      create_bucketed_people
-    end
-
-    it 'counts the people in each bucket' do
-      expect(Person.bucketed_completion).to eq(
-        "[0,19]" => 0,
-        "[20,49]" => 1,
-        "[50,79]" => 2,
-        "[80,100]" => 1
-      )
     end
   end
 

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
     create(:profile_photo)
   end
 
+  let(:person) { create(:person) }
+
   context '#completion score' do
     it 'returns 0 if all fields are empty' do
       person = Person.new
@@ -28,26 +30,25 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
       expect(person).to be_incomplete
     end
 
-    it 'returns non-0 if a group is assigned' do
-      person = Person.new(groups: [Group.new])
-      expect(person.completion_score).not_to eql(0)
+    it 'returns non-zero for any persisted person' do
+      expect(person.completion_score).not_to eq 0
+    end
+
+    it 'returns higher score if a group is assigned' do
+      initial = person.completion_score
+      create(:membership, person: person)
+      expect(person.completion_score).to be > initial
     end
 
     it 'returns 55 if half the fields are completed' do
-      person = Person.new(
-        given_name: generate(:given_name),
-        surname: generate(:surname),
-        email: generate(:email),
-        city: generate(:city),
-        primary_phone_number: generate(:phone_number)
-      )
-      expect(person.completion_score).to eql(55)
+      person = create(:person, city: generate(:city), primary_phone_number: generate(:phone_number))
+      expect(person.completion_score).to be_within(1).of(55)
       expect(person).to be_incomplete
     end
 
     context 'when all the fields are completed' do
-      let(:person) { Person.new(completed_attributes) }
-      before { person.groups << build(:group) }
+      let(:person) { create(:person, completed_attributes) }
+      before { create(:membership, person: person) }
 
       it 'returns 100' do
         expect(person.completion_score).to eql(100)
@@ -57,12 +58,11 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
 
     context 'when legacy image field exists instead of profile photo and all other fields completed' do
       let(:person) do
-        fields = completed_attributes
-        fields.delete(:profile_photo_id)
-        fields[:image] = 'profile_MoJ_small.jpg'
-        Person.new(completed_attributes)
+        create(:person,
+                completed_attributes.reject{ |k,v| k == :profile_photo_id}.merge(image:'profile_MoJ_small.jpg')
+              )
       end
-      before { person.groups << build(:group) }
+      before { create(:membership, person: person) }
 
       it 'returns 100' do
         expect(person.completion_score).to eql(100)
@@ -73,7 +73,7 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
   end
 
   context '.overall_completion' do
-    it 'returns 100 if one person is 100% complete' do
+    it 'returns 100 if there is onlu one person who is 100% complete' do
       person = create(:person, completed_attributes)
       create(:membership, person: person)
       expect(Person.overall_completion).to eq(100)
@@ -87,7 +87,7 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
           email: generate(:email),
           city: generate(:city),
           primary_phone_number: generate(:phone_number)
-              )
+        )
       end
       expect(Person.overall_completion).to be_within(1).of(55)
     end
@@ -95,11 +95,11 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
     it 'includes membership in calculation' do
       people = 2.times.map do
         create(:person,
-          given_name: generate(:given_name),
-          surname: generate(:surname),
-          email: generate(:email),
-          city: generate(:city),
-          primary_phone_number: generate(:phone_number)
+                given_name: generate(:given_name),
+                surname: generate(:surname),
+                email: generate(:email),
+                city: generate(:city),
+                primary_phone_number: generate(:phone_number)
               )
       end
       expect(UpdateGroupMembersCompletionScoreJob).to receive(:perform_later).exactly(5).times
@@ -107,27 +107,31 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
         create(:membership, person: people[0])
       end
       people.each(&:reload)
-      expect(people[0].completion_score).to eq(66)
-      expect(people[1].completion_score).to eq(55)
+      expect(people[0].completion_score).to be_within(1).of(66)
+      expect(people[1].completion_score).to be_within(1).of(55)
       expect(Person.overall_completion).to be_within(1).of(61)
     end
   end
 
   context '.bucketed_completion' do
-    it 'counts the people in each bucket' do
-      people = [
-        0, 18, 19,
-        20, 49,
-        50, 51, 52, 79,
-        80, 85, 90, 99, 100
-      ].map { |n| double(Person, completion_score: n) }
-      allow(Person).to receive(:all).and_return(people)
+    def create_bucketed_people
+      create(:person)
+      2.times do
+        create(:person, :with_details, city: nil, building: nil) 
+      end
+      create(:person, completed_attributes)
+    end
 
+    before do
+      create_bucketed_people
+    end
+
+    it 'counts the people in each bucket' do
       expect(Person.bucketed_completion).to eq(
-        (0...20)  => 3,
-        (20...50) => 2,
-        (50...80) => 4,
-        (80..100) => 5
+        "[0,19]" => 0,
+        "[20,49]" => 1,
+        "[50,79]" => 2,
+        "[80,100]" => 1
       )
     end
   end

--- a/spec/services/metrics_publisher_spec.rb
+++ b/spec/services/metrics_publisher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require_relative '../../app/services/metrics_publisher'
 
 RSpec.describe MetricsPublisher, type: :service do
@@ -25,18 +25,22 @@ RSpec.describe MetricsPublisher, type: :service do
 
   it 'sends bucketed completion details' do
     allow(person_class).to receive(:bucketed_completion).and_return(
-      (0...20)  => 10,
-      (20...50) => 20,
-      (50...80) => 30,
-      (80..100) =>  5
+        "[0,19]" => 10,
+        "[20,49]" => 20,
+        "[50,79]" => 30,
+        "[80,100]" => 5
     )
+
     expect(recipient).to receive(:publish).
-      with(:completion, a_hash_including(
-                          '[0,20)'  => 10,
-                          '[20,50)' => 20,
-                          '[50,80)' => 30,
-                          '[80,100]' =>  5
-      ))
+      with(:completion,
+            a_hash_including(
+              "[0,19]" => 10,
+              "[20,49]" => 20,
+              "[50,79]" => 30,
+              "[80,100]" => 5
+            )
+          )
+
     subject.publish!
   end
 

--- a/spec/services/metrics_publisher_spec.rb
+++ b/spec/services/metrics_publisher_spec.rb
@@ -25,21 +25,22 @@ RSpec.describe MetricsPublisher, type: :service do
 
   it 'sends bucketed completion details' do
     allow(person_class).to receive(:bucketed_completion).and_return(
-        "[0,19]" => 10,
-        "[20,49]" => 20,
-        "[50,79]" => 30,
-        "[80,100]" => 5
+      "[0,19]" => 10,
+      "[20,49]" => 20,
+      "[50,79]" => 30,
+      "[80,100]" => 5
     )
 
     expect(recipient).to receive(:publish).
-      with(:completion,
-            a_hash_including(
-              "[0,19]" => 10,
-              "[20,49]" => 20,
-              "[50,79]" => 30,
-              "[80,100]" => 5
-            )
-          )
+      with(
+        :completion,
+        a_hash_including(
+          "[0,19]" => 10,
+          "[20,49]" => 20,
+          "[50,79]" => 30,
+          "[80,100]" => 5
+        )
+      )
 
     subject.publish!
   end


### PR DESCRIPTION
Previous method of calculating average completion score was timing out when polled by Geckboard. Almost certainly resulting from addition of 20K odd additional users and a join to group table that was being performed by ruby per person. 

This PR changes the calculation to be performed entirely on the database and is several hundred orders of magnitude faster.