### PR TITLE
alter perm.sec. unique validation error message

### DIFF
--- a/app/form_builders/person_form_builder.rb
+++ b/app/form_builders/person_form_builder.rb
@@ -19,6 +19,10 @@ class PersonFormBuilder < GovukElementsFormBuilder::FormBuilder
     super
   end
 
+  def error_html_attributes attribute
+    GovukElementsErrorsHelper.error_html_attributes self, attribute
+  end
+
   # patch GovukElementsFormBuilder::FormBuilder#localized
   # as it does not work for hints on nested attributes.
   def localized scope, attribute, default

--- a/app/validators/permanent_secretary_unique_validator.rb
+++ b/app/validators/permanent_secretary_unique_validator.rb
@@ -10,13 +10,15 @@ class PermanentSecretaryUniqueValidator < ActiveModel::Validator
   private
 
   def scope_t
-    [:errors, :validators, :permanent_secretary_unique_validator]
+    [:errors, :validators, :permanent_secretary_unique_validator, :leader]
   end
 
   def perm_sec_unique_message
     I18n.t(
-      :leader,
-      scope: scope_t
+      :unique,
+      scope: scope_t,
+      name: Group.department.name,
+      role: current_perm_sec.role || 'Permanent Secretary'
     )
   end
 

--- a/app/views/people/_membership_fields.html.haml
+++ b/app/views/people/_membership_fields.html.haml
@@ -1,20 +1,19 @@
 - membership = membership_f.object
 
 .membership.panel
-
-  - if membership.errors.keys.include?(:group)
-    .form-group.error
-      = render partial: 'team_selector', locals: { person: person, membership_f: membership_f }
-  - else
-    .form-group
-      = render partial: 'team_selector', locals: { person: person, membership_f: membership_f }
+  .form-group{ membership_f.error_html_attributes(:group) }
+    = render partial: 'team_selector', locals: { person: person, membership_f: membership_f }
 
   .form-group
     = membership_f.text_field :role
 
-  .form-group.team-leader
+  .form-group.team-leader{ membership_f.error_html_attributes(:leader) }
     %fieldset.inline
-      %legend.form-label-bold= role_translate(person, 'memberships.leader').html_safe
+      %legend.form-label-bold
+        = role_translate(person, 'memberships.leader').html_safe
+      - membership.errors.full_messages_for(:leader).each do |message|
+        %span.error-message
+          = message
       = membership_f.label :leader, value: true, class: 'block-label' do
         = membership_f.radio_button :leader, true
         Yes

--- a/app/views/people/_team_selector.html.haml
+++ b/app/views/people/_team_selector.html.haml
@@ -6,7 +6,7 @@
 .editable-container
   .editable-summary.parent-summary
     - if membership.errors.keys.include?(:group)
-      %span.error-message{ id: GovukElementsErrorsHelper.dom_id_for_nested_error(membership.class.name.downcase, membership_f.index, :group) }
+      %span.error-message
         = membership.errors.full_messages_for(:group).first
     - if membership.group
       .title.breadcrumbs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -311,7 +311,9 @@ en:
         too_big: "file size, %{size}, is too large"
         not_in_range: "file size, %{size}, is not in expected range"
       permanent_secretary_unique_validator:
-        leader: Please select "No"
+        leader:
+          unique: "%{role} (leader of %{name}) already exists. Select \"No\" or change the current %{role}'s profile first"
+          # unique: "Leader, select \"No\" as there is already a Permanent Secretary (leader of Ministry of Justice). Alternatively, change the current Permanent Secretary's profile first"
   activerecord:
     errors:
       <<: *errors
@@ -326,6 +328,7 @@ en:
         leader: "Are you the Permanent Secretary of the Ministry of Justice?"
         group: Team
       membership:
+        leader: ''
         group: Team
 
   shared:

--- a/lib/ext/govuk_elements_errors_helper_extensions.rb
+++ b/lib/ext/govuk_elements_errors_helper_extensions.rb
@@ -45,7 +45,7 @@ module GovukElementsErrorsHelperExtensions
   def error_tag_for_nested_attribute object, index, attribute
     messages = object.errors.full_messages_for attribute
     messages.map do |message|
-      association_name = object.class.to_s.downcase
+      association_name = object.class.name.downcase
       dom_id = dom_id_for_nested_error(
         association_name,
         index,
@@ -55,6 +55,15 @@ module GovukElementsErrorsHelperExtensions
       content_tag(:li, content_tag(:a, message, href: "##{dom_id}"))
     end
   end
+
+  def error_html_attributes form_object, attribute
+    {
+      class: ('error' if form_object.object.errors.keys.include?(attribute)).to_s,
+      id: dom_id_for_nested_error(form_object.object.class.name.downcase, form_object.index, attribute)
+    }
+  end
+
+  private
 
   def dom_id_for_nested_error association_name, index, attribute
     ['error', association_name, index, attribute].join('_')

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -264,6 +264,22 @@ feature 'Person maintenance' do
         expect(another_person.reload.memberships.count).to eql 1
       end
 
+      scenario 'Validates uniqueness of leader in department', js: true do
+        role = 'Boss'
+        create(:person, :member_of, team: department, role: role, leader: true)
+
+        javascript_log_in
+        visit person_path(person)
+        click_edit_profile
+        expect(edit_profile_page).to have_selector('.membership.panel', count: 1)
+        within '.team-leader' do
+          govuk_label_click 'Yes'
+        end
+        click_button 'Save', match: :first
+        expect(edit_profile_page.error_summary).to have_leader_unique_error
+        expect(edit_profile_page.error_summary.leader_unique_error).to have_text "#{role} (leader of #{department}) already exists. Select \"No\" or change the current #{role}'s profile first", count: 1
+      end
+
       scenario 'Editing a person to have an existing e-mail raises an error' do
         existing_person = create(:person)
 

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe Membership, type: :model do
       end
 
       it 'adds appropriate error message to leader attribute' do
-        membership = build(:membership, person: person, group: moj, leader: true, role: 'another perm sec')
+        membership = build(:membership, person: person, group: moj, leader: true, role: 'Boss')
         membership.valid?
-        expect(membership.errors[:leader]).to include 'Please select "No"'
+        expect(membership.errors[:leader]).to include "Perm. Sec. (leader of Ministry of Justice) already exists. Select \"No\" or change the current Perm. Sec.'s profile first"
       end
     end
 

--- a/spec/support/pages/sections/error_summary.rb
+++ b/spec/support/pages/sections/error_summary.rb
@@ -9,6 +9,7 @@ module Pages
       # membership errors
       element :team_required_error, "a[href^='#error_membership_'][href$='_group']"
       element :team_membership_required_error, "a[href='#error_person_membership']"
+      element :leader_unique_error, "a[href^='#error_membership_'][href$='_leader']"
     end
   end
 end

--- a/spec/support/pages/sections/profile_form.rb
+++ b/spec/support/pages/sections/profile_form.rb
@@ -10,7 +10,7 @@ module Pages
 
       # membership errors
       element :team_membership_error_destination_anchor, '#error_person_membership'
-      elements :team_required_field_errors, 'span[id^="error_membership_"][id$="_group"]'
+      elements :team_required_field_errors, 'div[id^="error_membership_"][id$="_group"]'
 
       sections :membership_panels, Sections::MembershipPanel, '.membership.panel'
     end


### PR DESCRIPTION
**Why?**
current message for when a user attempts to make themselves leader of the MoJ is unclear.

**What?**
Change the error message based on feedback and add field level error and link to it