### PR TITLE
add IE7 organogram fix

### DIFF
--- a/app/assets/stylesheets/peoplefinder/peoplefinder-ie7.css.scss
+++ b/app/assets/stylesheets/peoplefinder/peoplefinder-ie7.css.scss
@@ -170,8 +170,15 @@ form #working-days ul,
 }
 
 form.search-box {
+  /*ensure search box height*/
   .form-control {
     height: 25px;
+  }
+  /*prevent submit text appearing over button*/
+  .submit-button {
+  line-height: 0;
+  width: 49px;
+  height: 49px;
   }
 }
 

--- a/app/assets/stylesheets/peoplefinder/peoplefinder-ie7.css.scss
+++ b/app/assets/stylesheets/peoplefinder/peoplefinder-ie7.css.scss
@@ -53,6 +53,7 @@
 .grid-wrapper{
   clear:both;
 }
+
 h1, h2 {
   margin: 30px 0;
   border-bottom: 1px solid $blackish;
@@ -163,7 +164,6 @@ form #working-days ul,
               this.insertBefore( document.createElement("span"), this.firstChild ).innerHTML="\25BC  "
              );
   }
-
   form{
     *zoom: 1;
   }
@@ -172,5 +172,13 @@ form #working-days ul,
 form.search-box {
   .form-control {
     height: 25px;
+  }
+}
+
+/*IE7 organogram hack - ensure inline block equivalent */
+.organogram-content {
+  .leader, .person, .team {
+    *display: inline;
+    *zoom: 1;
   }
 }

--- a/app/views/layouts/home.html.haml
+++ b/app/views/layouts/home.html.haml
@@ -7,7 +7,6 @@
   #wrapper
     %main#content{role: 'main'}
       =flash_messages
-      
       .inner-block
         #home-page= yield
 


### PR DESCRIPTION
In IE7 the team and group images were displaying
as block (vertical) rather than inline (horizontal).