### PR TITLE
register javascript driver to redirect console logging to /dev/null

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,12 @@ unless ENV['SKIP_SIMPLECOV']
   SimpleCov.minimum_coverage 95
 end
 
-Capybara.javascript_driver = :poltergeist
+Capybara.register_driver :poltergeist_silent do |app|
+  Capybara::Poltergeist::Driver.new(app, phantomjs_logger: File::NULL)
+end
+
+# Capybara.javascript_driver = :poltergeist # uncomment to enable console.log
+Capybara.javascript_driver = :poltergeist_silent # uncomment this to disable console.log (including warn)
 Capybara.default_max_wait_time = 3
 
 Dir[File.expand_path('../../{lib,app/*}', __FILE__)].each do |path|


### PR DESCRIPTION
The govuk_frontend_toolkit-5.2.0 has a deprecation warning
in selection-button.js that cannot be turned off.

Once this is resolved in the gem or in the app then we can revert
to using standard poltergiest driver. If you want to enble logging
for dev work just uncomment the `Capybara.javascript_driver = :poltergeist`
line in `rails_helper.rb`.