### PR TITLE
fix warning on use of shared examples

### DIFF
--- a/spec/controllers/concerns/shared_examples_for_session_person_creator.rb
+++ b/spec/controllers/concerns/shared_examples_for_session_person_creator.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 shared_examples_for "session_person_creatable" do
 
   it { is_expected.to respond_to :person_from_auth_hash }

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require Rails.root.join('spec', 'controllers', 'concerns', 'session_person_creator_spec.rb')
+require Rails.root.join('spec', 'controllers', 'concerns', 'shared_examples_for_session_person_creator.rb')
 
 RSpec.describe SessionsController, type: :controller do
   include PermittedDomainHelper

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require Rails.root.join('spec', 'controllers', 'concerns', 'session_person_creator_spec.rb')
+require Rails.root.join('spec', 'controllers', 'concerns', 'shared_examples_for_session_person_creator.rb')
 
 describe TokensController, type: :controller do
   include PermittedDomainHelper


### PR DESCRIPTION
fixes:

```
WARNING: Shared example group 'session_person_creatable' has been previously defined at:
  /Users/jsugarman/rails_projects/ds_work/peoplefinder/spec/controllers/concerns/session_person_creator_spec.rb:3
...and you are now defining it at:
  /Users/jsugarman/rails_projects/ds_work/peoplefinder/spec/controllers/concerns/session_person_creator_spec.rb:3
The new definition will overwrite the original one.
```

...that occured on running rspec.
