### PR TITLE
force dataset replacement

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,23 +5,23 @@ if ENV['ENV'] == 'production'
   job_type :rails_script, "cd /usr/src/app && ./rails_runner.sh ':task' :output"
 
   every :weekday, at: '6:00am' do
-    rails_script 'GeckoboardPublisher::PhotoProfilesReport.new.publish!'
+    rails_script 'GeckoboardPublisher::PhotoProfilesReport.new.publish!(true)'
   end
 
   every :weekday, at: '6:10am' do
-    rails_script 'GeckoboardPublisher::ProfilesPercentageReport.new.publish!'
+    rails_script 'GeckoboardPublisher::ProfilesPercentageReport.new.publish!(true)'
   end
 
   every :weekday, at: '6:20am' do
-    rails_script 'GeckoboardPublisher::TotalProfilesReport.new.publish!'
+    rails_script 'GeckoboardPublisher::TotalProfilesReport.new.publish!(true)'
   end
 
   every :weekday, at: '6:30am' do
-    rails_script 'GeckoboardPublisher::ProfilesChangedReport.new.publish!'
+    rails_script 'GeckoboardPublisher::ProfilesChangedReport.new.publish!(true)'
   end
 
   every :weekday, at: '6:40am' do
-    rails_script 'GeckoboardPublisher::ProfileCompletionsReport.new.publish!'
+    rails_script 'GeckoboardPublisher::ProfileCompletionsReport.new.publish!(true)'
   end
 
   every :weekday, at: '8am' do

--- a/spec/support/matchers/whenever_matchers.rb
+++ b/spec/support/matchers/whenever_matchers.rb
@@ -1,6 +1,6 @@
 RSpec::Matchers.define :be_defined do
   match do |actual|
-    command = actual.split('.')
+    command = actual.split('(')[0].split('.')
     command.first.constantize.public_methods.include?(command.last.to_sym) ||
       command.first.constantize.public_instance_methods.include?(command.last.to_sym)
   end


### PR DESCRIPTION
This avoids conflict errors that can arise when you change the
dataset schema/fields for an existing/published dataset.