### PR TITLE
remove xss attack vector

### DIFF
--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -1,0 +1,25 @@
+module ElasticsearchHelper
+
+  HIGHLIGHTER_TAGS = (PersonSearch::PRE_TAGS + PersonSearch::POST_TAGS).freeze
+
+  def es_highlighter hit, person, attribute
+    hit.try(:highlight).try(attribute) ? sanitize_highlighter(hit, person, attribute) : person.__send__(attribute)
+  end
+
+  private
+
+  def sanitize_highlighter hit, person, attribute
+    unsanitized = hit.highlight.__send__(attribute).join.html_safe
+    unhighlighted = strip_highlighting!(hit.highlight.__send__(attribute).join.html_safe)
+    sanitized = sanitize(person.__send__(attribute))
+
+    unhighlighted == sanitized ? unsanitized : person.__send__(attribute)
+  end
+
+  def strip_highlighting! html
+    HIGHLIGHTER_TAGS.each_with_object(html) do |tag, memo|
+      memo.gsub!(tag, '')
+    end
+  end
+
+end

--- a/app/helpers/elasticsearch_helper.rb
+++ b/app/helpers/elasticsearch_helper.rb
@@ -11,7 +11,7 @@ module ElasticsearchHelper
   def sanitize_highlighter hit, person, attribute
     unsanitized = hit.highlight.__send__(attribute).join.html_safe
     unhighlighted = strip_highlighting!(hit.highlight.__send__(attribute).join.html_safe)
-    sanitized = sanitize(person.__send__(attribute))
+    sanitized = sanitize person.__send__(attribute)
 
     unhighlighted == sanitized ? unsanitized : person.__send__(attribute)
   end

--- a/app/services/person_search.rb
+++ b/app/services/person_search.rb
@@ -2,6 +2,9 @@ class PersonSearch
 
   attr_reader :query, :results, :matches
 
+  PRE_TAGS = ['<span class="es-highlight">'].freeze
+  POST_TAGS = ['</span>'].freeze
+
   def initialize query, results
     @query = clean_query query
     @query_regexp = /#{@query.downcase}/i
@@ -188,8 +191,8 @@ class PersonSearch
 
   def highlighter
     {
-      pre_tags: ['<span class="es-highlight">'],
-      post_tags: ['</span>'],
+      pre_tags: PRE_TAGS,
+      post_tags: POST_TAGS,
       fields: fields_to_highlight
     }
   end

--- a/app/views/search/_person.html.haml
+++ b/app/views/search/_person.html.haml
@@ -6,8 +6,7 @@
           = profile_image_tag person
         .details
           %h3.result-name
-            = link_to hit.try(:highlight).try(:name) ? hit.highlight.name.join.html_safe : person.name,
-            person,
+            = link_to es_highlighter(hit, person, :name), person,
             { data: search_result_analytics_attributes(index) }
 
           .result-memberships
@@ -23,13 +22,13 @@
           .meta= call_to(person.phone)
           .result-email
             .meta
-              = mail_to(person.email, hit.try(:highlight).try(:email) ? hit.highlight.email.join.html_safe : person.email, data: search_result_analytics_attributes(index) )
+              = mail_to(person.email, es_highlighter(hit, person, :email), data: search_result_analytics_attributes(index) )
 
           .result-current-project
             - if person.current_project.present?
               .meta
                 Current project(s):
-                = hit.try(:highlight).try(:current_project) ? hit.highlight.current_project.join.html_safe : person.current_project
+                = es_highlighter(hit, person, :current_project)
 
       - if Rails.env.development? || current_user.super_admin?
         %span{style: "float: right; font-size: 10px;"}

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -13,6 +13,12 @@ feature 'Searching feature', elastic: true do
       primary_phone_number: '0711111111',
       current_project: 'Digital Prisons')
     create(:membership, person: person, group: group)
+    create(:person,
+      given_name: 'Dodgy<script> alert(\'XSS\'); </script>',
+      surname: 'Bloke',
+      email: 'dodgy.bloke@digital.justice.gov.uk',
+      primary_phone_number: '0711111111',
+      current_project: 'Digital Prisons')
   end
 
   before(:all) do
@@ -108,6 +114,15 @@ feature 'Searching feature', elastic: true do
       within '.result-current-project' do
         expect(page).to have_selector('.es-highlight', text: 'Digital')
         expect(page).to have_selector('.es-highlight', text: 'Prisons')
+      end
+    end
+
+    scenario 'does not highlight unsanitary attribute values' do
+      fill_in 'query', with: 'dodgy bloke'
+      click_button 'Submit search'
+      within '.result-name' do
+        expect(page).not_to have_selector('.es-highlight')
+        expect(page).to have_text('Dodgy<script> alert(\'XSS\'); </script> Bloke')
       end
     end
   end


### PR DESCRIPTION
elastic search highlighting requires an html_safe
on the es rendered html. This meant that js script
tags could be rendered unescaped.