### PR TITLE
Homepage info

### DIFF
--- a/app/assets/stylesheets/elements-local/_anchors.scss
+++ b/app/assets/stylesheets/elements-local/_anchors.scss
@@ -5,14 +5,19 @@ a{
 a:hover{
   text-decoration: underline;
 }
+
+.new-profile a {
+  display: inline-block;
+  margin-top: 13px;
+  padding: 2px 0 10px 30px;
+}
+
 .new-profile a.add-new-person {
     background: image-url('icon_add_person.png') scroll no-repeat 0 0;
 }
 
-.new-profile a {
-    display: inline-block;
-    margin-top: 13px;
-    padding: 2px 0 10px 30px;
+.new-profile a.add-new-team {
+    background: image-url('icon_add_person.png') scroll no-repeat 0 0;
 }
 
 .pipe-right{

--- a/app/assets/stylesheets/modules/_module-home.scss
+++ b/app/assets/stylesheets/modules/_module-home.scss
@@ -1,0 +1,10 @@
+.mod-link{
+  font-weight: normal;
+}
+
+.mod-home-info {
+  border-top: 10px solid $darkblue;
+  margin-right: 40px;
+  padding-top: 5px;
+  font-weight: normal;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,7 +12,7 @@ class HomeController < ApplicationController
   end
 
   def can_add_person_here?
-    true
+    params['action'] == 'show'
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,4 +11,9 @@ class HomeController < ApplicationController
     @all_people_count = @group.all_people_count
     @org_structure = Group.hierarchy_hash
   end
+
+  def can_add_person_here?
+    true
+  end
+
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,18 +2,27 @@ class HomeController < ApplicationController
 
   include UserAgentHelper
 
-  def show
-    @group = Group.department
-    unless @group
-      notice :top_level_group_needed
-      redirect_to(new_group_path) && return
-    end
-    @all_people_count = @group.all_people_count
+  before_action :set_department_or_redirect, only: [:show, :index]
+
+  def show; end
+
+  def index
+    @all_people_count = @department.all_people_count
     @org_structure = Group.hierarchy_hash
   end
 
   def can_add_person_here?
     true
+  end
+
+  private
+
+  def set_department_or_redirect
+    @department = Group.department
+    unless @department
+      notice :top_level_group_needed
+      redirect_to(new_group_path) && return
+    end
   end
 
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,0 +1,35 @@
+.grid-row
+  .column-two-thirds
+    %h1.heading-xlarge.cb-page-title
+      = t('.heading', department: @department.name)
+  .column-one-third
+    .heading-medium.mod-home-info
+      = t('.about_usage')
+    .new-profile
+      = link_to 'Create a new team', new_group_path, class: 'add-new-person'
+
+.grid-row.mod-team-overview
+  .column-one-third
+    - if @department.leaderships.count > 0
+      - @department.leaderships_by_person.each do |person, leaderships|
+        = render partial: 'groups/leaderships', object: leaderships, locals: { person: person, counter: @department.leaderships.count }
+
+  .column-two-thirds
+    %h3.heading-medium
+      = "About the team"
+    .mod-wrap-text.formatted-text
+      = govspeak(@department.with_placeholder_default(:description))
+
+    - if @department.children.present?
+      = link_to "View printable organogram", organogram_group_path(@department)
+    - unless @department.leaf_node?
+      - if @all_people_count > 0 && @department.parent.present?
+        = link_to "View #{ @all_people_count > 1 ? 'all' : '' } people", people_group_path(@department), class: 'view-all-people'
+
+.grid-row.mod-heading
+  .column-full
+    %h1.heading-large.mod-heading-border
+      = "Teams within #{@department.name}"
+
+#teams.grid-row.mod-subgroups
+  = render partial: "groups/subgroup", collection: @department.children

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,3 +1,10 @@
+
+- content_for :body_classes do
+  = 'browse-teams-page '
+
+- content_for :breadcrumbs do
+  = breadcrumbs(Home.path + ['Browse'])
+
 .grid-row
   .column-two-thirds
     %h1.heading-xlarge.cb-page-title

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -7,13 +7,14 @@
 
 .grid-row
   .column-two-thirds
-    %h1.heading-xlarge.cb-page-title
-      = t('.heading', department: @department.name)
+    %h1.heading-xlarge.with-border-lg.cb-page-title
+      = @page_title = t('.heading', department: @department.name)
+
   .column-one-third
-    .heading-medium.mod-home-info
+    .heading-medium.mod-home-info.cb-about-usage
       = t('.about_usage')
     .new-profile
-      = link_to 'Create a new team', new_group_path, class: 'add-new-person'
+      = link_to 'Create a new team', new_group_path, class: 'add-new-team'
 
 .grid-row.mod-team-overview
   .column-one-third

--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -8,13 +8,16 @@
     = t('.unsupported_browser_warning_html')
 
 .grid-row
-  .column-full
+  .column-two-thirds
     %h1.heading-xlarge.cb-page-title
-
       = t('home.heading', group_name: @group.name)
 
     %p.lede
       = t('home.explanation')
+
+  .column-one-third
+    .usage.heading-medium.cb-usage{ style: 'border-top: 10px solid #005EA5; font-weight: normal; margin-right: 40px; padding-top: 5px' }
+      = t('.usage')
 
 = render 'shared/search'
 

--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -1,8 +1,6 @@
 - content_for :body_classes do
   = 'home-page '
 
--# = link_to 'Create a new profile', new_person_path, class: 'add-new-person'
-
 - if unsupported_browser?
   .cb-unsupported-browser-warning.error-summary{"aria-labelledby" => "error-summary-heading", :role => "group", :tabindex => "-1"}
     = t('.unsupported_browser_warning_html')
@@ -10,46 +8,18 @@
 .grid-row
   .column-two-thirds
     %h1.heading-xlarge.cb-page-title
-      = t('home.heading', group_name: @group.name)
+      = t('.heading', group_name: @department.name)
 
     %p.lede
-      = t('home.explanation')
+      = t('.explanation')
 
   .column-one-third
-    .usage.heading-medium.cb-usage{ style: 'border-top: 10px solid #005EA5; font-weight: normal; margin-right: 40px; padding-top: 5px' }
-      = t('.usage')
+    .heading-medium.mod-home-info
+      = t('.about_usage')
 
 = render 'shared/search'
 
-.grid-row.mod-heading
+.grid-row
   .column-full
-    %h1.heading-xlarge.mod-heading-border
-      %span.heading-secondary
-        = @group.acronym
-      = @group.name
-
-.grid-row.mod-team-overview
-  .column-one-third
-    - if @group.leaderships.count > 0
-      - @group.leaderships_by_person.each do |person, leaderships|
-        = render partial: 'groups/leaderships', object: leaderships, locals: { person: person, counter: @group.leaderships.count }
-
-  .column-two-thirds
-    %h3.heading-medium
-      = "About the team"
-    .mod-wrap-text.formatted-text
-      = govspeak(@group.with_placeholder_default(:description))
-
-    - if @group.children.present?
-      = link_to "View printable organogram", organogram_group_path(@group)
-    - unless @group.leaf_node?
-      - if @all_people_count > 0 && @group.parent.present?
-        = link_to "View #{ @all_people_count > 1 ? 'all' : '' } people", people_group_path(@group), class: 'view-all-people'
-
-.grid-row.mod-heading
-  .column-full
-    %h1.heading-large.mod-heading-border
-      = "Teams within #{@group.name}"
-
-#teams.grid-row.mod-subgroups
-  = render partial: "groups/subgroup", collection: @group.children
+    .heading-small.mod-link
+      = link_to "Browse #{Group.department.short_name} teams", browse_path

--- a/app/views/home/show.html.haml
+++ b/app/views/home/show.html.haml
@@ -14,12 +14,12 @@
       = t('.explanation')
 
   .column-one-third
-    .heading-medium.mod-home-info
+    .heading-medium.mod-home-info.cb-about-usage
       = t('.about_usage')
 
 = render 'shared/search'
 
 .grid-row
   .column-full
-    .heading-small.mod-link
+    .heading-small.mod-link.cb-browse-teams
       = link_to "Browse #{Group.department.short_name} teams", browse_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
         We recommend the <strong style="font-weight: 700">Firefox</strong> web browser for a more enhanced experience.
         <br/><br/>
         <strong style="font-weight: 700">Copy and paste</strong> the link below to use in <strong style="font-weight: 700">Firefox</strong>
+    about_usage: &about_usage People Finder relies on contributions from everyone to help keep it up-to-date.
   time:
     formats:
       default: "%d %b %Y %H:%M"
@@ -338,7 +339,9 @@ en:
       <a href="/cookies">Find out more about cookies</a>
   home:
     show:
-      usage: People Finder relies on contributions from everyone to help keep it up-to-date.
+      heading: People Finder
+      explanation: Search for a person or team in the Ministry of Justice
+      about_usage: *about_usage
       unsupported_browser_warning_html: |
         <h1 id='error-summary-heading' class='heading-medium error-summary-heading'>
           People Finder is best viewed in Firefox.
@@ -349,8 +352,9 @@ en:
         <p>
           Copy the URL above into Firefox.
         </p>
-    heading: People Finder
-    explanation: Search for a person or team in the Ministry of Justice
+    index:
+      heading: Browse %{department} teams
+      about_usage: *about_usage
     org_heading: Browse the organisation
     org_sub_heading: Browse by team
     org_hint_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -338,6 +338,7 @@ en:
       <a href="/cookies">Find out more about cookies</a>
   home:
     show:
+      usage: People Finder relies on contributions from everyone to help keep it up-to-date.
       unsupported_browser_warning_html: |
         <h1 id='error-summary-heading' class='heading-medium error-summary-heading'>
           People Finder is best viewed in Firefox.
@@ -348,19 +349,8 @@ en:
         <p>
           Copy the URL above into Firefox.
         </p>
-    heading: Welcome to People Finder
-    explanation: |
-      Find out how to contact people, what team they’re in, where and when
-      they work.
-    search_heading: Search
-    search_hint: |
-      You can search by job title, location, phone number,
-      or by name.
-    usage_heading: Help keep People Finder up to date.
-    usage: |
-      Edit your profile to make sure your information is current and accurate.
-      You can also make changes to other people’s profiles. They will receive
-      an email notifying them of changes.
+    heading: People Finder
+    explanation: Search for a person or team in the Ministry of Justice
     org_heading: Browse the organisation
     org_sub_heading: Browse by team
     org_hint_html: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'home#show', as: :home
+  get 'browse', to: 'home#index', as: :browse
   get 'ping', to: 'ping#index'
   get 'healthcheck', to: 'health_check#index'
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -11,29 +11,50 @@ RSpec.describe HomeController, type: :controller do
 
   describe 'GET show' do
     context 'when there is no top-level group' do
+      before { get :show }
+
       it 'redirects to the new group page' do
-        get :show
         expect(response).to redirect_to(new_group_path)
       end
 
       it 'tells the user to create a top-level group' do
-        get :show
         expect(flash[:notice]).to have_text('create a top-level group')
       end
     end
 
     context 'when there is a top-level group' do
-      before { create(:department) }
+      before do
+        create(:department)
+        get :show
+      end
+
+      it '#can_add_person_here? returns true' do
+        expect(controller.can_add_person_here?).to eql true
+      end
 
       it 'renders the show template' do
-        get :show
         expect(response).to render_template('show')
       end
 
       it 'assigns the group to the top_level_group' do
-        get :show
-        expect(assigns(:group).name).to eql('Ministry of Justice')
+        expect(assigns(:department).name).to eql('Ministry of Justice')
       end
     end
   end
+
+  describe 'GET index' do
+    before do
+      create(:department)
+      get :index
+    end
+
+    it '#can_add_person_here? returns false' do
+      expect(controller.can_add_person_here?).to eql false
+    end
+
+    it 'assigns the group to the top_level_group' do
+      expect(assigns(:department).name).to eql('Ministry of Justice')
+    end
+  end
+
 end

--- a/spec/features/browse_spec.rb
+++ b/spec/features/browse_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+feature 'Browse page' do
+  include PermittedDomainHelper
+
+  let(:browse_page) { Pages::Browse.new }
+  let(:department) { create(:department) }
+
+  before do
+    create(:person, :member_of, team: department, leader: true, role: 'Permanent Secretary', given_name: 'Richard', surname: 'Heaton')
+  end
+
+  context 'page structure' do
+    background do
+      mock_readonly_user
+      visit '/browse'
+    end
+
+    it 'is all there' do
+      expect(browse_page).to be_displayed
+      expect(browse_page).to have_page_title
+      expect(browse_page).to have_about_usage
+      expect(browse_page).to have_create_team_link
+      expect(browse_page).to have_leader_profile_image
+    end
+
+    it 'has page title' do
+      expect(browse_page).to have_page_title
+      expect(browse_page.page_title).to have_text('Browse Ministry of Justice teams')
+    end
+
+    it 'has about usage section' do
+      expect(browse_page).to have_about_usage
+      expect(browse_page.about_usage).to have_text 'People Finder relies on contributions from everyone to help keep it up-to-date'
+    end
+
+    it 'displays perm sec\' image but not name and role' do
+      expect(browse_page).to have_leader_profile_image
+      expect(browse_page.leader_profile_image[:alt]).to eql 'Current photo of Richard Heaton'
+      expect(browse_page).not_to have_text 'Richard Heaton'
+    end
+  end
+end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -27,15 +27,20 @@ feature 'Home page' do
       it 'is all there' do
         expect(home_page).to be_displayed
         expect(home_page).to have_page_title
-        expect(home_page.page_title).to have_text('Welcome to People Finder')
-        expect(home_page).to have_leader_profile_image
+        expect(home_page).to have_about_usage
         expect(home_page).to have_search_form
+        expect(home_page).to have_browse_teams_link
+        expect(home_page).to have_create_profile_link
       end
 
-      it 'displays perm sec\' image but not name and role' do
-        expect(home_page).to have_leader_profile_image
-        expect(home_page.leader_profile_image[:alt]).to eql 'Current photo of Richard Heaton'
-        expect(home_page).not_to have_text 'Richard Heaton'
+      it 'has page title' do
+        expect(home_page).to have_page_title
+        expect(home_page.page_title).to have_text('People Finder')
+      end
+
+      it 'has about usage section' do
+        expect(home_page).to have_about_usage
+        expect(home_page.about_usage).to have_text 'People Finder relies on contributions from everyone to help keep it up-to-date'
       end
 
       context 'Firefox 31+' do

--- a/spec/support/pages/browse.rb
+++ b/spec/support/pages/browse.rb
@@ -1,0 +1,14 @@
+require_relative 'sections/about_usage'
+
+module Pages
+  class Browse < Base
+    set_url('/browse')
+    set_url_matcher('/browse')
+
+    element :page_title, '#content h1.cb-page-title'
+    element :create_team_link, '.add-new-team'
+    element :leader_profile_image, 'img.media-object'
+
+    section :about_usage, Sections::AboutUsage, '.cb-about-usage'
+  end
+end

--- a/spec/support/pages/home.rb
+++ b/spec/support/pages/home.rb
@@ -1,4 +1,5 @@
 require_relative 'sections/search_form'
+require_relative 'sections/about_usage'
 
 module Pages
   class Home < Base
@@ -7,8 +8,10 @@ module Pages
 
     element :page_title, '#content h1.cb-page-title'
     element :unsupported_browser_warning, '.cb-unsupported-browser-warning'
-    element :leader_profile_image, 'img.media-object'
+    element :browse_teams_link, '.cb-browse-teams'
+    element :create_profile_link, '.new-profile a.add-new-person'
 
     section :search_form, Sections::SearchForm, 'form.mod-search-form'
+    section :about_usage, Sections::AboutUsage, '.cb-about-usage'
   end
 end

--- a/spec/support/pages/sections/about_usage.rb
+++ b/spec/support/pages/sections/about_usage.rb
@@ -1,0 +1,6 @@
+module Pages
+  module Sections
+    class AboutUsage < SitePrism::Section
+    end
+  end
+end


### PR DESCRIPTION
**What**
- [X] Move department overview to separate page
- [X] Add create a team link to home page
- [X] Add brief about usage text to home page

**Why**
Simplify and focus home page on search tool
Enable easy access to profile creation
Encourage profile creation
