### PR TITLE
prevent enqueuing of unnecessary completion score update jobs

### DIFF
--- a/app/jobs/update_group_members_completion_score_job.rb
+++ b/app/jobs/update_group_members_completion_score_job.rb
@@ -12,6 +12,7 @@ class UpdateGroupMembersCompletionScoreJob < ActiveJob::Base
 
   # update current groups and parent's score
   def perform(group)
+    ap "File: #{File.basename(__FILE__)}, Method: #{__method__}, Line: #{__LINE__}"
     group.update_members_completion_score!
     if group.parent
       UpdateGroupMembersCompletionScoreJob.perform_later(group.parent)

--- a/app/jobs/update_group_members_completion_score_job.rb
+++ b/app/jobs/update_group_members_completion_score_job.rb
@@ -6,16 +6,27 @@ class UpdateGroupMembersCompletionScoreJob < ActiveJob::Base
 
   queue_as :low_priority
 
-  # update current groups score and enqueue job to update parent too
+  around_enqueue do |job, block|
+    block.call unless enqueued? job.arguments.first
+  end
+
+  # update current groups and parent's score
   def perform(group)
     group.update_members_completion_score!
-
-    if group.parent && group.parent != Group.department
+    if group.parent
       UpdateGroupMembersCompletionScoreJob.perform_later(group.parent)
     end
   end
 
   private
+
+  def enqueued? group
+    count = Delayed::Job.
+            where("substring(handler from 'job_class: #{self.class}') IS NOT NULL").
+            where("substring(handler from 'gid://peoplefinder/Group/#{group.id}.*') IS NOT NULL").
+            count
+    count > 0
+  end
 
   def error_handler exception
     Rails.logger.warn "#{self.class} encountered #{exception.class}: #{exception.message}"

--- a/spec/models/concerns/completion_spec.rb
+++ b/spec/models/concerns/completion_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Completion' do # rubocop:disable RSpec/DescribeClass
       Person.overall_completion
     end
 
-    it 'returns 100 if there is onlu one person who is 100% complete' do
+    it 'returns 100 if there is only one person who is 100% complete' do
       person = create(:person, completed_attributes)
       create(:membership, person: person)
       expect(Person.overall_completion).to eq(100)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -238,6 +238,24 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  context 'group member completion score update' do
+    include ActiveJob::TestHelper
+
+    let(:person) { build(:person) }
+    let!(:digital_services) { create(:group, name: 'Digital Services') }
+    before do
+      person.save!
+      person.memberships.create(group: digital_services, role: 'Service Assessments Lead')
+      person.save!
+      person.primary_phone_number = '00222'
+      clear_enqueued_jobs
+    end
+
+    it 'enqueues the UpdateGroupMembersCompletionScoreJob' do
+      expect { person.save! }.to have_enqueued_job(UpdateGroupMembersCompletionScoreJob).with(digital_services)
+    end
+  end
+
   context 'with two memberships in the same group' do
     before do
       person.save!


### PR DESCRIPTION
Completion score update jobs are being enqueued for the same group
multiple times. You only need one enqueued job per group at
any one moment in time.