### PR TITLE
amend read-only user ip whitelist mechanism

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 # minimum env vars required
 SUPPORT_EMAIL=support@example.com
-READONLY_HEADER=RO
-READONLY_VALUE=ENABLED
+
+# allow read-only access from local development
+READONLY_IP_WHITELIST=127.0.0.1

--- a/app/models/ip_address_matcher.rb
+++ b/app/models/ip_address_matcher.rb
@@ -2,7 +2,7 @@ require 'netaddr'
 
 class IpAddressMatcher
   def initialize(terms)
-    @cidrs = cidrs(terms)
+    @cidrs = cidrs(terms) || []
   end
 
   def ===(other)
@@ -12,7 +12,7 @@ class IpAddressMatcher
   private
 
   def cidrs(terms)
-    terms.split(';').map { |s| cidr(s) }
+    terms.split(';').map { |s| cidr(s) } unless terms.blank?
   end
 
   def cidr(term)

--- a/app/models/ip_address_matcher.rb
+++ b/app/models/ip_address_matcher.rb
@@ -1,6 +1,7 @@
 require 'netaddr'
 
 class IpAddressMatcher
+
   def initialize(terms)
     @cidrs = cidrs(terms) || []
   end
@@ -8,6 +9,7 @@ class IpAddressMatcher
   def ===(other)
     @cidrs.any? { |cidr| cidr.matches?(other) }
   end
+  alias include? ===
 
   private
 

--- a/app/models/readonly_user.rb
+++ b/app/models/readonly_user.rb
@@ -1,10 +1,17 @@
 class ReadonlyUser
-  def self.from_request(request)
-    return new if Rails.env.development?
-    header_name = "HTTP_#{Rails.configuration.readonly[:header].tr('-', '_')}"
-    header_value = Rails.configuration.readonly[:value]
 
-    if request.headers[header_name] && request.headers[header_name] == header_value
+  class ActionDispatch::Request
+    def readonly_ip_whitelist
+      @whitelist ||= IpAddressMatcher.new(Rails.configuration.readonly_ip_whitelist)
+    end
+
+    def remote_ip_whitelisted?
+      readonly_ip_whitelist === remote_ip
+    end
+  end
+
+  def self.from_request(request)
+    if request.remote_ip_whitelisted?
       new
     end
   end

--- a/app/models/readonly_user.rb
+++ b/app/models/readonly_user.rb
@@ -6,14 +6,12 @@ class ReadonlyUser
     end
 
     def remote_ip_whitelisted?
-      readonly_ip_whitelist === remote_ip
+      readonly_ip_whitelist.include? remote_ip
     end
   end
 
   def self.from_request(request)
-    if request.remote_ip_whitelisted?
-      new
-    end
+    new if request.remote_ip_whitelisted?
   end
 
   def id

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,14 +30,11 @@ module Peoplefinder
 
     config.admin_ip_ranges = ENV.fetch('ADMIN_IP_RANGES', '127.0.0.1')
 
+    config.readonly_ip_whitelist = ENV['READONLY_IP_WHITELIST']
+
     config.assets.paths << Rails.root.join('vendor', 'assets', 'components')
 
     config.support_email = ENV.fetch('SUPPORT_EMAIL')
-
-    config.readonly = {
-      header: ENV['READONLY_HEADER'],
-      value: ENV['READONLY_VALUE']
-    }
 
     config.action_mailer.default_options = {
       from:  config.support_email

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module Peoplefinder
 
     config.admin_ip_ranges = ENV.fetch('ADMIN_IP_RANGES', '127.0.0.1')
 
-    config.readonly_ip_whitelist = ENV['READONLY_IP_WHITELIST']
+    config.readonly_ip_whitelist = ENV.fetch('READONLY_IP_WHITELIST', '127.0.0.1')
 
     config.assets.paths << Rails.root.join('vendor', 'assets', 'components')
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,4 +17,6 @@ Rails.application.configure do
   config.action_mailer.asset_host = 'http://www.example.com'
   config.active_job.queue_adapter = :test
 
+  # mock the fact we are NOT on an IP whitelist for test runs
+  config.readonly_ip_whitelist = nil
 end

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -13,7 +13,7 @@ feature 'Group maintenance' do
   end
 
   before(:each, user: :readonly) do
-    page.driver.browser.header('RO', 'ENABLED')
+    mock_readonly_user
   end
 
   def visit_edit_view group

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -19,8 +19,7 @@ feature 'Home page' do
   context 'for the readonly user' do
     before do
       create(:department)
-
-      page.driver.header 'RO', 'ENABLED'
+      mock_readonly_user
       visit '/'
     end
 

--- a/spec/features/login_page_spec.rb
+++ b/spec/features/login_page_spec.rb
@@ -16,7 +16,7 @@ feature 'Login page' do
   end
   context 'User from inside the network' do
     before do
-      page.driver.browser.header('RO', 'ENABLED')
+      mock_readonly_user
     end
 
     scenario 'Is presented with standard login page and copy if they decide to login' do

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -12,7 +12,7 @@ feature 'Person maintenance' do
   end
 
   before(:each, user: :readonly) do
-    page.driver.browser.header('RO', 'ENABLED')
+    mock_readonly_user
   end
 
   let(:edit_profile_page) { Pages::EditProfile.new }

--- a/spec/features/suggestion_spec.rb
+++ b/spec/features/suggestion_spec.rb
@@ -25,7 +25,7 @@ feature 'Make a suggestion about a profile', js: true do
   end
 
   before(:each, user: :readonly) do
-    page.driver.browser.header('RO', 'ENABLED')
+    mock_readonly_user
     visit person_path(subject)
   end
 

--- a/spec/models/ip_address_matcher_spec.rb
+++ b/spec/models/ip_address_matcher_spec.rb
@@ -1,5 +1,4 @@
-require 'spec_helper'
-require 'ip_address_matcher'
+require 'rails_helper'
 
 RSpec.describe IpAddressMatcher do
   it 'matches a single IP address' do
@@ -21,5 +20,11 @@ RSpec.describe IpAddressMatcher do
     expect(matcher.===('12.34.56.78')).to be_truthy
     expect(matcher.===('127.0.0.1')).to be_truthy
     expect(matcher.===('12.33.44.44')).to be_falsy
+  end
+
+  it 'aliases include? to ===' do
+    matcher = described_class.new('12.34.0.0/16;127.0.0.0/24')
+    expect(matcher.include?('127.0.0.1')).to be_truthy
+    expect(matcher.include?('12.33.44.44')).to be_falsy
   end
 end

--- a/spec/models/readonly_user_spec.rb
+++ b/spec/models/readonly_user_spec.rb
@@ -3,19 +3,20 @@ require 'rails_helper'
 RSpec.describe ReadonlyUser, type: :model do
   subject { described_class.new }
 
+  let(:be_readonly_user) { be_instance_of described_class }
+
   describe '.from_request' do
-    let(:request) { double('request') }
+    let(:request) { ActionDispatch::TestRequest.new }
 
     subject { described_class.from_request(request) }
 
-    # when request IP is whitelisted were return an instance of read-only user
     context 'when client IP is whitelisted' do
       before do
         expect(request).to receive(:remote_ip_whitelisted?).and_return(true)
       end
 
       it "returns instance of #{described_class}" do
-        is_expected.to be_instance_of described_class
+        is_expected.to be_readonly_user
       end
     end
 
@@ -25,8 +26,33 @@ RSpec.describe ReadonlyUser, type: :model do
       end
 
       it 'returns nil' do
-        is_expected.to_not be_instance_of described_class
+        is_expected.to_not be_readonly_user
         is_expected.to be_nil
+      end
+    end
+
+    context 'whitelist' do
+      let(:ip_whitelist) { '127.0.0.2/31;127.0.0.4/32' }
+      before do
+        allow(Rails.configuration).to receive(:readonly_ip_whitelist).and_return ip_whitelist
+      end
+
+      context "For IPs in CIDR range" do
+        (2..4).each do |i|
+          it "accepts IP 127.0.0.#{i}" do
+            request.remote_addr = "127.0.0.#{i}"
+            is_expected.to be_readonly_user
+          end
+        end
+      end
+
+      context "For IPs outside CIDR range" do
+        [1, 5].each do |i|
+          it "rejects IP 127.0.0.#{i}" do
+            request.remote_addr = "127.0.0.#{i}"
+            is_expected.to be_nil
+          end
+        end
       end
     end
   end

--- a/spec/models/readonly_user_spec.rb
+++ b/spec/models/readonly_user_spec.rb
@@ -4,28 +4,30 @@ RSpec.describe ReadonlyUser, type: :model do
   subject { described_class.new }
 
   describe '.from_request' do
-    let(:headers) { {} }
-    let(:request) { double(headers: headers) }
+    let(:request) { double('request') }
 
     subject { described_class.from_request(request) }
 
-    # the header name and value is defined in .env for test
-    context 'when readonly header is set' do
-      context 'when the value is correct' do
-        let(:headers) { { 'HTTP_RO' => 'ENABLED' } }
-
-        it { is_expected.to be_a(described_class) }
+    # when request IP is whitelisted were return an instance of read-only user
+    context 'when client IP is whitelisted' do
+      before do
+        expect(request).to receive(:remote_ip_whitelisted?).and_return(true)
       end
 
-      context 'for any other value' do
-        let(:headers) { { 'HTTP_RO' => 'OTHER' } }
-
-        it { is_expected.to be nil }
+      it "returns instance of #{described_class}" do
+        is_expected.to be_instance_of described_class
       end
     end
 
-    context 'when readonly header is not set' do
-      it { is_expected.to be nil }
+    context 'when client IP is not whitelisted' do
+      before do
+        expect(request).to receive(:remote_ip_whitelisted?).and_return(false)
+      end
+
+      it 'returns nil' do
+        is_expected.to_not be_instance_of described_class
+        is_expected.to be_nil
+      end
     end
   end
 

--- a/spec/support/login.rb
+++ b/spec/support/login.rb
@@ -1,5 +1,9 @@
 module SpecSupport
   module Login
+    def mock_readonly_user
+      allow(ReadonlyUser).to receive(:from_request).and_return ReadonlyUser.new
+    end
+
     def mock_logged_in_user
       controller.session[::Login::SESSION_KEY] =
         create(:person, email: 'test.user@digital.justice.gov.uk').id


### PR DESCRIPTION
The IP whitelist needs to be handled in the deploy
repo as an environment variable rather than nginx
header insertions. The app then needs to handle this
this via config and code based on a requests remote
ip.