### PR TITLE
amend activation metrics to ensure they are scalable

### DIFF
--- a/app/models/concerns/acquisition.rb
+++ b/app/models/concerns/acquisition.rb
@@ -1,23 +1,22 @@
 module Concerns::Acquisition
   extend ActiveSupport::Concern
 
-  included do
-    # % of people who have logged in at least once
-    def self.acquired_percentage from: nil, before: nil
-      people_count = Person.count
-      if people_count == 0
-        0.0
-      else
-        (acquired_count(from: from, before: before).to_f / people_count * 100).round(0)
-      end
+  class_methods do
+    # % of people created between specified dates (from,before)
+    # and who have logged in at least once
+    def acquired_percentage from: nil, before: nil
+      (acquired_people(from: from, before: before).count.to_f / count * 100).round(0)
+    rescue FloatDomainError, ZeroDivisionError
+      0.0
     end
 
-    def self.acquired_count from: nil, before: nil
-      acquired = Person.logged_in_at_least_once
+    private
+
+    def acquired_people from: nil, before: nil
+      acquired = logged_in_at_least_once
       acquired = acquired.where('created_at >= ?', from) if from
       acquired = acquired.where('created_at < ?', before) if before
-      acquired.count
+      acquired
     end
-
   end
 end

--- a/app/models/concerns/completion.rb
+++ b/app/models/concerns/completion.rb
@@ -52,6 +52,10 @@ module Concerns::Completion
         order(:email)
     end
 
+    def completion_score_calculation
+      "(\nCOALESCE(#{completion_score_sum},0))::float/#{COMPLETION_FIELDS.size}"
+    end
+
     def overall_completion
       average_completion_score
     end
@@ -90,11 +94,6 @@ module Concerns::Completion
 
     def where_people_in id = nil
       ActiveRecord::Base.sanitize_conditions(['WHERE id IN (%s)', [id].flatten.join(',')], 'people') if id.present?
-    end
-
-    def completion_score_calculation
-      calc_sql = "(\nCOALESCE(#{completion_score_sum},0))::float/#{COMPLETION_FIELDS.size}"
-      calc_sql
     end
 
     def completion_score_sum

--- a/spec/models/concerns/activation_spec.rb
+++ b/spec/models/concerns/activation_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Concerns::Activation do
   end
 
   context '.activated_percentage' do
+
+    it 'uses .completion_score_calculation for scalablility' do
+      expect(Person).to receive(:completion_score_calculation).and_return(0.81)
+      Person.activated_percentage
+    end
+
     it 'returns 0 when no profiles' do
       expect(Person.activated_percentage).to eq(0)
     end
@@ -41,13 +47,13 @@ RSpec.describe Concerns::Activation do
       expect(Person.activated_percentage).to eq(100)
     end
 
-    it 'returns 50 when two people who have logged in, one with completeness > 80%, one with completeness > 80%' do
+    it 'returns 50 when two people who have logged in, one with completeness > 80%, one with completeness < 80%' do
       create(:person, completed_attributes.merge(login_count: 1))
       create(:person, login_count: 1)
       expect(Person.activated_percentage).to eq(50)
     end
 
-    it 'returns 67 when 3 people who have logged in, two with completeness > 80%, one with completeness > 80%' do
+    it 'returns 67 when 3 people who have logged in, two with completeness > 80%, one with completeness < 80%' do
       create(:person, completed_attributes.merge(login_count: 1))
       create(:person, completed_attributes.merge(email: 'test2@digital.justice.gov.uk', login_count: 1))
       create(:person, login_count: 1)

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
 
   let(:person) { create(:person) }
 
-  context '#completion score' do
+  context '#completion_score' do
     it 'returns 0 if all fields are empty' do
       person = Person.new
       expect(person.completion_score).to eql(0)
@@ -71,20 +71,6 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
         expect(person.completion_score).to eql(100)
         expect(person).not_to be_incomplete
       end
-    end
-  end
-
-  context '.average_completion_score' do
-    # TODO: raises PG warning
-    xit 'executes raw SQL for scalability/performance' do
-      results = double.as_null_object
-      expect(ActiveRecord::Base.connection).to receive(:execute).at_least(:once).and_return(results)
-      Person.average_completion_score
-    end
-
-    it 'returns a rounded float for use as a percentage' do
-      create(:person, :with_details)
-      expect(Person.average_completion_score).to eql 78
     end
   end
 
@@ -136,7 +122,33 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
     end
   end
 
-  describe '#inadequate_profiles' do
+  context '.completion_score_calculation' do
+    it 'constructs sql to calculate score based on existence of values for important fields' do
+      sql_regex = /COALESCE.*CASE WHEN length\(.*\,0\)\)::float.*/mi
+      expect(Person.completion_score_calculation).to match(sql_regex)
+    end
+
+    it 'uses number of COMPLETION_FIELDS to calculate fraction part of the whole' do
+      expect(Person::COMPLETION_FIELDS).to receive(:size)
+      Person.completion_score_calculation
+    end
+  end
+
+  context '.average_completion_score' do
+    it 'executes raw SQL for scalability/performance' do
+      conn = double.as_null_object
+      expect(ActiveRecord::Base).to receive(:connection).at_least(:once).and_return(conn)
+      expect(conn).to receive(:execute).with(/^\s*SELECT AVG\(.*$/i)
+      Person.average_completion_score
+    end
+
+    it 'returns a rounded float for use as a percentage' do
+      create(:person, :with_details)
+      expect(Person.average_completion_score).to eql 78
+    end
+  end
+
+  describe '.inadequate_profiles' do
     let!(:person) { create(:person, completed_attributes) }
     subject { Person.inadequate_profiles }
 


### PR DESCRIPTION
Stops acquisition and activation metrics raising 5xx errors. This is almost certainly a result of the non-scalable combination of AR sql and ruby looping. Tested locally using:

```
puts Benchmark.measure { Person.activated_percentage(from: Date.today-365 }
```
  - [X] refactor the concerns/mixins
  - [x] ensure scalability
  - [X] spec