### PR TITLE
close xss attack vector on role field

### DIFF
--- a/app/views/search/_person.html.haml
+++ b/app/views/search/_person.html.haml
@@ -14,7 +14,7 @@
               - if person.memberships.present?
                 - person.memberships.each.with_index do |membership, idx|
                   - if hit.try(:highlight).try(:role_and_group)
-                    = link_to hit.highlight.role_and_group.join.html_safe, membership.group, { data: search_result_analytics_attributes(index) } if idx == 0
+                    = link_to es_highlighter(hit, person, :role_and_group), membership.group, { data: search_result_analytics_attributes(index) } if idx == 0
                   - else
                     = "#{ membership.role }, " if membership.role?
                     = link_to membership.group.name, membership.group, { data: search_result_analytics_attributes(index) }


### PR DESCRIPTION
if a JS script is injected into a role then
a search that highlights the role and team
would execute it.