### PR TITLE
add metrics for number of people in a team not at a branch tip

### DIFF
--- a/app/models/concerns/geckoboard_datasets.rb
+++ b/app/models/concerns/geckoboard_datasets.rb
@@ -54,6 +54,13 @@ module Concerns::GeckoboardDatasets
       pgresults
     end
 
+    def not_in_tip_team
+      non_branch_tip_teams = Group.all.select(&:has_children?).map(&:id)
+      unscoped.
+        joins(:memberships).
+        where(memberships: { group_id: non_branch_tip_teams })
+    end
+
     private
 
     def profile_events_raw_sql

--- a/lib/geckoboard_publisher/profiles_percentage_report.rb
+++ b/lib/geckoboard_publisher/profiles_percentage_report.rb
@@ -7,7 +7,8 @@ module GeckoboardPublisher
         Geckoboard::PercentageField.new(:with_photos, name: 'With Photos'),
         Geckoboard::PercentageField.new(:with_additional_info, name: 'With Additional Info'),
         Geckoboard::PercentageField.new(:not_in_team, name: 'Not in any team nor MoJ'),
-        Geckoboard::PercentageField.new(:not_in_subteam, name: 'Not in a subteam - i.e. in MoJ')
+        Geckoboard::PercentageField.new(:not_in_subteam, name: 'Not in a subteam - i.e. in MoJ'),
+        Geckoboard::PercentageField.new(:not_in_tip_team, name: 'Not in a branch tip team - e.g. at Agency level')
       ]
     end
 
@@ -15,11 +16,11 @@ module GeckoboardPublisher
       setup
       [
         {
-          total: @total,
           with_photos: @with_photos,
           with_additional_info: @with_additional_info,
           not_in_team: @not_in_team,
-          not_in_subteam: @not_in_subteam
+          not_in_subteam: @not_in_subteam,
+          not_in_tip_team: @not_in_tip_team
         }
       ]
     end
@@ -27,11 +28,24 @@ module GeckoboardPublisher
     private
 
     def setup
-      @total ||= Person.count
-      @with_photos ||= (Person.photo_profiles.count.to_f/@total).round(2)
-      @with_additional_info ||= (Person.additional_info_profiles.count.to_f/@total).round(2)
-      @not_in_team ||= (Person.not_in_team.count.to_f/@total).round(2)
-      @not_in_subteam ||= (Person.not_in_subteam.count.to_f/@total).round(2)
+      percentage = PercentageOfTotal.new(Person)
+      @with_photos ||= percentage.value(:photo_profiles)
+      @with_additional_info ||= percentage.value(:additional_info_profiles)
+      @not_in_team ||= percentage.value(:not_in_team)
+      @not_in_subteam ||= percentage.value(:not_in_subteam)
+      @not_in_tip_team ||= percentage.value(:not_in_tip_team)
+    end
+
+    class PercentageOfTotal
+      def initialize model_klass
+        @model_klass = model_klass
+        @total = model_klass.count.to_f
+      end
+
+      def value scope
+        count = @model_klass.__send__(scope).count
+        (count/@total).round(2)
+      end
     end
   end
 

--- a/spec/lib/geckoboard_publisher/profiles_percentage_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profiles_percentage_report_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe GeckoboardPublisher::ProfilesPercentageReport do
         Geckoboard::PercentageField.new(:with_photos, name: 'With Photos'),
         Geckoboard::PercentageField.new(:with_additional_info, name: 'With Additional Info'),
         Geckoboard::PercentageField.new(:not_in_team, name: 'Not in any team nor MoJ'),
-        Geckoboard::PercentageField.new(:not_in_subteam, name: 'Not in a subteam - i.e. in MoJ')
+        Geckoboard::PercentageField.new(:not_in_subteam, name: 'Not in a subteam - i.e. in MoJ'),
+        Geckoboard::PercentageField.new(:not_in_tip_team, name: 'Not in a branch tip team - e.g. at Agency level')
       ].map { |field| [field.id,field.name] }
     end
 
@@ -27,11 +28,11 @@ RSpec.describe GeckoboardPublisher::ProfilesPercentageReport do
     let(:expected_items) do
       [
         {
-          total: 3,
           with_photos: 0.67,
           with_additional_info: 0.67,
           not_in_team: 0.33,
-          not_in_subteam: 0.33
+          not_in_subteam: 0.33,
+          not_in_tip_team: 0.33
         }
       ]
     end


### PR DESCRIPTION
To assist in determining team accuracy this metric returns profiles in teams that have sub teams i.e. not at the tip of a branch in the directory structure. Ideally there should be relatively few people in such teams.