### PR TITLE
set reply-to header for problem report submission

### DIFF
--- a/app/mailers/problem_report_mailer.rb
+++ b/app/mailers/problem_report_mailer.rb
@@ -3,6 +3,7 @@ class ProblemReportMailer < ActionMailer::Base
 
   def problem_report(details_hash)
     @problem_report = ProblemReport.new(details_hash)
-    mail to: Rails.configuration.support_email
+    mail to: Rails.configuration.support_email,
+      reply_to: @problem_report.person_email
   end
 end

--- a/spec/mailers/problem_report_mailer_spec.rb
+++ b/spec/mailers/problem_report_mailer_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe ProblemReportMailer do
+  include PermittedDomainHelper
+
+  let(:reporter) { create(:person, email: 'test.user@digital.justice.gov.uk') }
+  let(:reported) { Time.now.to_i }
+  let(:support_email) { Rails.configuration.support_email }
+  let(:details_hash) do
+    {
+      goal: 'Something daft',
+      problem: 'It broke',
+      ip_address: '255.255.255.255',
+      person_email: reporter.email,
+      person_id: reporter.id,
+      browser: 'IE99',
+      timestamp: reported
+    }
+  end
+
+  describe '.problem_report' do
+    let(:mail) do
+      described_class.problem_report(details_hash).
+        deliver_now
+    end
+
+    it 'is sent to support mailbox' do
+      expect(mail.to).to include(support_email)
+    end
+
+    it 'sets reply-to to persons email for automated response' do
+      expect(mail.reply_to).to include(reporter.email)
+    end
+
+    it 'has text part only' do
+      expect(mail.multipart?).to be false
+      expect(mail.content_type).to include 'text/plain'
+    end
+
+    it 'includes the email of the reporter when provided' do
+      expect(mail.body).to have_text(reporter.email)
+    end
+
+    it 'includes the IP address of the reporter' do
+      expect(mail.body).to have_text('255.255.255.255')
+    end
+
+    it 'includes the date reported in UTC iso8601 format' do
+      expect(mail.body).to have_text(Time.at(reported).utc.iso8601)
+    end
+
+    it 'includes the user agent details' do
+      expect(mail.body).to have_text('IE99')
+    end
+
+    context 'without reporter details' do
+      let(:details_hash) do
+        {
+          goal: 'Something daft',
+          problem: 'It broke',
+          ip_address: '255.255.255.255',
+          browser: 'IE99',
+          timestamp: reported
+        }
+      end
+
+      it 'does not set reply to' do
+        expect(mail.reply_to).to be_empty
+      end
+
+      it 'includes unknown for ID' do
+        expect(mail.body).to have_text('Person ID: unknown')
+      end
+
+      it 'includes unknown for email' do
+        expect(mail.body).to have_text('Email: unknown')
+      end
+    end
+
+  end
+end

--- a/spec/models/problem_report_spec.rb
+++ b/spec/models/problem_report_spec.rb
@@ -1,5 +1,4 @@
-require 'spec_helper'
-require 'problem_report'
+require 'rails_helper'
 
 RSpec.describe ProblemReport, type: :model do
   let(:current_time) { Time.at(1_410_298_077) }


### PR DESCRIPTION
PM has set up an auto response for the support inbox. In
order for problem report form submitters to receive this the
reply-to needs to be set on the email that is sent to the support email
by the form. It is set to the reporters email address, if available.