### PR TITLE
enable team creation via new profile form

### DIFF
--- a/app/views/people/_team_selector.html.haml
+++ b/app/views/people/_team_selector.html.haml
@@ -19,9 +19,8 @@
       = role_translate(@person, 'memberships.team_selector_hint')
     - if @org_structure
       = render 'shared/org_browser', org_structure: @org_structure, form: membership_f, field_name: :group_id
-      - unless membership.new_record?
-        = link_to 'Done', '#', class: 'hide-editable-fields button-secondary'
-        = link_to 'Add new sub-team to the <span class="team-led"></span>'.html_safe, '#', class: 'button-add-team'
+      = link_to 'Done', '#', class: 'hide-editable-fields button-secondary'
+      = link_to 'Add new sub-team to the <span class="team-led"></span>'.html_safe, '#', class: 'button-add-team'
       %div.new-team
         = membership_f.label 'addteam', 'Add new sub-team to the <span class="team-led"></span>'.html_safe, class: 'form-label-bold'
         %input.form-control.new-team-name#AddTeam


### PR DESCRIPTION
The ability to create new subteam via the team selector
was only enabled on the edit profile flow. This has
now been enabled for new profiles too, to encourage
accurate team memberships creation.