### PR TITLE
apply govuk styling to suggestion form elements

### DIFF
--- a/app/assets/stylesheets/modules/_module-suggestions.scss
+++ b/app/assets/stylesheets/modules/_module-suggestions.scss
@@ -9,6 +9,7 @@
 
   .extra-info {
     clear: both;
+    @extend %contain-floats;
     margin-bottom: 10px;
     border-left: 3px $grey-3 solid;
     padding-left: 20px;

--- a/app/form_builders/suggestion_form_builder.rb
+++ b/app/form_builders/suggestion_form_builder.rb
@@ -1,0 +1,20 @@
+class SuggestionFormBuilder < GovukElementsFormBuilder::FormBuilder
+
+  def check_box(method, options = {}, checked_value = '1', unchecked_value = '0')
+    @template.content_tag :div, class: 'form-group' do
+      @template.label(@object_name, method, class: 'block-label selection-button-checkbox') do
+        @template.check_box(@object_name, method.to_s, options, checked_value, unchecked_value) +
+          label_t(method)
+      end
+    end
+  end
+
+  private
+
+  LABEL_SCOPE = [:helpers, :label, :suggestion].freeze
+
+  def label_t attribute
+    I18n.t(attribute, scope: LABEL_SCOPE)
+  end
+
+end

--- a/app/views/suggestions/create.html.haml
+++ b/app/views/suggestions/create.html.haml
@@ -1,2 +1,7 @@
-%h1= t('suggestions.thank_you_intro')
-%p= t('suggestions.thank_you_detail', count: @delivery_details.recipient_count)
+%br/
+= render 'shared/search'
+
+%h1.heading-xlarge.with-border-lg
+  = t('suggestions.thank_you_intro')
+%p
+  = t('suggestions.thank_you_detail', count: @delivery_details.recipient_count)

--- a/app/views/suggestions/new.html.haml
+++ b/app/views/suggestions/new.html.haml
@@ -4,90 +4,62 @@
 %h1.heading-xlarge.with-border-lg
   Help improve this profile
 
-- if @suggestion.errors.any?
-  .alert.alert-error
-    %p= error_text('group.general_message')
-    %ul.form-error-list
-      -@suggestion.errors.full_messages.each do |error|
-        %li=error
+= GovukElementsErrorsHelper.error_summary @suggestion,
+  "There is a problem with the form",
+  "Check below for more detail"
 
-=form_for @suggestion, builder: ActionView::Helpers::FormBuilder, url: person_suggestions_path do |f|
+= form_for @suggestion, url: person_suggestions_path do |f|
 
+  - label_scope = [:helpers, :label, :suggestion]
   %fieldset
-    %legend Ask the person to:
+    %legend.form-label-bold Ask the person to:
 
-    .form-group.check-box
-      =f.check_box :missing_fields, target: '.missing-fields-info'
-      =f.label :missing_fields, 'fill missing fields'
+    .form-group
+      = f.label :missing_fields, class: 'block-label' do
+        = f.check_box :missing_fields, target: '.missing-fields-info'
+        = t(:missing_fields, scope: label_scope)
 
-    .missing-fields-info.extra-info{style: 'display: none;'}
-      %p Your message will be emailed to the person. You can make changes to the wording.
-      =f.label :missing_fields_info, class: 'visuallyhidden'
-      =f.text_area :missing_fields_info, class: 'form-control'
+      .missing-fields-info.extra-info{style: 'display: none;'}
+        = f.text_area :missing_fields_info
 
-    .form-group.check-box
-      =f.check_box :incorrect_fields, target: '.incorrect_fields_info'
-      =f.label :incorrect_fields, 'update incorrect fields'
+    .form-group
+      = f.label :incorrect_fields, class: 'block-label' do
+        = f.check_box :incorrect_fields, target: '.incorrect_fields_info'
+        = t(:incorrect_fields, scope: label_scope)
 
     .incorrect_fields_info.extra-info{style: 'display: none;'}
       %p Choose which information is incorrect
 
-      .form-group
-        =f.check_box :incorrect_first_name
-        =f.label :incorrect_first_name, 'First name'
-
-      .form-group
-        =f.check_box :incorrect_last_name
-        =f.label :incorrect_last_name, 'Last name'
-
-      .form-group
-        =f.check_box :incorrect_roles
-        =f.label :incorrect_roles, 'Roles'
-
-      .form-group
-        =f.check_box :incorrect_location_of_work
-        =f.label :incorrect_location_of_work, 'Location of work'
-
-      .form-group
-        =f.check_box :incorrect_working_days
-        =f.label :incorrect_working_days, 'Working days'
-
-      .form-group
-        =f.check_box :incorrect_phone_number
-        =f.label :incorrect_phone_number, 'Phone number'
-
-      .form-group
-        =f.check_box :incorrect_pager_number
-        =f.label :incorrect_pager_number, 'Pager number'
-
-      .form-group
-        =f.check_box :incorrect_image
-        =f.label :incorrect_image, 'Profile image'
-      &nbsp;
+      - Suggestion::POTENTIALLY_INCORRECT_FIELDS.each do |field|
+        .form-group
+          - incorrect_attr = "incorrect_#{field}".to_sym
+          = f.label incorrect_attr, class: 'block-label' do
+            = f.check_box incorrect_attr
+            = t(incorrect_attr, scope: label_scope)
 
   %fieldset
-    %legend Ask the team admin to:
-    .form-group.check-box
-      =f.check_box :duplicate_profile
-      =f.label :duplicate_profile, 'remove duplicate profile'
+    %legend.form-label-bold Ask the team admin to:
 
-    .form-group.check-box
-      =f.check_box :inappropriate_content, target: '.inappropriate-content-info'
-      =f.label :inappropriate_content, 'remove inappropriate content'
+    .form-group
+      = f.label :duplicate_profile, class: 'block-label' do
+        = f.check_box :duplicate_profile
+        = t(:duplicate_profile, scope: label_scope)
 
-    .inappropriate-content-info.extra-info{style: 'display: none;'}
-      %p Enter details of the content (mandatory)
-      =f.label :inappropriate_content_info, class: 'visuallyhidden'
-      =f.text_area :inappropriate_content_info, class: 'form-control'
+    .form-group
+      = f.label :inappropriate_content, class: 'block-label' do
+        = f.check_box :inappropriate_content, target: '.inappropriate-content-info'
+        = t(:inappropriate_content, scope: label_scope)
 
-    .form-group.check-box
-      =f.check_box :person_left, target: '.person-left-info'
-      =f.label :person_left, 'remove the profile as the person has left MOJ'
+      .inappropriate-content-info.extra-info{style: 'display: none;'}
+        = f.text_area :inappropriate_content_info
 
-    .person-left-info.extra-info{style: 'display: none;'}
-      %p Enter any additional information (optional)
-      =f.label :person_left_info, class: 'visuallyhidden'
-      =f.text_area :person_left_info, class: 'form-control'
+    .form-group
+      = f.label :person_left, class: 'block-label' do
+        = f.check_box :person_left, target: '.person-left-info'
+        = t(:person_left, scope: label_scope)
+
+      .person-left-info.extra-info{style: 'display: none;'}
+        =f.text_area :person_left_info
 
   .submit-button{style: 'display: none;'}
     =f.submit 'Submit', class: 'button'

--- a/app/views/suggestions/new.html.haml
+++ b/app/views/suggestions/new.html.haml
@@ -8,58 +8,34 @@
   "There is a problem with the form",
   "Check below for more detail"
 
-= form_for @suggestion, url: person_suggestions_path do |f|
+= form_for @suggestion, builder: SuggestionFormBuilder, url: person_suggestions_path do |f|
 
-  - label_scope = [:helpers, :label, :suggestion]
   %fieldset
     %legend.form-label-bold Ask the person to:
 
-    .form-group
-      = f.label :missing_fields, class: 'block-label' do
-        = f.check_box :missing_fields, target: '.missing-fields-info'
-        = t(:missing_fields, scope: label_scope)
+    = f.check_box :missing_fields, target: '.missing-fields-info'
+    .missing-fields-info.extra-info{style: 'display: none;'}
+      = f.text_area :missing_fields_info
 
-      .missing-fields-info.extra-info{style: 'display: none;'}
-        = f.text_area :missing_fields_info
-
-    .form-group
-      = f.label :incorrect_fields, class: 'block-label' do
-        = f.check_box :incorrect_fields, target: '.incorrect_fields_info'
-        = t(:incorrect_fields, scope: label_scope)
-
+    = f.check_box :incorrect_fields, target: '.incorrect_fields_info'
     .incorrect_fields_info.extra-info{style: 'display: none;'}
-      %p Choose which information is incorrect
-
+      %span.form-hint
+        Choose which information is incorrect
       - Suggestion::POTENTIALLY_INCORRECT_FIELDS.each do |field|
-        .form-group
-          - incorrect_attr = "incorrect_#{field}".to_sym
-          = f.label incorrect_attr, class: 'block-label' do
-            = f.check_box incorrect_attr
-            = t(incorrect_attr, scope: label_scope)
+        = f.check_box "incorrect_#{field}".to_sym
 
   %fieldset
     %legend.form-label-bold Ask the team admin to:
 
-    .form-group
-      = f.label :duplicate_profile, class: 'block-label' do
-        = f.check_box :duplicate_profile
-        = t(:duplicate_profile, scope: label_scope)
+    = f.check_box :duplicate_profile
 
-    .form-group
-      = f.label :inappropriate_content, class: 'block-label' do
-        = f.check_box :inappropriate_content, target: '.inappropriate-content-info'
-        = t(:inappropriate_content, scope: label_scope)
+    = f.check_box :inappropriate_content, target: '.inappropriate-content-info'
+    .inappropriate-content-info.extra-info{style: 'display: none;'}
+      = f.text_area :inappropriate_content_info
 
-      .inappropriate-content-info.extra-info{style: 'display: none;'}
-        = f.text_area :inappropriate_content_info
-
-    .form-group
-      = f.label :person_left, class: 'block-label' do
-        = f.check_box :person_left, target: '.person-left-info'
-        = t(:person_left, scope: label_scope)
-
-      .person-left-info.extra-info{style: 'display: none;'}
-        =f.text_area :person_left_info
+    = f.check_box :person_left, target: '.person-left-info'
+    .person-left-info.extra-info{style: 'display: none;'}
+      = f.text_area :person_left_info
 
   .submit-button{style: 'display: none;'}
     =f.submit 'Submit', class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,7 @@ en:
     group:
       description: |
         Discover what this team is responsible for, who is in it and how you can get in touch with them.
+
   # the following translations are used by the govuk_elements_form_builder gem
   helpers:
     fieldset:
@@ -359,6 +360,23 @@ en:
         name: Team name
         acronym: Team initials (optional)
         description: Team description (optional)
+      suggestion:
+        missing_fields: Fill missing fields
+        missing_fields_info: Missing fields
+        incorrect_fields: Update incorrect fields
+        incorrect_first_name: First name
+        incorrect_last_name: Last name
+        incorrect_roles: Roles
+        incorrect_location_of_work: Location of work
+        incorrect_working_days: Working days
+        incorrect_phone_number: Phone number
+        incorrect_pager_number: Pager number
+        incorrect_image: Profile image
+        duplicate_profile: Remove duplicate profile
+        inappropriate_content: Remove inappropriate content
+        inappropriate_content_info: Inappropriate content
+        person_left: Remove the profile as the person has left MOJ
+        person_left_info: Additional information
 
     placeholder:
       group:
@@ -392,6 +410,10 @@ en:
         name: Write out the name of your team in full. Do not use initials
         acronym: If your team is also known by its initials (eg HMCTS) add them below
         description: What is the role and purpose of the team?
+      suggestion:
+        missing_fields_info: Your message will be emailed to the person. You can make changes to the wording
+        inappropriate_content_info: Enter details of the content (mandatory)
+        person_left_info: Where they went, why, other (optional). Your message will be sent to team leaders
 
   will_paginate:
     models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,7 +412,6 @@ en:
         description: What is the role and purpose of the team?
       suggestion:
         missing_fields_info: Your message will be emailed to the person. You can make changes to the wording
-        inappropriate_content_info: Enter details of the content (mandatory)
         person_left_info: Where they went, why, other (optional). Your message will be sent to team leaders
 
   will_paginate:

--- a/spec/features/suggestion_spec.rb
+++ b/spec/features/suggestion_spec.rb
@@ -36,8 +36,8 @@ feature 'Make a suggestion about a profile', js: true do
   end
 
   scenario 'Ask a person to complete missing fields', user: :regular do
-    check 'fill missing fields'
-    fill_in 'Missing fields info', with: 'Write more stuff'
+    govuk_label_click 'Fill missing fields'
+    fill_in 'Missing fields', with: 'Write more stuff'
     click_button 'Submit'
 
     expect(page).to have_text('We’ve sent an email to the relevant person')
@@ -47,8 +47,8 @@ feature 'Make a suggestion about a profile', js: true do
   end
 
   scenario 'Ask a person to update incorrect fields', user: :regular do
-    check 'update incorrect fields'
-    check 'Last name'
+    govuk_label_click 'Update incorrect fields'
+    govuk_label_click 'Last name'
     click_button 'Submit'
 
     expect(page).to have_text('We’ve sent an email to the relevant person')
@@ -58,7 +58,7 @@ feature 'Make a suggestion about a profile', js: true do
   end
 
   scenario 'Ask an admin to remove duplicate profile', user: :regular do
-    check 'remove duplicate profile'
+    govuk_label_click 'Remove duplicate profile'
     click_button 'Submit'
 
     expect(page).to have_text('We’ve sent an email to the relevant person')
@@ -68,8 +68,8 @@ feature 'Make a suggestion about a profile', js: true do
   end
 
   scenario 'Ask an admin to remove inappropriate content', user: :regular do
-    check 'remove inappropriate content'
-    fill_in 'Inappropriate content info', with: 'Outrageous!'
+    govuk_label_click 'Remove inappropriate content'
+    fill_in 'Inappropriate content', with: 'Outrageous!'
     click_button 'Submit'
 
     expect(page).to have_text('We’ve sent an email to the relevant person')
@@ -79,8 +79,8 @@ feature 'Make a suggestion about a profile', js: true do
   end
 
   scenario 'Ask an admin to remove the profile', user: :regular do
-    check 'remove the profile as the person has left MOJ'
-    fill_in 'Person left info', with: 'They have left to become a goatherd'
+    govuk_label_click 'Remove the profile as the person has left MOJ'
+    fill_in 'Additional information', with: 'They have left to become a goatherd'
     click_button 'Submit'
 
     expect(page).to have_text('We’ve sent an email to the relevant person')
@@ -93,10 +93,10 @@ feature 'Make a suggestion about a profile', js: true do
     another_leader = create(:person)
     create(:membership, person: another_leader, group: group, leader: true)
 
-    check 'fill missing fields'
-    fill_in 'Missing fields info', with: 'Write more stuff'
-    check 'remove inappropriate content'
-    fill_in 'Inappropriate content info', with: 'Outrageous!'
+    govuk_label_click 'Fill missing fields'
+    fill_in 'Missing fields', with: 'Write more stuff'
+    govuk_label_click 'Remove inappropriate content'
+    fill_in 'Inappropriate content', with: 'Outrageous!'
     click_button 'Submit'
 
     expect(page).to have_text('We’ve sent emails to the relevant people')

--- a/spec/form_builders/form_groups_spec.rb
+++ b/spec/form_builders/form_groups_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-# require 'form_groups'
 require_relative '../../app/form_builders/form_groups'
 
 describe FormGroups do

--- a/spec/form_builders/suggestion_form_builder_spec.rb
+++ b/spec/form_builders/suggestion_form_builder_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe SuggestionFormBuilder, type: :form_builder do
+
+  let(:object) { Object.new }
+  let(:template) { ActionView::Base.new }
+  let(:options) { {} }
+  let(:builder) { described_class.new(:suggestion, object, template, options) }
+
+  # patch String#strip_heredoc to remove whitespace resulting from line breaks
+  class String
+    def squish_heredoc
+      squish.gsub(/\s*</, "<").gsub(/>\s*/, ">").strip_heredoc
+    end
+  end
+
+  describe '#check_box' do
+    subject { builder.check_box(:test_field) }
+
+    before do
+      I18n.backend.store_translations(
+        :en,
+        helpers: {
+          label: {
+            suggestion: {
+              test_field: 'My test label'
+            }
+          }
+        }
+      )
+    end
+
+    let(:output) do
+      <<~HTML.squish_heredoc
+      <div class="form-group">
+        <label class="block-label selection-button-checkbox" for="suggestion_test_field">
+          <input name="suggestion[test_field]" type="hidden" value="0" />
+          <input type="checkbox" value="1" name="suggestion[test_field]" id="suggestion_test_field" />
+          My test label
+        </label>
+      </div>
+      HTML
+    end
+
+    it 'returns govuk styled check box' do
+      is_expected.to eql output
+    end
+
+    it 'adds outer form-group div' do
+      is_expected.to match(/<div class="form-group">.*<\/div>/)
+    end
+
+    it 'adds a selectable block-label inside the form-group' do
+      is_expected.to match(/.*form-group.*<label class="block-label selection-button-checkbox" for="suggestion_test_field">.*<\/label>/)
+    end
+
+    it 'adds a checkbox inside the label' do
+      is_expected.to match(/<label.*<input type="checkbox" value="1" name="suggestion\[test_field\]" id="suggestion_test_field" \/>.*<\/label>/)
+    end
+
+    it 'adds label from translation defined in specific scope' do
+      is_expected.to include 'My test label'
+    end
+
+  end
+
+end


### PR DESCRIPTION
Applies the govuk elements styling to the suggestions form elements via a domain specific form builder. 

GovukElementFormBuilder does not cater for individual checkboxes (checkbox fieldsets only) so this wraps the logic of an individual check box to output the expected html for a govuk styled checkbox (and allow for pass thru of other options).
