### PR TITLE
stub geckoboard requests for geckoboard specs only

### DIFF
--- a/spec/lib/geckoboard_publisher/photo_profiles_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/photo_profiles_report_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GeckoboardPublisher::PhotoProfilesReport do
+RSpec.describe GeckoboardPublisher::PhotoProfilesReport, geckoboard: true do
   include PermittedDomainHelper
 
   it_behaves_like 'geckoboard publishable report'

--- a/spec/lib/geckoboard_publisher/profile_completions_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profile_completions_report_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GeckoboardPublisher::ProfileCompletionsReport do
+RSpec.describe GeckoboardPublisher::ProfileCompletionsReport, geckoboard: true do
   include PermittedDomainHelper
 
   it_behaves_like 'geckoboard publishable report'

--- a/spec/lib/geckoboard_publisher/profile_duplicates_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profile_duplicates_report_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GeckoboardPublisher::ProfileDuplicatesReport do
+RSpec.describe GeckoboardPublisher::ProfileDuplicatesReport, geckoboard: true do
   include PermittedDomainHelper
 
   it_behaves_like 'geckoboard publishable report'

--- a/spec/lib/geckoboard_publisher/profiles_changed_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profiles_changed_report_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GeckoboardPublisher::ProfilesChangedReport do
+RSpec.describe GeckoboardPublisher::ProfilesChangedReport, geckoboard: true do
   include PermittedDomainHelper
 
   it_behaves_like 'geckoboard publishable report'

--- a/spec/lib/geckoboard_publisher/profiles_percentage_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/profiles_percentage_report_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GeckoboardPublisher::ProfilesPercentageReport do
+RSpec.describe GeckoboardPublisher::ProfilesPercentageReport, geckoboard: true do
   include PermittedDomainHelper
 
   it_behaves_like 'geckoboard publishable report'

--- a/spec/lib/geckoboard_publisher/total_profiles_report_spec.rb
+++ b/spec/lib/geckoboard_publisher/total_profiles_report_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GeckoboardPublisher::TotalProfilesReport do
+RSpec.describe GeckoboardPublisher::TotalProfilesReport, geckoboard: true do
   include PermittedDomainHelper
 
   it_behaves_like 'geckoboard publishable report'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
 
   WebMock.disable_net_connect!(allow_localhost: true)
 
-  config.before(:each) do
+  config.before :each, geckoboard: true do
     stub_request(:get, "https://api.geckoboard.com/").
       with(headers: { 'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Geckoboard-Ruby/0.3.0' }).
       to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
previous rpsec config was unnecessarily stubbing geckboard api for all tests. This ensures the GB api calls are only stubbed for relevant/tagged tests