### PR TITLE
use asynchronous job on instance for report generation

### DIFF
--- a/app/controllers/admin/management_controller.rb
+++ b/app/controllers/admin/management_controller.rb
@@ -4,8 +4,9 @@ module Admin
     before_action :authorize_user
 
     def generate_user_behavior_report
-      report = serialize(CsvPublisher::UserBehaviorReport)
-      GenerateReportJob.perform_later(report)
+      # report = serialize(CsvPublisher::UserBehaviorReport)
+      # GenerateReportJob.perform_now(report)
+      self.class.generate
       notice :generate_user_behavior_report
       redirect_to :back
     end
@@ -16,6 +17,16 @@ module Admin
     end
 
     private
+
+    class << self
+
+      # has to be class method to use with handle_asynchornously from a controller
+      def generate
+        CsvPublisher::UserBehaviorReport.publish!
+      end
+      handle_asynchronously :generate, queue: :generate_report
+
+    end
 
     def download file:, name:
       if File.exist? file
@@ -30,11 +41,11 @@ module Admin
       end
     end
 
-    def serialize klass
-      {
-        'json_class' => klass.name
-      }.to_json
-    end
+    # def serialize klass
+    #   {
+    #     'json_class' => klass.name
+    #   }.to_json
+    # end
 
     def set_search_box_render
       @admin_management = true

--- a/app/jobs/generate_report_job.rb
+++ b/app/jobs/generate_report_job.rb
@@ -12,7 +12,7 @@ class GenerateReportJob < ActiveJob::Base
   end
 
   def max_run_time
-    5.minutes
+    10.minutes
   end
 
   def destroy_failed_jobs?

--- a/app/queries/user_behavior_query.rb
+++ b/app/queries/user_behavior_query.rb
@@ -55,31 +55,6 @@ class UserBehaviorQuery < BaseQuery
     SQL
   end
 
-  # def select_ancestors
-  #   <<~SQL
-  #     CASE
-  #       WHEN groups.ancestry_depth IS NOT NULL then
-  #         regexp_split_to_array(groups.ancestry,'\/')
-  #     END AS ancestors
-  #   SQL
-  # end
-
-  # TO SLOW/UNSCALABLE
-  # def select_ancestor_name_array
-  #   <<~SQL
-  #     (
-  #       SELECT array_agg(name) AS names
-  #         FROM
-  #           (
-  #             SELECT g2.name AS name
-  #             FROM groups AS g2
-  #             WHERE g2.id::text = ANY (regexp_split_to_array(groups.ancestry,'\/'))
-  #             ORDER BY g2.ancestry_depth ASC
-  #           ) AS group_names
-  #     )
-  #   SQL
-  # end
-
   def select_updates_count
     <<~SQL
       (

--- a/spec/features/management_spec.rb
+++ b/spec/features/management_spec.rb
@@ -38,8 +38,7 @@ feature 'Management flow' do
     end
 
     scenario 'can be generated' do
-      expect(GenerateReportJob).to receive(:perform_later)
-      click_link 'generate'
+      expect { click_link 'generate' }.to delay_method(:generate)
     end
 
     scenario 'can be downloaded', skip: 'until we can implement an approrpiate web driver for testing downloads' do

--- a/spec/jobs/generate_report_job_spec.rb
+++ b/spec/jobs/generate_report_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GenerateReportJob, type: :job do
   context 'when enqueued' do
     it "enqueues with appropriate config settings" do
       expect(job.queue_name).to eq 'generate_report'
-      expect(job.max_run_time).to eq 5.minutes
+      expect(job.max_run_time).to eq 10.minutes
       expect(job.max_attempts).to eq 3
       expect(job.destroy_failed_jobs?).to eq true
     end


### PR DESCRIPTION
using a delayed job means the file is produced on the
worker instance and is therefore unavailable to download
on the app instance