### PR TITLE
Geckoboard team profile percentages

### DIFF
--- a/lib/geckoboard_publisher/profile_completions_report.rb
+++ b/lib/geckoboard_publisher/profile_completions_report.rb
@@ -5,13 +5,23 @@ module GeckoboardPublisher
       [
         Geckoboard::StringField.new(:team, name: 'Team name'),
         Geckoboard::NumberField.new(:total, name: 'Total profiles'),
-        Geckoboard::NumberField.new(:with_photos, name: 'Profiles with photos'),
-        Geckoboard::NumberField.new(:with_additional_info, name: 'Profiles with Additional Info')
+        Geckoboard::PercentageField.new(:with_photos, name: '% Profiles with photos'),
+        Geckoboard::PercentageField.new(:with_additional_info, name: '% Profiles with Additional Info')
       ]
     end
 
     def items
-      @items ||= Person.completions_per_top_level_team
+      @items ||= parse Person.completions_per_top_level_team
+    end
+
+    private
+
+    def parse items
+      items.each do |item|
+        total = item[:total].to_f
+        item[:with_photos] = item[:with_photos]/total
+        item[:with_additional_info] = item[:with_additional_info]/total
+      end
     end
 
   end

--- a/spec/lib/geckoboard_publisher/photo_profiles_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/photo_profiles_report_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe GeckoboardPublisher::PhotoProfilesReport do
   it_behaves_like 'geckoboard publishable report'
 
   describe '#fields' do
-    subject { described_class.new.fields.map { |field| [field.id, field.name] } }
+    subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
 
     let(:expected_fields) do
       [
         Geckoboard::NumberField.new(:count, name: 'Count'),
         Geckoboard::DateField.new(:photo_added_at, name: 'Photo Added'),
-      ].map { |field| [field.id,field.name] }
+      ].map { |field| [field.class, field.id, field.name] }
     end
 
     it { is_expected.to eq expected_fields }

--- a/spec/lib/geckoboard_publisher/profile_completions_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profile_completions_report_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe GeckoboardPublisher::ProfileCompletionsReport do
   it_behaves_like 'geckoboard publishable report'
 
   describe '#fields' do
-    subject { described_class.new.fields.map { |field| [field.id, field.name] } }
+    subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
 
     let(:expected_fields) do
       [
         Geckoboard::StringField.new(:team, name: 'Team name'),
         Geckoboard::NumberField.new(:total, name: 'Total profiles'),
-        Geckoboard::NumberField.new(:with_photos, name: 'Profiles with photos'),
-        Geckoboard::NumberField.new(:with_additional_info, name: 'Profiles with Additional Info')
-      ].map { |field| [field.id,field.name] }
+        Geckoboard::PercentageField.new(:with_photos, name: '% Profiles with photos'),
+        Geckoboard::PercentageField.new(:with_additional_info, name: '% Profiles with Additional Info')
+      ].map { |field| [field.class, field.id, field.name] }
     end
 
     it { is_expected.to eq expected_fields }
@@ -28,20 +28,20 @@ RSpec.describe GeckoboardPublisher::ProfileCompletionsReport do
         {
           team: "Corporate Services Group",
           total: 1,
-          with_photos: 0,
-          with_additional_info: 1
+          with_photos: 0.0,
+          with_additional_info: 1.0
         },
         {
           team: "Digital Services",
           total: 1,
-          with_photos: 1,
-          with_additional_info: 0
+          with_photos: 1.0,
+          with_additional_info: 0.0
         },
         {
           team: "NOMS",
-          total: 1,
-          with_photos: 1,
-          with_additional_info: 1
+          total: 2,
+          with_photos: 0.5,
+          with_additional_info: 0.5
         }
       ]
     end
@@ -53,6 +53,7 @@ RSpec.describe GeckoboardPublisher::ProfileCompletionsReport do
       person = create :person, :member_of, team: csg, description: 'description added'
       person = create :person, :with_photo, :member_of, team: ds, current_project: " \n\t" # test whitespace exclusion
       person = create :person, :with_photo, :member_of, team: noms, current_project: "mmmmm, donuts!"
+      person = create :person, :member_of, team: noms
     end
 
     include_examples 'returns valid items structure'

--- a/spec/lib/geckoboard_publisher/profiles_changed_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profiles_changed_report_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GeckoboardPublisher::ProfilesChangedReport do
   it { is_expected.to respond_to :limit= }
 
   describe '#fields' do
-    subject { described_class.new.fields.map { |field| [field.id, field.name] } }
+    subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
 
     let(:expected_fields) do
       [
@@ -17,7 +17,7 @@ RSpec.describe GeckoboardPublisher::ProfilesChangedReport do
         Geckoboard::NumberField.new(:create, name: 'Added'),
         Geckoboard::NumberField.new(:update, name: 'Edited'),
         Geckoboard::NumberField.new(:destroy, name: 'Deleted')
-      ].map { |field| [field.id,field.name] }
+      ].map { |field| [field.class, field.id, field.name] }
     end
 
     it { is_expected.to eq expected_fields }

--- a/spec/lib/geckoboard_publisher/profiles_percentage_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profiles_percentage_report_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GeckoboardPublisher::ProfilesPercentageReport do
   it_behaves_like 'geckoboard publishable report'
 
   describe '#fields' do
-    subject { described_class.new.fields.map { |field| [field.id, field.name] } }
+    subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
 
     let(:expected_fields) do
       [
@@ -16,7 +16,7 @@ RSpec.describe GeckoboardPublisher::ProfilesPercentageReport do
         Geckoboard::PercentageField.new(:not_in_subteam, name: 'Not in a subteam - i.e. in MoJ'),
         Geckoboard::PercentageField.new(:not_in_tip_team, name: 'Not in a branch tip team - e.g. at Agency level'),
         Geckoboard::PercentageField.new(:not_edited, name: 'Never been edited')
-      ].map { |field| [field.id,field.name] }
+      ].map { |field| [field.class, field.id,field.name] }
     end
 
     it { is_expected.to eq expected_fields }

--- a/spec/lib/geckoboard_publisher/total_profiles_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/total_profiles_report_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe GeckoboardPublisher::TotalProfilesReport do
   it_behaves_like 'geckoboard publishable report'
 
   describe '#fields' do
-    subject { described_class.new.fields.map { |field| [field.id, field.name] } }
+    subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
 
     let(:expected_fields) do
       [
         Geckoboard::NumberField.new(:count, name: 'Count'),
         Geckoboard::DateField.new(:created_at, name: 'Created'),
-      ].map { |field| [field.id,field.name] }
+      ].map { |field| [field.class, field.id,field.name] }
     end
 
     it { is_expected.to eq expected_fields }


### PR DESCRIPTION
change the profile completion geckoboard dataset to use percentage of total profiles for those with photos and additional info. Makes it easier to compare teams completion stats - rather than the previous raw counts.

Also, apply more robust field set tests to all geckoboard dataset specs - to include Field type/class test.