### PR TITLE
update ruby to 2.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.3.3
 
 # https://github.com/ministryofjustice/docker-templates/issues/37
 # UTF 8 issue during bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '2.3.3'
 gem 'rails', '~> 4.2.7'
 gem 'text'
 gem 'ancestry', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -703,7 +703,7 @@ DEPENDENCIES
   will_paginate-bootstrap (~> 1.0, >= 1.0.1)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
   ruby:
     version:
-      2.3.1
+      2.3.3
 
   environment:
     DB_TEST_URL: postgres://ubuntu:@127.0.0.1:5432/circle_test


### PR DESCRIPTION
Tried 2.4.0 (rc1) but this is incompatible with json 1.8.3
that is required by rails 4.2.7. rails 4.2.8 is intended to
fix this but is not yet available. could also use latest json 1.8 branch
explicitly in Gemfile but requires rails branch usage. Will await
ruby version bump or rails version bump.

see:
- [Stack Overflow](http://stackoverflow.com/questions/41298904/is-it-possible-to-run-a-rails-4-2-app-on-ruby-2-4)
- [Github Issue](https://github.com/flori/json/issues/303)