### PR TITLE
Geckoboard duplicate profiles

### DIFF
--- a/app/models/concerns/geckoboard_datasets.rb
+++ b/app/models/concerns/geckoboard_datasets.rb
@@ -98,7 +98,7 @@ module Concerns::GeckoboardDatasets
       }
     end
 
-     def duplicate_profiles_sql
+    def duplicate_profiles_sql
       <<~SQL
         SELECT given_name || ' ' || surname AS full_name,
                email
@@ -106,7 +106,8 @@ module Concerns::GeckoboardDatasets
         WHERE given_name || ' ' || surname IN (SELECT given_name || ' ' || surname
                                                 FROM people
                                                 GROUP BY given_name || ' ' || surname
-                                                HAVING count(*) > 1) order by given_name || ' ' || surname
+                                                HAVING count(*) > 1)
+        ORDER BY given_name || ' ' || surname
       SQL
     end
 

--- a/lib/geckoboard_publisher/profile_completions_report.rb
+++ b/lib/geckoboard_publisher/profile_completions_report.rb
@@ -19,8 +19,8 @@ module GeckoboardPublisher
     def parse items
       items.each do |item|
         total = item[:total].to_f
-        item[:with_photos] = item[:with_photos]/total
-        item[:with_additional_info] = item[:with_additional_info]/total
+        item[:with_photos] = (item[:with_photos]/total).round(2)
+        item[:with_additional_info] = (item[:with_additional_info]/total).round(2)
       end
     end
 

--- a/lib/geckoboard_publisher/profile_completions_report.rb
+++ b/lib/geckoboard_publisher/profile_completions_report.rb
@@ -5,8 +5,8 @@ module GeckoboardPublisher
       [
         Geckoboard::StringField.new(:team, name: 'Team name'),
         Geckoboard::NumberField.new(:total, name: 'Total profiles'),
-        Geckoboard::PercentageField.new(:with_photos, name: '% Profiles with photos'),
-        Geckoboard::PercentageField.new(:with_additional_info, name: '% Profiles with Additional Info')
+        Geckoboard::PercentageField.new(:with_photos, name: '% profiles with photos'),
+        Geckoboard::PercentageField.new(:with_additional_info, name: '% profiles with Additional Info')
       ]
     end
 

--- a/lib/geckoboard_publisher/profile_duplicates_report.rb
+++ b/lib/geckoboard_publisher/profile_duplicates_report.rb
@@ -1,0 +1,50 @@
+
+
+
+module GeckoboardPublisher
+  class ProfileDuplicatesReport < Report
+
+    attr_accessor :limit
+
+    def initialize
+      @limit = 5000
+      @items = nil
+      super
+    end
+
+    def fields
+      [
+        Geckoboard::StringField.new(:full_name, name: 'Duplicate name'),
+        Geckoboard::NumberField.new(:emails, name: 'email list')
+      ]
+    end
+
+    def items
+      @items ||= parse Person.duplicate_profiles
+    end
+
+    private
+
+    def parse pgresult
+      @sets = []
+      pgresult.each do |row|
+        find_or_create_set(row)
+      end
+      @sets
+    end
+
+    # geckboard datasets can only accept 500 sets per POST or PUT and only 5000 sets maximum
+    def replace_dataset!
+      raise "To be implemented"
+    end
+
+    def find_or_create_set row
+      @sets.each do |set|
+        if set[:full_name] == row['full_name']
+          return set[:emails] = set[:emails] + ', ' + row['email']
+        end
+      end
+      @sets << { full_name: row['full_name'], emails: row['email'] }
+    end
+  end
+end

--- a/lib/geckoboard_publisher/profile_duplicates_report.rb
+++ b/lib/geckoboard_publisher/profile_duplicates_report.rb
@@ -33,11 +33,6 @@ module GeckoboardPublisher
       @sets
     end
 
-    # geckboard datasets can only accept 500 sets per POST or PUT and only 5000 sets maximum
-    def replace_dataset!
-      raise "To be implemented"
-    end
-
     def find_or_create_set row
       @sets.each do |set|
         if set[:full_name] == row['full_name']

--- a/lib/geckoboard_publisher/profile_duplicates_report.rb
+++ b/lib/geckoboard_publisher/profile_duplicates_report.rb
@@ -1,21 +1,10 @@
-
-
-
 module GeckoboardPublisher
   class ProfileDuplicatesReport < Report
-
-    attr_accessor :limit
-
-    def initialize
-      @limit = 5000
-      @items = nil
-      super
-    end
 
     def fields
       [
         Geckoboard::StringField.new(:full_name, name: 'Duplicate name'),
-        Geckoboard::NumberField.new(:emails, name: 'email list')
+        Geckoboard::StringField.new(:emails, name: 'email list')
       ]
     end
 

--- a/lib/geckoboard_publisher/profiles_changed_report.rb
+++ b/lib/geckoboard_publisher/profiles_changed_report.rb
@@ -1,11 +1,6 @@
 module GeckoboardPublisher
   class ProfilesChangedReport < Report
 
-    def initialize
-      @items = nil
-      super
-    end
-
     def fields
       [
         Geckoboard::DateField.new(:date, name: 'Date'),

--- a/lib/geckoboard_publisher/profiles_changed_report.rb
+++ b/lib/geckoboard_publisher/profiles_changed_report.rb
@@ -1,10 +1,7 @@
 module GeckoboardPublisher
   class ProfilesChangedReport < Report
 
-    attr_accessor :limit
-
     def initialize
-      @limit = 500
       @items = nil
       super
     end
@@ -29,11 +26,7 @@ module GeckoboardPublisher
       pgresult.each do |row|
         find_or_create_set(row)
       end
-      @sets.drop(limit_diff)
-    end
-
-    def limit_diff
-      [0, @sets.size - limit].max
+      @sets
     end
 
     def template date, options = {}

--- a/lib/geckoboard_publisher/report.rb
+++ b/lib/geckoboard_publisher/report.rb
@@ -77,8 +77,12 @@ module GeckoboardPublisher
     end
 
     def replace_dataset!
-      items.each_slice(ITEMS_CHUNK_SIZE) do |chunk|
-        @published = dataset.put(chunk)
+      items.each_slice(ITEMS_CHUNK_SIZE).with_index do |chunk, idx|
+        @published = if idx == 0
+                       dataset.put(chunk)
+                     else
+                       dataset.post(chunk)
+                     end
         break unless published?
       end
       published?

--- a/lib/geckoboard_publisher/report.rb
+++ b/lib/geckoboard_publisher/report.rb
@@ -8,9 +8,11 @@ module GeckoboardPublisher
 
     # geckboard datasets can only accept 500 sets per POST or PUT
     # and only 5000 sets maximum
-    ITEMS_CHUNK_SIZE = 500.freeze
+    ITEMS_CHUNK_SIZE = 500
 
-    attr_reader :client, :dataset
+    attr_reader :client, :dataset, :published, :force
+    alias published? published
+    alias force? force
 
     def initialize
       @published = false
@@ -66,14 +68,6 @@ module GeckoboardPublisher
 
     def items
       raise "Implement #{__method__} in subclass"
-    end
-
-    def force?
-      @force
-    end
-
-    def published?
-      @published
     end
 
     private

--- a/spec/lib/geckoboard_publisher/profile_completions_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profile_completions_report_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe GeckoboardPublisher::ProfileCompletionsReport do
       [
         Geckoboard::StringField.new(:team, name: 'Team name'),
         Geckoboard::NumberField.new(:total, name: 'Total profiles'),
-        Geckoboard::PercentageField.new(:with_photos, name: '% Profiles with photos'),
-        Geckoboard::PercentageField.new(:with_additional_info, name: '% Profiles with Additional Info')
+        Geckoboard::PercentageField.new(:with_photos, name: '% profiles with photos'),
+        Geckoboard::PercentageField.new(:with_additional_info, name: '% profiles with Additional Info')
       ].map { |field| [field.class, field.id, field.name] }
     end
 

--- a/spec/lib/geckoboard_publisher/profile_duplicates_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profile_duplicates_report_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe GeckoboardPublisher::ProfileDuplicatesReport do
     end
 
     before do
-      person = create :person, given_name: 'Sid', surname: 'James', email: 'sid.james@digital.justice.gov.uk'
-      person = create :person, given_name: 'Sid', surname: 'James', email: 'sid.james2@digital.justice.gov.uk'
-      person = create :person, given_name: 'Peter', surname: 'Smith', email: 'peter.smith@digital.justice.gov.uk'
-      person = create :person, given_name: 'Peter', surname: 'Smith', email: 'peter.smith2@digital.justice.gov.uk'
-      person = create :person, given_name: 'Sidney', surname: 'James', email: 'sidney.james@digital.justice.gov.uk'
+      create :person, given_name: 'Sid', surname: 'James', email: 'sid.james@digital.justice.gov.uk'
+      create :person, given_name: 'Sid', surname: 'James', email: 'sid.james2@digital.justice.gov.uk'
+      create :person, given_name: 'Peter', surname: 'Smith', email: 'peter.smith@digital.justice.gov.uk'
+      create :person, given_name: 'Peter', surname: 'Smith', email: 'peter.smith2@digital.justice.gov.uk'
+      create :person, given_name: 'Sidney', surname: 'James', email: 'sidney.james@digital.justice.gov.uk'
     end
 
     include_examples 'returns valid items structure'

--- a/spec/lib/geckoboard_publisher/profile_duplicates_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profile_duplicates_report_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe GeckoboardPublisher::ProfileDuplicatesReport do
     let(:expected_fields) do
       [
         Geckoboard::StringField.new(:full_name, name: 'Duplicate name'),
-        Geckoboard::NumberField.new(:emails, name: 'email list'),
+        Geckoboard::StringField.new(:emails, name: 'email list'),
       ].map { |field| [field.class, field.id, field.name] }
     end
 

--- a/spec/lib/geckoboard_publisher/profile_duplicates_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profile_duplicates_report_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe GeckoboardPublisher::ProfileDuplicatesReport do
+  include PermittedDomainHelper
+
+  it_behaves_like 'geckoboard publishable report'
+
+  describe '#fields' do
+    subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
+
+    let(:expected_fields) do
+      [
+        Geckoboard::StringField.new(:full_name, name: 'Duplicate name'),
+        Geckoboard::NumberField.new(:emails, name: 'email list'),
+      ].map { |field| [field.class, field.id, field.name] }
+    end
+
+    it { is_expected.to eq expected_fields }
+  end
+
+  describe '#items' do
+    subject { described_class.new.items }
+
+    let(:expected_items) do
+      [
+        {
+          full_name: "Sid James",
+          emails: 'sid.james@digital.justice.gov.uk, sid.james2@digital.justice.gov.uk'
+        },
+        {
+          full_name: "Peter Smith",
+          emails: 'peter.smith@digital.justice.gov.uk, peter.smith2@digital.justice.gov.uk'
+        }
+      ]
+    end
+
+    before do
+      person = create :person, given_name: 'Sid', surname: 'James', email: 'sid.james@digital.justice.gov.uk'
+      person = create :person, given_name: 'Sid', surname: 'James', email: 'sid.james2@digital.justice.gov.uk'
+      person = create :person, given_name: 'Peter', surname: 'Smith', email: 'peter.smith@digital.justice.gov.uk'
+      person = create :person, given_name: 'Peter', surname: 'Smith', email: 'peter.smith2@digital.justice.gov.uk'
+      person = create :person, given_name: 'Sidney', surname: 'James', email: 'sidney.james@digital.justice.gov.uk'
+    end
+
+    include_examples 'returns valid items structure'
+
+    it 'returns expected dataset items' do
+      expect(subject.size).to eql 2
+      expected_items.each do |item|
+        is_expected.to include item
+      end
+    end
+
+  end
+
+end

--- a/spec/lib/geckoboard_publisher/profiles_changed_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profiles_changed_report_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe GeckoboardPublisher::ProfilesChangedReport do
 
   it_behaves_like 'geckoboard publishable report'
 
-  it { is_expected.to respond_to :limit }
-  it { is_expected.to respond_to :limit= }
-
   describe '#fields' do
     subject { described_class.new.fields.map { |field| [field.class, field.id, field.name] } }
 
@@ -84,23 +81,6 @@ RSpec.describe GeckoboardPublisher::ProfilesChangedReport do
       expect(subject.size).to eql 4
       expected_items.each do |item|
         is_expected.to include item
-      end
-    end
-
-    context 'limitability' do
-      it 'limits the number of returned items' do
-        expect_any_instance_of(described_class).to receive(:limit).and_return 1
-        expect(subject.size).to eql 1
-      end
-
-      it 'removes items over the limit oldest first' do
-        allow_any_instance_of(described_class).to receive(:limit).and_return 3
-        is_expected.not_to include expected_items.first
-        is_expected.to include expected_items.last
-      end
-
-      it 'default limit is 500 - due to geckoboard limitation of 500' do
-        expect(described_class.new.limit).to eql 500
       end
     end
   end

--- a/spec/lib/geckoboard_publisher/profiles_percentage_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profiles_percentage_report_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GeckoboardPublisher::ProfilesPercentageReport do
         Geckoboard::PercentageField.new(:not_in_subteam, name: 'Not in a subteam - i.e. in MoJ'),
         Geckoboard::PercentageField.new(:not_in_tip_team, name: 'Not in a branch tip team - e.g. at Agency level'),
         Geckoboard::PercentageField.new(:not_edited, name: 'Never been edited')
-      ].map { |field| [field.class, field.id,field.name] }
+      ].map { |field| [field.class, field.id, field.name] }
     end
 
     it { is_expected.to eq expected_fields }

--- a/spec/lib/geckoboard_publisher/total_profiles_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/total_profiles_report_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GeckoboardPublisher::TotalProfilesReport do
       [
         Geckoboard::NumberField.new(:count, name: 'Count'),
         Geckoboard::DateField.new(:created_at, name: 'Created'),
-      ].map { |field| [field.class, field.id,field.name] }
+      ].map { |field| [field.class, field.id, field.name] }
     end
 
     it { is_expected.to eq expected_fields }

--- a/spec/support/matchers/general_matchers.rb
+++ b/spec/support/matchers/general_matchers.rb
@@ -1,4 +1,5 @@
 require 'rspec/expectations'
+require 'byebug'
 
 RSpec::Matchers.define :include_hash_matching do |expected|
   match do |array_of_hashes|
@@ -11,5 +12,31 @@ RSpec::Matchers.define :include_hash_matching do |expected|
 
   failure_message_when_negated do |array_of_hashes|
     "expected #{array_of_hashes} not to include key-value pair #{expected.to_s.gsub(/\{|\}/, '')}."
+  end
+end
+
+RSpec::Matchers.define :have_constant do |expected|
+  match do |owner|
+    result = owner.const_defined?(expected[:name])
+    result = owner.const_get(expected[:name]) == expected[:value] if expected.key? :value
+    result
+  end
+
+  description do
+    string = "have constant named #{expected[:name]}"
+    string += " with a value of #{expected[:value]}." if expected.key? :value
+    string
+  end
+
+  failure_message do |owner|
+    msg = "expected #{owner} to have a constant named #{expected[:name]} defined"
+    msg += " with a value of #{expected[:value]}." if expected.key? :value
+    msg
+  end
+
+  failure_message_when_negated do |owner|
+    msg = "expected #{owner} not to have a constant named #{expected[:name]} defined "
+    msg += "with a value of #{expected[:value]}." if expected.key? :value
+    msg
   end
 end

--- a/spec/support/shared_examples_for_geckoboard_reports.rb
+++ b/spec/support/shared_examples_for_geckoboard_reports.rb
@@ -12,6 +12,8 @@ shared_examples 'geckoboard publishable report' do
   it { is_expected.to respond_to :id }
   it { is_expected.to respond_to :fields }
   it { is_expected.to respond_to :publish! }
+  it { is_expected.to respond_to :force? }
+  it { is_expected.to respond_to :published? }
 
   def mock_expectations exit_without_ping = nil
     allow(ENV).to receive(:[]).with('ENV').and_return 'staging'
@@ -68,7 +70,7 @@ shared_examples 'geckoboard publishable report' do
         end
       end
 
-      it 'by trying once again when force specified' do
+      it 'by overwriting existing dataset when force specified' do
         expect(subject).to receive(:overwrite!)
         subject.publish! true
       end

--- a/spec/support/shared_examples_for_geckoboard_reports.rb
+++ b/spec/support/shared_examples_for_geckoboard_reports.rb
@@ -69,12 +69,12 @@ shared_examples 'geckoboard publishable report' do
       end
 
       it 'by trying once again when force specified' do
-        expect(subject).to receive(:try_once_more!)
+        expect(subject).to receive(:overwrite!)
         subject.publish! true
       end
 
       it 'by raising errors when force not specified' do
-        expect(subject).not_to receive(:try_once_more!)
+        expect(subject).not_to receive(:overwrite!)
         expect { subject.publish! }.to raise_error Geckoboard::ConflictError
       end
     end

--- a/spec/support/shared_examples_for_geckoboard_reports.rb
+++ b/spec/support/shared_examples_for_geckoboard_reports.rb
@@ -8,6 +8,7 @@ shared_examples 'geckoboard publishable report' do
 
   subject { described_class.new }
 
+  it { expect(described_class).to have_constant name: :ITEMS_CHUNK_SIZE, value: 500 }
   it { is_expected.to respond_to :client }
   it { is_expected.to respond_to :id }
   it { is_expected.to respond_to :fields }


### PR DESCRIPTION
Adds a report on duplicate people. 

Also modifies the super class for geckboard publisher to chunk POST/PUTs, to the API at 500 records each - to match the APIs limits.

NOTE: am thinking to refactor some of the SQL to Query objects and use arel