### PR TITLE
modify the department_members_in_other_teams scope

### DIFF
--- a/app/models/concerns/data_migration_utils.rb
+++ b/app/models/concerns/data_migration_utils.rb
@@ -4,23 +4,41 @@ module Concerns::DataMigrationUtils
   included do
     scope :non_team_members, -> { unscoped.where(non_member_sql) }
     scope :department_members_in_other_teams, -> { department_members_in_other_teams_query }
+  end
 
-    def self.non_member_sql
+  class_methods do
+
+    private
+
+    def non_member_sql
       <<~SQL
         NOT EXISTS (SELECT 1 FROM memberships WHERE memberships.person_id = people.id)
       SQL
     end
 
-    def self.department_members_in_other_teams_query
+    def department_members_in_other_teams_query
       unscoped.joins(:memberships).where(department_members_in_other_teams_conditions)
     end
 
-    def self.department_members_in_other_teams_conditions
+    def department_members_in_other_teams_conditions
       dept_id = Group.department.id
       <<~SQL
         memberships.group_id = #{dept_id}
         AND memberships.leader = 'f'
-        AND EXISTS (SELECT 1 FROM memberships m2 WHERE m2.person_id = people.id AND m2.group_id != #{dept_id})
+        AND #{blank?('memberships.role')}
+        AND EXISTS (SELECT 1
+                    FROM memberships m2
+                    WHERE m2.person_id = people.id AND m2.group_id != #{dept_id}
+                    )
+      SQL
+    end
+
+    def blank? column_name
+      <<~SQL
+        (
+          length(regexp_replace(#{column_name},'[\s\t\n]+','','g')) = 0
+          OR #{column_name} IS NULL
+        )
       SQL
     end
 

--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -136,8 +136,7 @@ namespace :peoplefinder do
       task :remove_unnecessary_department_memberships => :environment do
         puts "Remove #{Person.department_members_in_other_teams.count} unnecessary #{department} memberships"
         Person.department_members_in_other_teams.each do |person|
-          puts "Testing: removing #{person} from #{department}"
-          # person.memberships.find_by(group_id: department).destroy_all
+          person.memberships.find_by(group_id: department).destroy_all
         end
       end
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Person, type: :model do
       person.save!
     end
 
-    it 'returns people in department who are also in another team' do
+    it 'returns people in department with no role who are also in another team' do
       person.memberships.create(group: create(:group, name: 'Technology'))
       expect(described_class.department_members_in_other_teams).to include(person)
     end
@@ -152,6 +152,12 @@ RSpec.describe Person, type: :model do
 
     it 'does not return people in department who are also in another team if they are the department leader' do
       person.memberships.find_by(group_id: Group.department).update(leader: true)
+      person.memberships.create(group: create(:group, name: 'Technology'))
+      expect(described_class.department_members_in_other_teams).to_not include(person)
+    end
+
+    it 'does not return people in department who are also in another team if they have a role in the department' do
+      person.memberships.find_by(group_id: Group.department.id).update(role: 'SIRO for peoplefinder')
       person.memberships.create(group: create(:group, name: 'Technology'))
       expect(described_class.department_members_in_other_teams).to_not include(person)
     end


### PR DESCRIPTION
Exclude people in MoJ that have a role. This is because some people
may have a job title/role in MoJ that is deliberately different from
their role in another team.