### PR TITLE
Change content of filter sidebar and result summary

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -22,7 +22,7 @@ module SearchHelper
   def result_summary
     options = { style: 'font-size: 25px;' }
     summary = if matches_exist?
-                [bold_tag(pluralize(result_count, 'result'), options), 'found', filter_text]
+                [bold_tag(pluralize(result_count, 'result'), options), filter_text]
               else
                 [
                   bold_tag(@query, options),

--- a/app/views/search/_filter_sidebar.html.haml
+++ b/app/views/search/_filter_sidebar.html.haml
@@ -1,12 +1,10 @@
 %h2.heading-small{ style: 'margin-top: 0;' }
   = t('.filter_results_heading')
-= t('.filter_results_hint')
+
 
 = form_tag '/search', method: :get, id: 'mod-search-filter-form' do
   = hidden_field_tag :query, @query
 
-  %h3.heading-small
-    = t('.people_team_filter_heading')
   .grid-row
     .column-two-thirds
       = check_box_tag 'search_filters[]', :people, people_filter?, id: :people, :onclick => "javascript: submit_search();"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,9 +39,7 @@ en:
     index:
       results_footer_html: "Can't find the person you're looking for? Why not %{new_profile_link}"
     filter_sidebar:
-        filter_results_heading: Filter results
-        filter_results_hint: The results will update automatically based on your selection
-        people_team_filter_heading: People and teams
+        filter_results_heading: "Filter by:"
         people_checkbox_label: People
         teams_checkbox_label: Teams
   sessions:

--- a/spec/features/search_filter_spec.rb
+++ b/spec/features/search_filter_spec.rb
@@ -66,7 +66,7 @@ feature 'Search results page' do
 
     scenario 'on people', js: true do
       uncheck 'Teams'
-      expect(search_page.search_result_summary).to have_text('2 results found from people')
+      expect(search_page.search_result_summary).to have_text('2 results from people')
       expect(search_page.search_results).to have_people_results count: 2
       expect(search_page.search_results).to have_team_results count: 0
       expect(search_page.search_results.people_result_names).to include 'Jon Browne', 'Jim Browne'

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -58,7 +58,7 @@ feature 'Searching feature', elastic: true do
         expect(page).to have_text('Search results')
       end
       within('.cb-search-result-summary') do
-        expect(page).to have_text(/\d+ result(s)? found/)
+        expect(page).to have_text(/\d+ result(s)?/)
       end
       within('.mod-search-form') do
         expect(page).to have_selector("input[value='Browne']")

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe SearchHelper, type: :helper do
 
       context 'unfiltered' do
         it 'outputs expected text including sub-counts' do
-          expect(helper.result_summary).to match(/\A.*4 results.* found from people \(3\) and teams \(1\)\z/)
+          expect(helper.result_summary).to match(/\A.*4 results.* from people \(3\) and teams \(1\)\z/)
         end
       end
 
@@ -75,7 +75,7 @@ RSpec.describe SearchHelper, type: :helper do
           @search_filters = ['people']
         end
         it 'outputs expected text, not including sub counts' do
-          expect(helper.result_summary).to match(/\A.*3 results.* found from people\z/)
+          expect(helper.result_summary).to match(/\A.*3 results.* from people\z/)
         end
       end
 
@@ -85,7 +85,7 @@ RSpec.describe SearchHelper, type: :helper do
           @search_filters = ['teams']
         end
         it 'outputs expected text, not including sub counts' do
-          expect(helper.result_summary).to match(/\A.*1 result.* found from teams\z/)
+          expect(helper.result_summary).to match(/\A.*1 result.* from teams\z/)
         end
       end
     end


### PR DESCRIPTION
Following design advice it was recommended
to remove much of the content from the filter sidebar
and simplify the result summary.