### PR TITLE
fix scalability of people in subteams count query

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -83,11 +83,13 @@ class Group < ActiveRecord::Base
   end
 
   def people_outside_subteams
+    # TODO: replace with scope and person method for role_names
+    # i.e. Person.outside_subteams(self)
     Person.all_in_groups([id]) - Person.all_in_groups(subteam_ids) - leaders
   end
 
   def people_outside_subteams_count
-    Person.count_in_groups([id], excluded_group_ids: subteam_ids, excluded_ids: leaders.pluck(:id))
+    Person.outside_subteams(self).count
   end
 
   def leaderships_by_person

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -112,6 +112,15 @@ class Person < ActiveRecord::Base
   scope :all_in_groups_scope, -> (groups) { from(all_in_groups_from_clause(groups), :people) }
   scope :all_in_subtree, -> (group) { from(all_in_groups_from_clause(group.subtree_ids), :people) }
 
+  def self.outside_subteams(group)
+    unscope(:order).
+      joins(:memberships).
+      where(memberships: { group_id: group.id }).
+      where(memberships: { leader: false }).
+      where('NOT EXISTS (SELECT 1 FROM memberships m2 WHERE m2.person_id = people.id AND m2.group_id != ?)', group.id).
+      uniq
+  end
+
   # Does not return ActiveRecord::Relation
   # - see all_in_groups_scope alternative
   # TODO: remove when not needed


### PR DESCRIPTION
Team pages query the number of people that are in that team but not in a subteam thereof. For MoJ and NOMS teams the query method was taking 14+ secs and resulting in a timeout for the response and consequently raising a 500 error to the user.

This PR creates a more efficient scope which hits the db only once for the count