### PR TITLE
validate uniqueness of the Permanent Secretary

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -21,6 +21,7 @@ class Membership < ActiveRecord::Base
 
   validates :person, presence: true, on: :update
   validates :group, presence: true, on: :update
+  validates_with PermanentSecretaryUniqueValidator
 
   delegate :name, to: :person, prefix: true
   delegate :image, to: :person, prefix: true

--- a/app/validators/permanent_secretary_unique_validator.rb
+++ b/app/validators/permanent_secretary_unique_validator.rb
@@ -1,0 +1,35 @@
+class PermanentSecretaryUniqueValidator < ActiveModel::Validator
+
+  def validate(record)
+    @record = record
+    if perm_sec? && perm_sec_exists?
+      record.errors[:leader] << perm_sec_unique_message
+    end
+  end
+
+  private
+
+  def scope_t
+    [:errors, :validators, :permanent_secretary_unique_validator]
+  end
+
+  def perm_sec_unique_message
+    I18n.t(
+      :leader,
+      scope: scope_t
+    )
+  end
+
+  def perm_sec?
+    @record.leader && @record.group_id == Group.department.id
+  end
+
+  def perm_sec_exists?
+    current_perm_sec.present? &&
+      current_perm_sec.id != @record.id
+  end
+
+  def current_perm_sec
+    Membership.where(group_id: Group.department.id).where(leader: true).limit(1).first
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,8 @@ en:
       file_size_validator:
         too_big: "file size, %{size}, is too large"
         not_in_range: "file size, %{size}, is not in expected range"
+      permanent_secretary_unique_validator:
+        leader: can't have more than one Permanent Secretary
   activerecord:
     errors:
       <<: *errors
@@ -255,6 +257,8 @@ en:
         given_name: "First name"
         email: Main email
         secondary_email: Alternative work email
+      memberships:
+        leader: "Are you the Permanent Secretary?"
   shared:
     search:
       hint: 'Search name, job title, team name or location'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -68,9 +68,11 @@ FactoryGirl.define do
     trait :member_of do
       transient do
         team nil
+        leader false
+        role 'leader'
       end
       after(:create) do |peep, evaluator|
-        create(:membership, person: peep, group: evaluator.team)
+        create(:membership, person: peep, group: evaluator.team, leader: evaluator.leader, role: evaluator.role)
       end
     end
 

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -15,6 +15,9 @@
 require 'rails_helper'
 
 RSpec.describe Membership, type: :model do
+  include PermittedDomainHelper
+  let(:moj) { create :department, name: 'Ministry of Justice' }
+
   it { should validate_presence_of(:person).on(:update) }
   it { should validate_presence_of(:group).on(:update) }
 
@@ -24,7 +27,70 @@ RSpec.describe Membership, type: :model do
     expect(subject).not_to be_leader
   end
 
-  it 'is suscribed by default' do
+  it 'is subscribed by default' do
     expect(subject).to be_subscribed
+  end
+
+  # The Permanent Secretary is whomever has a membership indicating
+  # that they are the leader of the top-most team (a.k.a department,
+  # Ministry of Justice)
+  #
+  context 'validates uniqueness of Permanent Secretary' do
+    let(:csg) { create :group, name: 'Corporate Services Group' }
+    let(:person) { create :person, :member_of, team: csg }
+    let(:membership) { person.memberships.first }
+
+    context 'when a perm. sec. already exists' do
+      let!(:boss) { create :person, :member_of, team: moj, leader: true, role: 'Perm. Sec.' }
+
+      it 'permits changing team to department' do
+        membership.group_id = moj.id
+        expect(membership).to be_valid
+      end
+
+      it 'permits becoming leader of sub-department' do
+        membership.leader = true
+        expect(membership).to be_valid
+      end
+
+      it 'permits changing perm. sec. to not being the perm. sec.' do
+        membership = boss.memberships.first
+        membership.leader = false
+        expect(membership).to be_valid
+      end
+
+      it 'permits updates to perm. sec.' do
+        membership = boss.memberships.first
+        membership.subscribed = !membership.subscribed
+        expect(membership).to be_valid
+      end
+
+      it 'prevents new memberships as perm. sec.' do
+        membership = build(:membership, person: person, group: moj, leader: true, role: 'another perm sec')
+        expect(membership).to be_invalid
+      end
+
+      it 'prevents changing team to department if you are a leader' do
+        membership.leader = true
+        expect(membership).to be_valid
+        membership.group_id = moj.id
+        expect(membership).to be_invalid
+      end
+
+      it 'adds appropriate error message to leader attribute' do
+        membership = build(:membership, person: person, group: moj, leader: true, role: 'another perm sec')
+        membership.valid?
+        expect(membership.errors[:leader]).to include 'can\'t have more than one Permanent Secretary'
+      end
+    end
+
+    context 'when a perm. sec. does not exist' do
+      it 'permits becoming perm. sec.' do
+        membership.group_id = moj.id
+        membership.leader = true
+        expect(membership).to be_valid
+      end
+    end
+
   end
 end


### PR DESCRIPTION
On regular occasions users have inadvertently made themselves
the leader of the top-level "Department" (Ministry of Justice).

This validation prevents this unless the current perm.sec.
is either deleted, moved to another team or modified to
not be the leader.