### PR TITLE
fix bug stopping saving of leader/subscription change

### DIFF
--- a/app/views/people/confirm.html.haml
+++ b/app/views/people/confirm.html.haml
@@ -16,6 +16,8 @@
     = f.fields_for :memberships do |membership_f|
       = membership_f.hidden_field :role
       = membership_f.hidden_field :group_id
+      = membership_f.hidden_field :leader
+      = membership_f.hidden_field :subscribed
 
     = f.hidden_field :location_in_building
     = f.hidden_field :building

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -34,6 +34,23 @@ feature "Person maintenance" do
     expect(page).to have_selector('.group-leader .leader-role', text: 'Head Honcho')
   end
 
+  scenario 'Confirming an identical person with membership details', js: true do
+    create(:group, name: 'Digital Justice')
+    create(:person, given_name: person_attributes[:given_name], surname: person_attributes[:surname])
+
+    javascript_log_in
+    visit new_person_path
+    fill_in_complete_profile_details
+    fill_in_membership_details('Digital Justice')
+
+    click_button 'Save', match: :first
+
+    expect(page).to have_text('1 result found')
+    click_button 'Continue'
+    duplicate = Person.find_by(email: person_attributes[:email])
+    expect(duplicate.memberships.last).to have_attributes membership_attributes
+  end
+
   scenario 'Editing a job title', js: true do
     person = create_person_in_digital_justice
 
@@ -105,9 +122,6 @@ feature "Person maintenance" do
     within('.new-team') do
       fill_in 'AddTeam', with: 'New team'
     end
-    # click_link 'Create'
-    # expect(page).to have_selector('.subteam-name', text: 'New team', visible: :visible)
-
   end
 
   scenario 'Adding an additional role', js: true do
@@ -129,8 +143,8 @@ feature "Person maintenance" do
     expect(Person.last.memberships.length).to eql(2)
   end
 
-  def check_leader
-    within('.team-leader') { choose('Yes') }
+  def check_leader(choice = 'Yes')
+    within('.team-leader') { choose(choice) }
   end
 
   scenario 'Adding an additional leadership role in same team', js: true do

--- a/spec/support/profile.rb
+++ b/spec/support/profile.rb
@@ -16,6 +16,15 @@ module SpecSupport
       }
     end
 
+    def membership_attributes
+      {
+        role: 'The boss',
+        group_id: Group.first.id || create(:group).id,
+        leader: true,
+        subscribed: false
+      }
+    end
+
     def complete_profile!(person)
       profile_photo = create(:profile_photo)
       person.update_attributes(
@@ -41,6 +50,17 @@ module SpecSupport
       fill_in 'Current project(s)', with: person_attributes[:current_project]
       uncheck('Monday')
       uncheck('Friday')
+    end
+
+    def fill_in_membership_details(team_name)
+      fill_in 'Job title', with: membership_attributes[:role]
+      select_in_team_select(team_name)
+      within '.team-leader' do
+        choose(membership_attributes[:leader] ? 'Yes' : 'No')
+      end
+      within '.team-subscribed' do
+        choose membership_attributes[:subscribed] ? 'Yes' : 'No'
+      end
     end
 
     def check_creation_of_profile_details


### PR DESCRIPTION
when creating/editing a profile the flow checks whether
the person is a duplicate, however the leader and subscription
attributes were not being stored in the hidden fields on the
confirmation page thereby causing them to be lost on subsequent
submission.