### PR TITLE
add queued notification processing to demo (and dev)

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -46,7 +46,7 @@ if ENV['ENV'] == 'production'
 
 end
 
-if ENV['ENV'] == 'staging'
+if %w(dev demo staging).include? ENV['ENV']
 
   set :output, standard: '/var/log/cron.log', error: '/var/log/cron_error.log'
 

--- a/spec/config/schedule_spec.rb
+++ b/spec/config/schedule_spec.rb
@@ -15,23 +15,23 @@ RSpec.describe 'Whenever schedule' do
         expect(job[:task]).to be_defined
       end
     end
-  end
 
-  context 'non-production enviroments' do
-    context 'staging' do
-
-      before { allow(ENV).to receive(:[]).with('ENV').and_return 'staging' }
-
-      it 'only schedules the Sender Notification job' do
-        expect(schedule.jobs[:rails_script]).to eq(
-          [
-            {
-              task: "NotificationSender.new.send!",
-              every: [300.seconds],
-              command: "cd /usr/src/app && ./rails_runner.sh ':task' :output"
-            }
-        ])
+    it 'all rails runner script jobs command' do
+      schedule.jobs[:rails_script].each do |job|
+        expect(job[:command]).to eql "cd /usr/src/app && ./rails_runner.sh ':task' :output"
       end
     end
   end
+
+  %w(dev demo staging).each do |env|
+    context "#{env} environment" do
+      before { allow(ENV).to receive(:[]).with('ENV').and_return env.to_s }
+      it 'only schedules the Sender Notification job, every 5 minutes' do
+        expect(schedule.jobs[:rails_script].count).to eql 1
+        expect(schedule.jobs[:rails_script].first[:task]).to eql "NotificationSender.new.send!"
+        expect(schedule.jobs[:rails_script].first[:every]).to include 300.seconds
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
required for testing. Mail interceptor redirects mail to support
inbox in any event. This was as intended before the single email
notification mailer went in too.

ticket PFT-285