### PR TITLE
hide preview button

### DIFF
--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -116,7 +116,6 @@
     = f.text_area :description, class: 'form-control'
 
   .form-group.save-cancel-actions
-    = f.submit 'Preview', name: 'preview', class: 'button-secondary'
     = f.submit class: 'button'
     .cancel
       = link_to 'Cancel and go to profile page', @person.new_record? ? :back : @person

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -68,24 +68,6 @@ feature 'Person maintenance' do
         check_creation_of_profile_details
       end
 
-      scenario 'Previewing on creation' do
-        visit new_person_path
-
-        fill_in 'First name', with: 'Jane'
-        fill_in 'Surname', with: 'Doe'
-        fill_in 'Main email', with: person_attributes[:email]
-
-        expect do
-          click_button 'Preview'
-        end.not_to change(Person, :count)
-
-        expect(page).to have_selector('.preview h1', text: 'Jane Doe')
-
-        expect do
-          click_button 'Save', match: :first
-        end.to change(Person, :count).by(1)
-      end
-
       scenario 'Creating an invalid person' do
         new_profile_page.load
         new_profile_page.form.save.click
@@ -184,25 +166,6 @@ feature 'Person maintenance' do
         within('h1') do
           expect(page).to have_text('Jane Doe')
         end
-      end
-
-      scenario 'Previewing on update' do
-        person = create(:person, given_name: 'Jane', surname: 'Doe')
-
-        visit person_path(person)
-        click_link 'Edit this profile'
-
-        fill_in 'First name', with: 'Monica'
-        fill_in 'Surname', with: 'Changed'
-
-        click_button 'Preview'
-
-        expect(page).to have_selector('.preview h1', text: 'Monica Changed')
-        expect(person.reload.name).to eq('Jane Doe')
-
-        click_button 'Save', match: :first
-
-        expect(person.reload.name).to eq('Monica Changed')
       end
 
       scenario 'Editing my own profile from a normal edit link' do


### PR DESCRIPTION
remove preview button as prelude to removing all functionality and historical data.

see [ticket PFT-273](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=49&projectKey=PFT&view=detail&selectedIssue=PFT-273)