### PR TITLE
prevent record not found error when processing user update email

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,6 +18,7 @@ Metrics/ClassLength:
     - 'app/models/person.rb'
     - 'app/controllers/people_controller.rb'
     - 'app/services/person_search.rb'
+    - 'app/presenters/membership_changes_presenter.rb'
 
 # Offense count: 299
 # Cop supports --auto-correct.

--- a/app/jobs/update_group_members_completion_score_job.rb
+++ b/app/jobs/update_group_members_completion_score_job.rb
@@ -12,7 +12,6 @@ class UpdateGroupMembersCompletionScoreJob < ActiveJob::Base
 
   # update current groups and parent's score
   def perform(group)
-    ap "File: #{File.basename(__FILE__)}, Method: #{__method__}, Line: #{__LINE__}"
     group.update_members_completion_score!
     if group.parent
       UpdateGroupMembersCompletionScoreJob.perform_later(group.parent)

--- a/app/presenters/membership_change_set.rb
+++ b/app/presenters/membership_change_set.rb
@@ -19,8 +19,11 @@ class MembershipChangeSet
   end
 
   def team_name
-    team = change(raw_changes[:group_id])
-    Group.find(team.new_val || team.old_val).name
+    group = change(raw_changes[:group_id])
+    team = Group.find(group.new_val || group.old_val)
+    "the #{team}"
+  rescue ActiveRecord::RecordNotFound
+    'a no longer existing'
   end
 
   def team id
@@ -38,7 +41,7 @@ class MembershipChangeSet
   def added_sentence
     role_addendum = " as #{role}" if role?
     leader_addendum = ' You are a leader of the team.' if leader?
-    "Added you to the #{team_name} team#{role_addendum}.#{leader_addendum}"
+    "Added you to #{team_name} team#{role_addendum}.#{leader_addendum}"
   end
 
   def removed_sentence

--- a/app/presenters/membership_changes_presenter.rb
+++ b/app/presenters/membership_changes_presenter.rb
@@ -135,12 +135,18 @@ class MembershipChangesPresenter < ChangesPresenter
   def team_change_sentence raw_change
     change = Change.new(raw_change)
     if change.addition?
-      "Added you to the #{Group.find(change.new_val).name} team"
+      "Added you to #{team_name(change.new_val)} team"
     elsif change.removal?
-      "Removed you from the #{Group.find(change.old_val).name} team"
+      "Removed you from #{team_name(change.old_val)} team"
     elsif change.modification?
-      "Changed your membership of the #{Group.find(change.old_val).name} team \
-      to the #{Group.find(change.new_val).name} team"
+      "Changed your membership of #{team_name(change.old_val)} team \
+      to #{team_name(change.new_val)} team"
     end
+  end
+
+  def team_name id
+    "the #{Group.find(id).name}"
+  rescue ActiveRecord::RecordNotFound
+    'a no longer existing'
   end
 end


### PR DESCRIPTION
An activerecor:recordnotfound error can be raise if a team
is removed between enqueuing of an email job and its processing.