### PR TITLE
default team membership to MoJ if none specified

### DIFF
--- a/app/services/person_creator.rb
+++ b/app/services/person_creator.rb
@@ -14,6 +14,7 @@ class PersonCreator
 
   def create!
     person.save!
+    person.memberships.create(group: Group.department) if person.memberships.empty?
     send_create_email!
   end
 

--- a/app/services/person_creator.rb
+++ b/app/services/person_creator.rb
@@ -14,11 +14,15 @@ class PersonCreator
 
   def create!
     person.save!
-    person.memberships.create(group: Group.department) if person.memberships.empty?
+    default_membership!(person) if person.memberships.empty?
     send_create_email!
   end
 
   private
+
+  def default_membership! person
+    person.memberships.create!(group: Group.department) if Group.department.present?
+  end
 
   def send_create_email!
     if person.notify_of_change?(@current_user)

--- a/spec/features/group_browsing_spec.rb
+++ b/spec/features/group_browsing_spec.rb
@@ -78,7 +78,7 @@ feature 'Group browsing' do
 
       visit group_path(department)
       expect(page).not_to have_link("View all 7 people in #{department.name}")
-      expect(page).to have_link("View 1 person not assigned to a sub-team")
+      expect(page).to have_link("View 2 people not assigned to a sub-team")
       expect(page).to have_link("View printable organogram")
     end
 

--- a/spec/services/person_creator_spec.rb
+++ b/spec/services/person_creator_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PersonCreator, type: :service do
+  include PermittedDomainHelper
   let(:person) do
     double(
       'Person',
@@ -21,7 +22,19 @@ RSpec.describe PersonCreator, type: :service do
     end
   end
 
+
   describe 'create!' do
+    context 'person membership defaults' do
+      subject { described_class.new(person_object, current_user).create! }
+
+      let!(:moj) { create(:department) }
+      let(:person_object) { build(:person) }
+
+      it 'adds membership of the top team if none specified' do
+        expect{ subject }.to change(person_object.memberships, :count).by(1)
+      end
+    end
+
     it 'saves the person' do
       expect(person).to receive(:save!)
       subject.create!

--- a/spec/services/person_creator_spec.rb
+++ b/spec/services/person_creator_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PersonCreator, type: :service do
     double(
       'Person',
       email: 'example.user.1@digital.justice.gov.uk',
+      memberships: ['MoJ'],
       save!: true,
       new_record?: false,
       notify_of_change?: false
@@ -22,16 +23,15 @@ RSpec.describe PersonCreator, type: :service do
     end
   end
 
-
   describe 'create!' do
     context 'person membership defaults' do
       subject { described_class.new(person_object, current_user).create! }
-
       let!(:moj) { create(:department) }
       let(:person_object) { build(:person) }
 
       it 'adds membership of the top team if none specified' do
-        expect{ subject }.to change(person_object.memberships, :count).by(1)
+        expect { subject }.to change(person_object.memberships, :count).by(1)
+        expect(person_object.memberships.first.group).to eql Group.department
       end
     end
 


### PR DESCRIPTION
New profiles created via the GUI need not be given a membership of a team. This results in profiles that are not locatable through navigation of the team structure - they are are findable via search. This PR defaults new profiles created without a membership to be in the Top level team - MoJ.