### PR TITLE
fix bug on search result display for role and group

### DIFF
--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -60,7 +60,7 @@ class PersonSearch
   end
 
   def any_partial_match? person
-    [:description, :role_and_group, :location_in_building, :building, :city, :current_project].any? do |field|
+    [:description, :role_and_group, :location, :current_project].any? do |field|
       any_partial_match_for?(person, field)
     end
   end

--- a/app/views/search/_person.html.haml
+++ b/app/views/search/_person.html.haml
@@ -11,12 +11,14 @@
             { data: search_result_analytics_attributes(index) }
 
           .result-memberships
-            - if person.memberships.present?
-              - person.memberships.each do |membership|
-                .meta
-                  = link_to hit.try(:highlight).try(:role_and_group) ? hit.highlight.role_and_group.join.html_safe : membership.group.name,
-                    membership.group,
-                    { data: search_result_analytics_attributes(index) }
+            .meta
+              - if person.memberships.present?
+                - person.memberships.each.with_index do |membership, idx|
+                  - if hit.try(:highlight).try(:role_and_group)
+                    = link_to hit.highlight.role_and_group.join.html_safe, membership.group, { data: search_result_analytics_attributes(index) } if idx == 0
+                  - else
+                    = "#{ membership.role }, " if membership.role?
+                    = link_to membership.group.name, membership.group, { data: search_result_analytics_attributes(index) }
 
           .meta= call_to(person.phone)
           .result-email

--- a/app/views/search/_person_confirmation.html.haml
+++ b/app/views/search/_person_confirmation.html.haml
@@ -9,6 +9,7 @@
 
           - if person.memberships.present?
             - person.memberships.each do |membership|
+              = "#{ membership.role }, " if membership.role?
               = link_to membership.group.name, membership.group
 
           .meta= call_to(person.phone)


### PR DESCRIPTION
 1. show role for search results that have no hit on role and group.
 2. prevent duplicate role and group links