### PR TITLE
Prevent CSRFs and 404s after reporting a problem

### DIFF
--- a/app/controllers/problem_reports_controller.rb
+++ b/app/controllers/problem_reports_controller.rb
@@ -5,10 +5,25 @@ class ProblemReportsController < ApplicationController
     problem_report = ProblemReport.new(problem_report_params)
     ProblemReportMailer.problem_report(problem_report.to_hash).deliver_later
     notice('report_sent')
-    redirect_to :back
+    redirect_to valid_return_path_or_login
   end
 
   private
+
+  # This method returns the path that the user came here from, unless it was from a path
+  # which doesn't exist within the application, or from the /auth/gplus path (which would
+  # cause a CSRF error). In either of these cases we redirect to the login page.
+  #
+  def valid_return_path_or_login
+    return_path = request.env['HTTP_REFERER']
+    begin
+      path_hash = Rails.application.routes.recognize_path(return_path)
+      return_path = new_sessions_path if path_hash[:provider] == 'gplus'
+    rescue ActionController::RoutingError
+      return_path = new_sessions_path
+    end
+    return_path
+  end
 
   def problem_report_params
     params.require(:problem_report).

--- a/app/models/permitted_domain.rb
+++ b/app/models/permitted_domain.rb
@@ -1,3 +1,3 @@
 class PermittedDomain < ActiveRecord::Base
-  validates :domain, presence: true
+  validates :domain, presence: true, uniqueness: true
 end

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -24,7 +24,7 @@ feature 'Report a problem', js: true do
       fill_in 'What went wrong?', with: 'Custard'
       click_button 'Report'
 
-      expect(current_path).to eq(group_path(group))
+      expect(current_path).to eq group_path(group)
 
       expect(last_email.to).to eq([Rails.configuration.support_email])
       body = last_email.body.encoded


### PR DESCRIPTION
Attempting to login with a google address that isn't in permitted domains will
lead to a CSRF error when redirecting back to the original page.  This PR allows
us to detect that, and redirect to the login page.