### PR TITLE
Improve group score update speed

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -94,17 +94,13 @@ class Group < ActiveRecord::Base
     leaderships.group_by(&:person)
   end
 
-  def update_members_completion_score!
-    # TODO: this can be very slow for large teams e.g. NOMS
+  def average_completion_score
     people = all_people
-    score = if people.blank?
-              0
-            else
-              total_score = people.inject(0) do |total, person|
-                total + person.completion_score
-              end
-              (total_score / people.length.to_f).round(0)
-            end
+    people.blank? ? 0 : Person.average_completion_score(people.pluck(:id))
+  end
+
+  def update_members_completion_score!
+    score = average_completion_score
     update_columns(members_completion_score: score)
   end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -386,4 +386,22 @@ RSpec.describe Group, type: :model do
     end
   end
 
+  describe '#average_completion_score' do
+    let(:team) { create(:group) }
+    let(:subteam) { create(:group, parent: team) }
+
+    it 'returns 0 when no one exists in subtree' do
+      expect(team.average_completion_score).to be 0
+    end
+
+    it 'returns average completion score of all people in group and subtree' do
+      create(:membership, group: team, person: create(:person))
+      create(:membership, group: team, person: create(:person))
+      create(:membership, group: subteam, person: create(:person, city: 'Wherever'))
+      expect(team.average_completion_score).to be_between(47, 49)
+      expect(subteam.average_completion_score).to be_between(55, 58)
+    end
+
+  end
+
 end


### PR DESCRIPTION
previously this was using a combination of ruby inject and sql which is slow for large groups of people. changed to use existing sql based solution for scalability.