### PR TITLE
add background job for generating user behaviour report

### DIFF
--- a/app/assets/stylesheets/peoplefinder/admin.scss
+++ b/app/assets/stylesheets/peoplefinder/admin.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   padding-right: 0.4em;
 }
-.download-link {
+.download-link, .generate-link {
   height: 18px;
   border-left: 1px solid black;
   display: inline-block;

--- a/app/controllers/admin/management_controller.rb
+++ b/app/controllers/admin/management_controller.rb
@@ -3,16 +3,38 @@ module Admin
     before_action :set_search_box_render
     before_action :authorize_user
 
+    def generate_user_behavior_report
+      report = serialize(CsvPublisher::UserBehaviorReport)
+      GenerateReportJob.perform_later(report)
+      notice :generate_user_behavior_report
+      redirect_to :back
+    end
+
     def user_behavior_report
-      @file = CsvPublisher::UserBehaviorReport.new.publish!
-      send_file(
-        @file,
-        filename: "user_behaviour_report_#{Date.current.strftime('%d-%m-%Y')}.csv",
-        type: 'text/csv'
-      )
+      file = CsvPublisher::UserBehaviorReport.default_file_path
+      download(file: file, name: __method__)
     end
 
     private
+
+    def download file:, name:
+      if File.exist? file
+        send_file(
+          file,
+          filename: "#{name}_#{Date.current.strftime('%d-%m-%Y')}.csv",
+          type: 'text/csv'
+        )
+      else
+        warning :file_not_generated
+        redirect_to :back
+      end
+    end
+
+    def serialize klass
+      {
+        'json_class' => klass.name
+      }.to_json
+    end
 
     def set_search_box_render
       @admin_management = true

--- a/app/jobs/generate_report_job.rb
+++ b/app/jobs/generate_report_job.rb
@@ -1,0 +1,28 @@
+class GenerateReportJob < ActiveJob::Base
+
+  queue_as :generate_report
+
+  def perform(report)
+    report = deserialize report
+    report.publish!
+  end
+
+  def max_attempts
+    3
+  end
+
+  def max_run_time
+    5.minutes
+  end
+
+  def destroy_failed_jobs?
+    false
+  end
+
+  private
+
+  def deserialize json
+    JSON.parse(json)['json_class'].constantize
+  end
+
+end

--- a/app/policies/admin/management_policy.rb
+++ b/app/policies/admin/management_policy.rb
@@ -15,5 +15,9 @@ module Admin
       admin_user?
     end
 
+    def generate_user_behavior_report?
+      admin_user?
+    end
+
   end
 end

--- a/app/views/admin/management/show.html.haml
+++ b/app/views/admin/management/show.html.haml
@@ -6,6 +6,8 @@
   .grid
     .report-name
       User behaviour report
+    .generate-link
+      = link_to 'generate', admin_generate_user_behavior_report_path
     .download-link
       = link_to 'download', admin_user_behavior_report_path
 

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -2,7 +2,8 @@ Delayed::Worker.queue_attributes = [
   { name: :high_priority, priority: -10 }, # lower number = higher priority
   { name: :mailers, priority: 0 },
   { name: :low_priority, priority: 10 }, # higher number = lower priority
-  { name: :person_import, priority: -11 }
+  { name: :person_import, priority: -11 },
+  { name: :generate_report, priority: -11 }
 ]
 
 Delayed::Worker.max_attempts = 5

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,8 @@ en:
         upload_failed: "Upload failed"
       management:
         unauthorised: *unauthorised
+        generate_user_behavior_report: User behaviour report will be processed shortly. Try downloading in 2 minutes
+        file_not_generated: User behaviour report has not been generated. Generate first
     groups:
       group_created: "Created %{group}"
       group_updated: "Updated %{group}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
     namespace :admin do
       root to: 'management#show', as: :home
       get 'user_behavior_report', controller: 'management', action: :user_behavior_report
+      get 'generate_user_behavior_report', controller: 'management', action: :generate_user_behavior_report
       resources :person_uploads, only: [:new, :create]
     end
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,6 +24,10 @@ if ENV['ENV'] == 'production'
     rails_script 'GeckoboardPublisher::ProfileCompletionsReport.new.publish!(true)'
   end
 
+  every :weekday, at: '7:00am' do
+    rails_script 'CsvPublisher::UserBehaviorReport.publish!'
+  end
+
   every :weekday, at: '8am' do
     rails_script 'NeverLoggedInNotifier.send_reminders'
   end

--- a/lib/csv_publisher/user_behavior_report.rb
+++ b/lib/csv_publisher/user_behavior_report.rb
@@ -2,6 +2,7 @@ require 'csv'
 
 module CsvPublisher
   class UserBehaviorReport
+    extend SingleForwardable
 
     attr_reader :file, :query, :dataset
 
@@ -14,12 +15,9 @@ module CsvPublisher
       @dataset = query.data
       write! if dataset.present?
     end
+    def_single_delegator :new, :publish!, :publish!
 
     class << self
-
-      def publish!
-        new.publish!
-      end
 
       def default_file_path
         Dir.mkdir(tmp_dir) unless Dir.exist? tmp_dir

--- a/lib/csv_publisher/user_behavior_report.rb
+++ b/lib/csv_publisher/user_behavior_report.rb
@@ -15,12 +15,16 @@ module CsvPublisher
       write! if dataset.present?
     end
 
-    def self.default_file_path
-      Dir.mkdir(tmp_dir) unless Dir.exist? tmp_dir
-      tmp_dir.join(default_file_name)
-    end
-
     class << self
+
+      def publish!
+        new.publish!
+      end
+
+      def default_file_path
+        Dir.mkdir(tmp_dir) unless Dir.exist? tmp_dir
+        tmp_dir.join(default_file_name)
+      end
 
       private
 

--- a/spec/config/schedule_spec.rb
+++ b/spec/config/schedule_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Whenever schedule' do
     before { allow(ENV).to receive(:[]).with('ENV').and_return 'production' }
 
     it 'has expected number of jobs' do
-      expect(schedule.jobs[:rails_script].count).to eql 8
+      expect(schedule.jobs[:rails_script].count).to eql 9
     end
 
     it 'all rails script runnner job tasks are defined' do

--- a/spec/jobs/generate_report_job_spec.rb
+++ b/spec/jobs/generate_report_job_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe GenerateReportJob, type: :job do
+
+  let(:csv_report) { CsvPublisher::UserBehaviorReport }
+  let(:serialized_csv_report) do
+    {
+      'json_class' => csv_report.name
+    }.to_json
+  end
+
+  subject(:perform_later) { described_class.perform_later(serialized_csv_report) }
+  subject(:perform_now) { described_class.perform_now(serialized_csv_report) }
+  subject(:job) { described_class.new }
+
+  context 'when enqueued' do
+    it "enqueues with appropriate config settings" do
+      expect(job.queue_name).to eq 'generate_report'
+      expect(job.max_run_time).to eq 5.minutes
+      expect(job.max_attempts).to eq 3
+      expect(job.destroy_failed_jobs?).to eq false
+    end
+
+    it 'enqueues job with expected arguments' do
+      expect do
+        perform_later
+      end.to have_enqueued_job(described_class).with(serialized_csv_report)
+    end
+
+    it 'enqueues on named queue' do
+      expect do
+        perform_later
+      end.to have_enqueued_job(described_class).on_queue('generate_report')
+    end
+  end
+
+  context 'when performed' do
+    it 'uses the injected report object to publish the report' do
+      expect(csv_report).to receive(:publish!)
+      perform_now
+    end
+  end
+
+end

--- a/spec/lib/csv_publisher/user_behavior_report_spec.rb
+++ b/spec/lib/csv_publisher/user_behavior_report_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe CsvPublisher::UserBehaviorReport, versioning: true do
   it { is_expected.to respond_to :file }
   it { is_expected.to respond_to :query }
   it { is_expected.to respond_to :dataset }
+  it { expect(described_class).to respond_to :publish! }
   it { expect(described_class).to respond_to :default_file_path }
 
   describe '#default_file_path' do

--- a/spec/policies/admin/management_policy_spec.rb
+++ b/spec/policies/admin/management_policy_spec.rb
@@ -4,24 +4,29 @@ RSpec.describe Admin::ManagementPolicy, type: :policy do
 
   subject { described_class.new(user, nil) }
 
+  ACTIONS = %w(show user_behavior_report generate_user_behavior_report).map(&:to_sym)
+
   context 'for a super admin user' do
     let(:user) { build_stubbed(:person, super_admin: true) }
 
-    it { is_expected.to permit_action(:show) }
-    it { is_expected.to permit_action(:user_behavior_report) }
+    ACTIONS.each do |action|
+      it { is_expected.to permit_action(action) }
+    end
   end
 
   context 'for a regular user' do
     let(:user) { build_stubbed(:person, super_admin: false) }
 
-    it { is_expected.not_to permit_action(:show) }
-    it { is_expected.not_to permit_action(:user_behavior_report) }
+    ACTIONS.each do |action|
+      it { is_expected.not_to permit_action(action) }
+    end
   end
 
   context 'for the readonly user' do
     let(:user) { build_stubbed(:readonly_user) }
 
-    it { is_expected.not_to permit_action(:show) }
-    it { is_expected.not_to permit_action(:user_behavior_report) }
+    ACTIONS.each do |action|
+      it { is_expected.not_to permit_action(action) }
+    end
   end
 end


### PR DESCRIPTION
User behaviour report takes over 14 seconds to run on production. This hits the server timeout and therefore a background job is necessary to run it.  

This PR adds a generate link to enable users to kick of the background job to get the latest data and  adds a nightly scheduled job as well.