### PR TITLE
add task to move non-team-members to department

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -101,7 +101,7 @@ Metrics/AbcSize:
 # Offense count: 227
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 417
+  Max: 430
 
 # Offense count: 4
 # Configuration parameters: CountComments.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -101,7 +101,9 @@ Metrics/AbcSize:
 # Offense count: 227
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 430
+  Max: 400
+  Exclude:
+    - 'spec/models/person_spec.rb'
 
 # Offense count: 4
 # Configuration parameters: CountComments.

--- a/app/assets/stylesheets/modules/_module-team-selector.scss
+++ b/app/assets/stylesheets/modules/_module-team-selector.scss
@@ -320,10 +320,3 @@ form .org-browser {
     padding: 8px;
   }
 }
-
-// Target the top level node
-.root-node .team-link:first-child{
-  color: $text-colour !important;
-  padding-top: 4px;
-  padding-left: $gutter/2 !important;
-}

--- a/app/helpers/org_browser_helper.rb
+++ b/app/helpers/org_browser_helper.rb
@@ -1,6 +1,22 @@
 module OrgBrowserHelper
+
   def current_group_or_department? group
-    (@group && @group.id == group.id) ||
-      (group == Group.department && controller.controller_name == 'people')
+    @group_nav_item = group
+    group_nav_item_is_self? || group_nav_item_is_department?
   end
+
+  private
+
+  # when editing a group you should not be able to select that group as its own parent
+  #
+  def group_nav_item_is_self?
+    @group && @group.id == @group_nav_item.id && controller.controller_name == 'groups'
+  end
+
+  # when editing a person you should not be able to select the department
+  #
+  def group_nav_item_is_department?
+    @group_nav_item == Group.department && controller.controller_name == 'people'
+  end
+
 end

--- a/app/helpers/org_browser_helper.rb
+++ b/app/helpers/org_browser_helper.rb
@@ -1,8 +1,8 @@
 module OrgBrowserHelper
 
-  def current_group_or_department? group
+  def current_group? group
     @group_nav_item = group
-    group_nav_item_is_self? || group_nav_item_is_department?
+    group_nav_item_is_self?
   end
 
   private
@@ -11,12 +11,6 @@ module OrgBrowserHelper
   #
   def group_nav_item_is_self?
     @group && @group.id == @group_nav_item.id && controller.controller_name == 'groups'
-  end
-
-  # when editing a person you should not be able to select the department
-  #
-  def group_nav_item_is_department?
-    @group_nav_item == Group.department && controller.controller_name == 'people'
   end
 
 end

--- a/app/models/concerns/data_migration_utils.rb
+++ b/app/models/concerns/data_migration_utils.rb
@@ -2,12 +2,27 @@ module Concerns::DataMigrationUtils
   extend ActiveSupport::Concern
 
   included do
-    scope :non_team_members, -> { where(non_member_sql) }
+    scope :non_team_members, -> { unscoped.where(non_member_sql) }
+    scope :department_members_in_other_teams, -> { department_members_in_other_teams_query }
 
     def self.non_member_sql
       <<~SQL
         NOT EXISTS (SELECT 1 FROM memberships WHERE memberships.person_id = people.id)
       SQL
     end
+
+    def self.department_members_in_other_teams_query
+      unscoped.joins(:memberships).where(department_members_in_other_teams_conditions)
+    end
+
+    def self.department_members_in_other_teams_conditions
+      dept_id = Group.department.id
+      <<~SQL
+        memberships.group_id = #{dept_id}
+        AND memberships.leader = 'f'
+        AND EXISTS (SELECT 1 FROM memberships m2 WHERE m2.person_id = people.id AND m2.group_id != #{dept_id})
+      SQL
+    end
+
   end
 end

--- a/app/models/concerns/data_migration_utils.rb
+++ b/app/models/concerns/data_migration_utils.rb
@@ -1,0 +1,13 @@
+module Concerns::DataMigrationUtils
+  extend ActiveSupport::Concern
+
+  included do
+    scope :non_team_members, -> { where(non_member_sql) }
+
+    def self.non_member_sql
+      <<~SQL
+        NOT EXISTS (SELECT 1 FROM memberships WHERE memberships.person_id = people.id)
+      SQL
+    end
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -43,6 +43,7 @@ class Person < ActiveRecord::Base
   include Concerns::ExposeMandatoryFields
   include Concerns::GeckoboardDatasets
   include Concerns::PersonChangesTracker
+  include Concerns::DataMigrationUtils
 
   belongs_to :profile_photo
 
@@ -123,11 +124,9 @@ class Person < ActiveRecord::Base
 
   scope :never_logged_in, PeopleNeverLoggedInQuery.new
   scope :logged_in_at_least_once, PeopleLoggedInAtLeastOnceQuery.new
-  scope :last_reminder_email_older_than, ->(within) { ReminderMailOlderThanQuery.new(within).call }
+  scope :last_reminder_email_older_than, -> (within) { ReminderMailOlderThanQuery.new(within).call }
   scope :updated_at_older_than, -> (within) { PeopleUpdatedOlderThanQuery.new(within).call }
-
   scope :updated_at_older_than, -> (within) { where('updated_at < ?', within) }
-
   scope :created_at_older_than, -> (within) { where('created_at < ?', within) }
 
   scope :namesakes, -> (person) { NamesakesQuery.new(person).call }

--- a/app/views/people/_membership_fields.html.haml
+++ b/app/views/people/_membership_fields.html.haml
@@ -1,7 +1,6 @@
 - membership = membership_f.object
 .membership.panel
   .form-group
-    -# = membership_f.label :role, 'Job title', class: 'form-label-bold'
     = membership_f.text_field :role
 
   .form-group
@@ -11,8 +10,6 @@
     %p.form-hint
       = role_translate(person, 'memberships.team_creation_hint')
     .editable-container
-
-      / - unless membership.new_record?
       .editable-summary.parent-summary
         - if membership.group
           .title.breadcrumbs= breadcrumbs(membership.path, show_links: false)

--- a/app/views/shared/_org_browser_level_heading.html.haml
+++ b/app/views/shared/_org_browser_level_heading.html.haml
@@ -1,4 +1,4 @@
-- disable = current_group_or_department?(group)
+- disable = current_group?(group)
 
 %a{href:'#', :class => 'team-back'} Back
 

--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -99,6 +99,20 @@ namespace :peoplefinder do
       end
     end
 
+    desc 'adding people not in a team to the Department level team'
+    task :move_unassigned_to_department => :environment do
+      department = Group.department
+      puts "Assign #{Person.non_team_members.count} people not in a team to #{department}"
+      Person.non_team_members.each do |person|
+        begin
+          person.memberships.create(group: department)
+          print '.'
+        rescue => err
+          puts "Failed to assign #{person.name} to #{department}: #{err}"
+        end
+      end
+    end
+
     def csv_header
       PersonCsvImporter::REQUIRED_COLUMNS + PersonCsvImporter::OPTIONAL_COLUMNS
     end

--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -99,20 +99,6 @@ namespace :peoplefinder do
       end
     end
 
-    desc 'adding people not in a team to the Department level team'
-    task :move_unassigned_to_department => :environment do
-      department = Group.department
-      puts "Assign #{Person.non_team_members.count} people not in a team to #{department}"
-      Person.non_team_members.each do |person|
-        begin
-          person.memberships.create(group: department)
-          print '.'
-        rescue => err
-          puts "Failed to assign #{person.name} to #{department}: #{err}"
-        end
-      end
-    end
-
     def csv_header
       PersonCsvImporter::REQUIRED_COLUMNS + PersonCsvImporter::OPTIONAL_COLUMNS
     end
@@ -125,6 +111,35 @@ namespace :peoplefinder do
         record += [person.__send__(attribute)]
       end
       record
+    end
+
+    namespace :migration do
+
+      def department
+        @department ||= Group.department
+      end
+
+      desc 'Adds people not in a team to the Department level team'
+      task :move_unassigned_to_department => :environment do
+        puts "Assign #{Person.non_team_members.count} people not in a team to #{department}"
+        Person.non_team_members.each do |person|
+          begin
+            person.memberships.create(group: department)
+            print '.'
+          rescue => err
+            puts "Failed to assign #{person.name} to #{department}: #{err}"
+          end
+        end
+      end
+
+      desc 'Deletes department level team memberships for those in another team'
+      task :remove_unnecessary_department_memberships => :environment do
+        puts "Remove #{Person.department_members_in_other_teams.count} unnecessary #{department} memberships"
+        Person.department_members_in_other_teams.each do |person|
+          puts "Testing: removing #{person} from #{department}"
+          # person.memberships.find_by(group_id: department).destroy_all
+        end
+      end
     end
 
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -102,6 +102,19 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe '.non_team_members' do
+    before do
+      person.memberships.build(group: create(:department))
+      person.save!
+    end
+
+    it 'returns people in no team' do
+      expect(described_class.non_team_members).to_not include(person)
+      person.memberships.destroy_all
+      expect(described_class.non_team_members).to include(person)
+    end
+  end
+
   describe '#name' do
     context 'with a given_name and surname' do
       let(:person) { build(:person, given_name: 'Jon', surname: 'von Brown') }

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -108,10 +108,47 @@ RSpec.describe Person, type: :model do
       person.save!
     end
 
-    it 'returns people in no team' do
+    it 'does not return people in one or more teams' do
       expect(described_class.non_team_members).to_not include(person)
+    end
+
+    it 'returns people in no team' do
       person.memberships.destroy_all
       expect(described_class.non_team_members).to include(person)
+    end
+  end
+
+  describe '.department_members_in_other_teams' do
+    before do
+      person.save!
+      person.memberships.create(group: create(:department))
+    end
+
+    it 'returns people in department who are also in another team' do
+      person.memberships.create(group: create(:group, name: 'Technology'))
+      expect(described_class.department_members_in_other_teams).to include(person)
+    end
+
+    it 'does not return people in no team' do
+      person.memberships.destroy_all
+      expect(described_class.department_members_in_other_teams).to_not include(person)
+    end
+
+    it 'does not return people only in one team' do
+      expect(described_class.department_members_in_other_teams).to_not include(person)
+    end
+
+    it 'does not return people in department who are also in another team if they are the department leader' do
+      person.memberships.find_by(group_id: Group.department).update(leader: true)
+      person.memberships.create(group: create(:group, name: 'Technology'))
+      expect(described_class.department_members_in_other_teams).to_not include(person)
+    end
+
+    it 'does not return people in multiple non-department teams' do
+      person.memberships.destroy_all
+      person.memberships.create(group: create(:group, name: 'Technology'))
+      person.memberships.create(group: create(:group, name: 'Digital'))
+      expect(described_class.department_members_in_other_teams).to_not include(person)
     end
   end
 


### PR DESCRIPTION
There are many profiles on prod that are not
associated with any team. These are to be moved
to the department level.