### PR TITLE
Asynchronous expired token destruction

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -89,6 +89,7 @@ class Token < ActiveRecord::Base
   def remove_expired_tokens
     self.class.expired.destroy_all
   end
+  handle_asynchronously :remove_expired_tokens, queue: :high_priority
 
   def deactivate_tokens
     self.class.unspent.where('user_email = ? AND id != ?', user_email, id).update_all(spent: true)

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -79,11 +79,11 @@ RSpec.describe Token, type: :model do
     let!(:expiring_tokens) { create_list(:token, 3) }
 
     it 'enqueues delayed job for destroying expired tokens' do
-      expect{ token.save }.to have_delayed_job 1
+      expect { token.save }.to have_delayed_job 1
     end
 
     it 'destroys expired tokens asynchronously for scalability' do
-      expect{ token.save }.to delay_method(:remove_expired_tokens)
+      expect { token.save }.to delay_method(:remove_expired_tokens)
     end
 
     context 'destroys all tokens older than the throttle limit' do

--- a/spec/support/matchers/delayed_job_matchers.rb
+++ b/spec/support/matchers/delayed_job_matchers.rb
@@ -1,0 +1,52 @@
+require 'rspec/expectations'
+
+module DelayedJobHelper
+
+  RSpec::Matchers.define :delay_method do |expected|
+    def supports_block_expectations?
+      true
+    end
+
+    match do |proc|
+      Delayed::Worker.new.work_off
+      proc.call
+      job = Delayed::Job.last
+      @actual = job.payload_object.method_name.to_sym
+      (@actual == expected) || (@actual == "#{expected}_without_delay".to_sym)
+    end
+
+    failure_message do |actual|
+      "expected code block to have delayed the method '#{expected}' but got '#{@actual}'"
+    end
+
+    failure_message_when_negated do |actual|
+      "expected code block not to have delayed the method '#{expected}'"
+    end
+  end
+
+  RSpec::Matchers.define :have_delayed_job do |count|
+    def supports_block_expectations?
+      true
+    end
+
+    match do |proc|
+      Delayed::Worker.new.work_off
+      @expected_count = count || 1
+      ap @expected_count
+      before_count = Delayed::Job.count
+      proc.call
+      after_count = Delayed::Job.count
+      @actual_count = (after_count - before_count)
+      @actual_count == @expected_count
+    end
+
+    failure_message do |process|
+      "expected to have enqueued #{@expected_count} delayed job(s) but enqueued #{@actual_count}"
+    end
+
+    failure_message_when_negated do |proc|
+      "expected not to have enqueued #{@expected_count} delayed job(s) but enqueued #{@actual_count}"
+    end
+  end
+
+end

--- a/spec/support/matchers/delayed_job_matchers.rb
+++ b/spec/support/matchers/delayed_job_matchers.rb
@@ -15,12 +15,12 @@ module DelayedJobHelper
       (@actual == expected) || (@actual == "#{expected}_without_delay".to_sym)
     end
 
-    failure_message do |actual|
-      "expected code block to have delayed the method '#{expected}' but got '#{@actual}'"
+    failure_message do |proc|
+      "expected #{proc} to have delayed the method '#{expected}' but got '#{@actual}'"
     end
 
-    failure_message_when_negated do |actual|
-      "expected code block not to have delayed the method '#{expected}'"
+    failure_message_when_negated do |proc|
+      "expected #{proc} not to have delayed the method '#{expected}'"
     end
   end
 
@@ -32,7 +32,6 @@ module DelayedJobHelper
     match do |proc|
       Delayed::Worker.new.work_off
       @expected_count = count || 1
-      ap @expected_count
       before_count = Delayed::Job.count
       proc.call
       after_count = Delayed::Job.count
@@ -40,12 +39,12 @@ module DelayedJobHelper
       @actual_count == @expected_count
     end
 
-    failure_message do |process|
-      "expected to have enqueued #{@expected_count} delayed job(s) but enqueued #{@actual_count}"
+    failure_message do |proc|
+      "expected #{proc}to have enqueued #{@expected_count} delayed job(s) but enqueued #{@actual_count}"
     end
 
     failure_message_when_negated do |proc|
-      "expected not to have enqueued #{@expected_count} delayed job(s) but enqueued #{@actual_count}"
+      "expected #{proc} not to have enqueued #{@expected_count} delayed job(s) but enqueued #{@actual_count}"
     end
   end
 


### PR DESCRIPTION
required for scalability since mailer jobs
can create large numbers of tokens that will expire at
the same time. This can caused 500 errors on hitting the request link
button in the login page (i.e. when
the destruction of expired tokens is performed
synchronously, initiated by a token request event.