### PR TITLE
bump nokogiri 1.7.1 --> 1.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
     netaddr (1.5.0)
-    nokogiri (1.7.1)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     notiffany (0.0.8)
       nenv (~> 0.1)


### PR DESCRIPTION
A security alert was raised by gemnasium:
Sources: https://github.com/sparklemotion/nokogiri/issues/1634
http://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-5029.html
http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-4738.html

![screen shot 2017-05-17 at 16 45 37](https://cloud.githubusercontent.com/assets/7016425/26163028/532fb092-3b20-11e7-8ea4-bb81caa2eccb.png)

