### PR TITLE
remove editing and building alerts

### DIFF
--- a/app/assets/stylesheets/peoplefinder/application.scss
+++ b/app/assets/stylesheets/peoplefinder/application.scss
@@ -260,12 +260,6 @@ select.form-control {
   -webkit-appearance: menulist;
 }
 
-.editing-alert {
-  background-color: $turqoise;
-  text-align: center;
-  padding:1em;
-  height: auto;
-}
 form {
   position: relative;
 }

--- a/app/assets/stylesheets/peoplefinder/peoplefinder-ie7.css.scss
+++ b/app/assets/stylesheets/peoplefinder/peoplefinder-ie7.css.scss
@@ -64,13 +64,6 @@ h1, h2 {
   border-bottom: 1px solid $blackish;
   *zoom: 1;
 }
-.editing-alert {
-  background-color: $turqoise;
-  text-align: center;
-  padding:1em;
-  height: auto;
-  display: block;
-}
 
 .breadcrumbs {
   margin-top: 1em;

--- a/app/assets/stylesheets/peoplefinder/peoplefinder-lt-ie9.css.scss
+++ b/app/assets/stylesheets/peoplefinder/peoplefinder-lt-ie9.css.scss
@@ -42,10 +42,6 @@
   }
 }
 
-.editing-alert {
-  background-color: $turqoise;
-}
-
 /*required because CSS3 media rule/query not available til IE9*/
 .no-desk {
   display: none;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -116,15 +116,4 @@ module ApplicationHelper
       end
     end
   end
-
-  def editing_mode(building = false)
-    @editing_mode = true
-    content_for :editing_alert do
-      if building
-        render partial: 'shared/building_alert'
-      else
-        render partial: 'shared/editing_alert'
-      end
-    end
-  end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,4 +1,4 @@
-= editing_mode
+- @editing_mode = true
 = form_for @group do |f|
 
   - if @group.errors.any?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,6 @@
 - content_for :content do
   #wrapper
     %main#content{role: 'main'}
-      = yield :editing_alert
       = flash_messages
       .grid-wrapper
         .grid.grid-3-3

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -1,4 +1,4 @@
-= editing_mode(building)
+- @editing_mode = true
 = form_for @person, builder: PersonFormBuilder, html: { multipart: true, class: person_form_class(@person, @activity) } do |f|
 
   - if @person.errors.any?

--- a/app/views/sessions/person_confirm.html.haml
+++ b/app/views/sessions/person_confirm.html.haml
@@ -1,4 +1,4 @@
-- @editing_mode = false
+- @editing_mode = true
 #search_results
   %h1.noborder= @page_title = 'Create profile'
   .spacer-5

--- a/app/views/shared/_building_alert.html.haml
+++ b/app/views/shared/_building_alert.html.haml
@@ -1,3 +1,0 @@
-.inner-block
-  .editing-alert
-    = info_text('building_alert')

--- a/app/views/shared/_editing_alert.html.haml
+++ b/app/views/shared/_editing_alert.html.haml
@@ -1,6 +1,0 @@
-.inner-block
-  .editing-alert
-    - if params['prompt'] == 'profile'
-      = info_text('complete_your_profile_alert_html')
-    - else
-      = info_text('editing_alert')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -243,13 +243,10 @@ en:
       Click on departments and teams, or see the whole of the %{link}.
   views:
     info_text:
-      building_alert: "You are creating a profile - click the Save button to finish"
-      complete_your_profile_alert_html: "Start building your profile now so colleagues and co-workers can get the latest information on you.<br/>We’ll send you regular reminders until it’s complete."
       delete_this_profile: "Delete this profile"
       delete_this_team: "Delete this team"
       duplicate_names_hint: "There are existing profiles that look similar to the details you entered. Check you don’t already have a profile or continue to create a new one."
       duplicate_names_warning: "If you select an existing profile we will update your email address to the one you logged in with."
-      editing_alert: "You are currently editing this profile - click the Save button to finish"
       hint_add_person_team_not_found: "If you can’t find your team, you’ll need to add it."
       hint_add_person_to_team: "Find the team from this organisation browser."
       hint_team_name: "Write out the name of your team in full. Do not use initials."

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -128,14 +128,14 @@ feature 'Group maintenance' do
       visit_edit_view(group)
 
       expect(page).to have_title("Edit team - #{app_title}")
-      expect(page).to have_text('You are currently editing this profile')
+      expect(page).not_to have_selector('.search-box')
       new_name = 'Cyberdigital Cyberservices'
       fill_in 'Team name', with: new_name
 
       click_button 'Save'
 
       expect(page).to have_content('Updated Cyberdigital Cyberservices')
-      expect(page).not_to have_text('You are currently editing this profile')
+      expect(page).to have_selector('.search-box')
       group.reload
       expect(group.name).to eql(new_name)
 
@@ -255,16 +255,13 @@ feature 'Group maintenance' do
     scenario 'UI elements on the new/edit pages' do
       visit new_group_path
       expect(page).not_to have_selector('.search-box')
-      expect(page).to have_text('You are currently editing this profile')
 
       fill_in 'Team name', with: 'Digital'
       click_button 'Save'
       expect(page).to have_selector('.search-box')
-      expect(page).not_to have_text('You are currently editing this profile')
 
       click_link 'Edit this team'
       expect(page).not_to have_selector('.search-box')
-      expect(page).to have_text('You are currently editing this profile')
     end
 
     scenario 'Cancelling an edit' do

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -385,17 +385,14 @@ feature 'Person maintenance' do
   scenario 'UI elements on the new/edit pages', user: :regular do
     visit new_person_path
     expect(page).not_to have_selector('.search-box')
-    expect(page).to have_text('You are creating a profile')
 
     fill_in 'Surname', with: person_attributes[:surname]
     fill_in 'Main email', with: person_attributes[:email]
     click_button 'Save', match: :first
     expect(page).to have_selector('.search-box')
-    expect(page).not_to have_text('You are currently editing this profile')
 
     click_link 'Edit this profile'
     expect(page).not_to have_selector('.search-box')
-    expect(page).to have_text('You are currently editing this profile')
   end
 
 end


### PR DESCRIPTION
remove editing and building alerts/flash notices. These user messages are redundant given the context of the pages they display on and the designer requested their removal.