### PR TITLE
fix null search 500 error

### DIFF
--- a/app/services/search_results.rb
+++ b/app/services/search_results.rb
@@ -2,7 +2,7 @@ require 'forwardable'
 
 class SearchResults
   extend Forwardable
-  def_delegators :set, :size, :each, :each_with_hit, :present?
+  def_delegators :set, :size, :each, :present?, :empty?
 
   attr_accessor :set, :contains_exact_match
 
@@ -10,4 +10,13 @@ class SearchResults
     @set = set
     @contains_exact_match = contains_exact_match
   end
+
+  def each_with_hit(&block)
+    if @set.is_a? Elasticsearch::Model::Response::Records
+      @set.each_with_hit(&block)
+    else
+      @set.each(&block)
+    end
+  end
+
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -31,6 +31,11 @@ feature 'Searching feature', elastic: true do
     visit home_path
   end
 
+  scenario 'does not error on null search' do
+    click_button 'Submit search'
+    expect(page).to have_content('not found')
+  end
+
   feature 'for people' do
 
     scenario 'retrieves single exact match for email' do


### PR DESCRIPTION
null string returns a search result of empty array rather than Elasticsearch records object. This PR fixes the issue by providing an override enumerable method to handle the possible types returned