### PR TITLE
Team selector MOJ level fixes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -242,3 +242,10 @@ $border-color: #bfc1c3;
     width: auto;
   }
 }
+
+
+.root-node .team-link:first-child{
+  color: $text-colour !important;
+  padding-top: 4px;
+  padding-left: $gutter/2 !important;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -242,10 +242,3 @@ $border-color: #bfc1c3;
     width: auto;
   }
 }
-
-
-.root-node .team-link:first-child{
-  color: $text-colour !important;
-  padding-top: 4px;
-  padding-left: $gutter/2 !important;
-}

--- a/app/assets/stylesheets/modules/_module-team-selector.scss
+++ b/app/assets/stylesheets/modules/_module-team-selector.scss
@@ -320,3 +320,10 @@ form .org-browser {
     padding: 8px;
   }
 }
+
+// Target the top level node
+.root-node .team-link:first-child{
+  color: $text-colour !important;
+  padding-top: 4px;
+  padding-left: $gutter/2 !important;
+}

--- a/app/helpers/org_browser_helper.rb
+++ b/app/helpers/org_browser_helper.rb
@@ -1,0 +1,6 @@
+module OrgBrowserHelper
+  def current_group_or_department? group
+    (@group && @group.id == group.id) ||
+      (group == Group.department && controller.controller_name == 'people')
+  end
+end

--- a/app/views/shared/_org_browser_level_heading.html.haml
+++ b/app/views/shared/_org_browser_level_heading.html.haml
@@ -1,10 +1,9 @@
-- group_disabled = (@group && @group.id == group.id) || (group == Group.department)
+- disable = current_group_or_department?(group)
 
 %a{href:'#', :class => 'team-back'} Back
 
-
-%h3{class: (group_disabled ? 'disabled' : '')}
-  - if form && !group_disabled
+%h3{class: (disable ? 'disabled' : '')}
+  - if form && !disable
     = form.radio_button(field_name, group.id)
 
   %a{href: group_path(group['id']), :class => 'team-link', title: group.name }<

--- a/app/views/shared/_org_browser_level_heading.html.haml
+++ b/app/views/shared/_org_browser_level_heading.html.haml
@@ -1,6 +1,7 @@
-- group_disabled = (@group && @group.id == group.id)
+- group_disabled = (@group && @group.id == group.id) || (group == Group.department)
 
 %a{href:'#', :class => 'team-back'} Back
+
 
 %h3{class: (group_disabled ? 'disabled' : '')}
   - if form && !group_disabled
@@ -8,3 +9,5 @@
 
   %a{href: group_path(group['id']), :class => 'team-link', title: group.name }<
     = group['name']
+
+

--- a/spec/features/group_maintenance_spec.rb
+++ b/spec/features/group_maintenance_spec.rb
@@ -146,7 +146,7 @@ feature 'Group maintenance' do
       expect(last_email.body.encoded).to match(group_url(group))
     end
 
-    scenario 'Changing a team parent via clicking "Back"', js: true do
+    scenario 'Change parent to department via clicking "Back"', js: true do
       group = setup_three_level_group
       setup_group_member group
       expect(dept.name).to eq 'Ministry of Justice'

--- a/spec/features/person_membership_spec.rb
+++ b/spec/features/person_membership_spec.rb
@@ -97,15 +97,15 @@ feature "Person maintenance" do
     expect(page).to have_selector('.hide-editable-fields', visible: :visible)
 
     within('.team.selected') { click_link 'Back' }
-    expect(page).to have_selector('a.team-link', text: /#{Group.department.name}/, visible: :visible)
-
+    expect(page).to have_selector('a.subteam-link', text: /CSG/, visible: :visible)
+    within('.team.selected') { click_link 'CSG' }
     click_link 'Done'
     expect(page).to have_selector('.editable-fields', visible: :hidden)
 
     click_button 'Save', match: :first
 
     person.reload
-    expect(person.memberships.last.group).to eql(Group.department)
+    expect(person.memberships.last.group).to eql(Group.find_by(name: 'CSG'))
   end
 
   scenario 'Adding a new team', js: true do


### PR DESCRIPTION
What this PR does:
Hide the radio button on the MOJ level to stop a person from selecting it

<img width="506" alt="screen shot 2017-06-13 at 13 21 14" src="https://user-images.githubusercontent.com/3668907/27082133-6e86e146-503b-11e7-9f0d-bdbb88e3276b.png">