### PR TITLE
apply profiles changed report limitation of 500 records

### DIFF
--- a/app/models/concerns/geckoboard_datasets.rb
+++ b/app/models/concerns/geckoboard_datasets.rb
@@ -65,6 +65,7 @@ module Concerns::GeckoboardDatasets
         WHERE item_type = 'Person'
         AND v.event IN ('create','update','destroy')
         GROUP BY event_date, event
+        ORDER BY event_date ASC
       SQL
     end
 

--- a/lib/geckoboard_publisher/profiles_changed_report.rb
+++ b/lib/geckoboard_publisher/profiles_changed_report.rb
@@ -1,6 +1,14 @@
 module GeckoboardPublisher
   class ProfilesChangedReport < Report
 
+    attr_accessor :limit
+
+    def initialize
+      @limit = 500
+      @items = nil
+      super
+    end
+
     def fields
       [
         Geckoboard::DateField.new(:date, name: 'Date'),
@@ -11,7 +19,7 @@ module GeckoboardPublisher
     end
 
     def items
-      parse Person.profile_events
+      @items ||= parse Person.profile_events
     end
 
     private
@@ -21,7 +29,11 @@ module GeckoboardPublisher
       pgresult.each do |row|
         find_or_create_set(row)
       end
-      @sets
+      @sets.drop(limit_diff)
+    end
+
+    def limit_diff
+      [0, @sets.size - limit].max
     end
 
     def template date, options = {}

--- a/spec/lib/geckoboard_publisher/profiles_changed_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profiles_changed_report_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe GeckoboardPublisher::ProfilesChangedReport do
 
   it_behaves_like 'geckoboard publishable report'
 
+  it { is_expected.to respond_to :limit }
+  it { is_expected.to respond_to :limit= }
+
   describe '#fields' do
     subject { described_class.new.fields.map { |field| [field.id, field.name] } }
 
@@ -81,6 +84,23 @@ RSpec.describe GeckoboardPublisher::ProfilesChangedReport do
       expect(subject.size).to eql 4
       expected_items.each do |item|
         is_expected.to include item
+      end
+    end
+
+    context 'limitability' do
+      it 'limits the number of returned items' do
+        expect_any_instance_of(described_class).to receive(:limit).and_return 1
+        expect(subject.size).to eql 1
+      end
+
+      it 'removes items over the limit oldest first' do
+        allow_any_instance_of(described_class).to receive(:limit).and_return 3
+        is_expected.not_to include expected_items.first
+        is_expected.to include expected_items.last
+      end
+
+      it 'default limit is 500 - due to geckoboard limitation of 500' do
+        expect(described_class.new.limit).to eql 500
       end
     end
   end

--- a/spec/support/shared_examples_for_geckoboard_reports.rb
+++ b/spec/support/shared_examples_for_geckoboard_reports.rb
@@ -62,7 +62,6 @@ shared_examples 'geckoboard publishable report' do
   end
 
   describe '#unpublish!' do
-
     context 'when dataset exists' do
       it 'deletes the dataset and returns true' do
         mock_expectations do |client|
@@ -72,6 +71,7 @@ shared_examples 'geckoboard publishable report' do
         end
       end
     end
+
     context 'when dataset does not exist' do
       it 'returns false when the dataset does not exist' do
         mock_expectations do |client|


### PR DESCRIPTION
Geckboard datasets are limited to 500 records and this report regularly exceeds it.