### PR TITLE
render text emails only for probation token login

### DIFF
--- a/app/helpers/mail_helper.rb
+++ b/app/helpers/mail_helper.rb
@@ -24,8 +24,6 @@ module MailHelper
     content_tag(:p, mailer_t(:do_not_reply))
   end
 
-  private
-
   def link_to_guidance
     link_to('MoJ Intranet', APP_GUIDANCE_PAGE, target: '_blank')
   end

--- a/app/mailers/token_mailer.rb
+++ b/app/mailers/token_mailer.rb
@@ -5,6 +5,14 @@ class TokenMailer < ActionMailer::Base
 
   def new_token_email(token)
     @token = token
-    mail to: @token.user_email
+    mail(to: @token.user_email) do |format|
+      if @token.user_email.include?('@probation.gsi.gov.uk')
+        headers['skip_premailer'] = true
+        format.text
+      else
+        format.text
+        format.html
+      end
+    end
   end
 end

--- a/app/mailers/token_mailer.rb
+++ b/app/mailers/token_mailer.rb
@@ -6,7 +6,7 @@ class TokenMailer < ActionMailer::Base
   def new_token_email(token)
     @token = token
     mail(to: @token.user_email) do |format|
-      if @token.user_email.include?('@probation.gsi.gov.uk')
+      if @token.user_email.include?('@probation.gsi')
         headers['skip_premailer'] = true
         format.text
       else

--- a/app/views/layouts/email.text.erb
+++ b/app/views/layouts/email.text.erb
@@ -1,0 +1,11 @@
+Ministry of Justice
+
+People Finder
+
+<%= yield %>
+
+
+------------------------------------------
+If you're unsure an email is from the MOJ:
+
+• forward it to phishing@digital.justice.gov.uk

--- a/app/views/token_mailer/new_token_email.text.erb
+++ b/app/views/token_mailer/new_token_email.text.erb
@@ -1,12 +1,17 @@
-Hello
+Hello,
+
 
 Thank you for your request to access People Finder.
 
 Please use the link below to continue.
 
+<%=  '-' * mailer_t(:browser_warning).size %>
 <%= mailer_t(:browser_warning) %>
+<%=  '-' * mailer_t(:browser_warning).size %>
+
 
 <%= token_url(@token) %>
+
 
 People Finder allows you to update any profile. Find out more about how to use People Finder on the <%= MailHelper::APP_GUIDANCE_PAGE %>
 

--- a/app/views/token_mailer/new_token_email.text.erb
+++ b/app/views/token_mailer/new_token_email.text.erb
@@ -1,0 +1,14 @@
+Hello
+
+Thank you for your request to access People Finder.
+
+Please use the link below to continue.
+
+<%= mailer_t(:browser_warning) %>
+
+<%= token_url(@token) %>
+
+People Finder allows you to update any profile. Find out more about how to use People Finder on the <%= MailHelper::APP_GUIDANCE_PAGE %>
+
+<%= mailer_t(:do_not_reply) %>
+

--- a/spec/mailers/token_mailer_spec.rb
+++ b/spec/mailers/token_mailer_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe TokenMailer do
+  include PermittedDomainHelper
+
+  before do
+    PermittedDomain.find_or_create_by(domain: 'probation.gsi.gov.uk')
+  end
+
+  let(:requestor) { create(:person, email: 'requestor@digital.justice.gov.uk') }
+  let(:token) { Token.new(user_email: requestor.email) }
+
+  describe '.new_token_email' do
+    let(:mail) do
+      described_class.new_token_email(token).
+        deliver_now
+    end
+
+    it 'is sent to requestor' do
+      expect(mail.to).to include(requestor.email)
+    end
+
+    it 'has text and html part' do
+      expect(mail.multipart?).to be true
+      expect(mail.content_type).to include('multipart/alternative')
+    end
+
+    it 'includes the browser warning' do
+      %w(plain html).each do |part_type|
+        expect(get_message_part(mail, part_type)).to have_text('Internet Explorer 6 and 7 users')
+      end
+    end
+
+    it 'includes the app guidance' do
+      %w(plain html).each do |part_type|
+        expect(get_message_part(mail, part_type)).to have_text('Find out more about how to use People Finder on the')
+        expect(get_message_part(mail, part_type)).to have_text('https://intranet.justice.gov.uk/peoplefinder') if part_type == 'plain'
+        expect(get_message_part(mail, part_type)).to have_link('MoJ Intranet', href: 'https://intranet.justice.gov.uk/peoplefinder') if part_type == 'html'
+      end
+    end
+
+    it 'includes the do not reply warning' do
+      %w(plain html).each do |part_type|
+        expect(get_message_part(mail, part_type)).to have_text('This email is automatically generated. Do not reply')
+      end
+    end
+
+    context 'probation users' do
+      let(:requestor) { create(:person, email: 'requestor@probation.gsi.gov.uk') }
+
+      it 'has text part only for probation email' do
+        expect(mail.multipart?).to be false
+        expect(mail.content_type).to include 'text/plain'
+      end
+    end
+  end
+end


### PR DESCRIPTION
**what**
send text only token login emails to OMNI probation addresses 

**why**
probation users on OMNI network use lotus notes 7 as email client. This client
does not respect HTML (see [lotus notes overview](https://litmus.com/community/learning/20-lotus-notes-overview) and [email client css compatability table](https://i3.campaignmonitor.com/assets/files/css/campaign-monitor-guide-to-css-in-email-sep-2013V2.pdf?ver=2157&_ga=1.39670883.1992293110.1386961694)).

Lotus Notes makes copying and pasting the token into Firefox (rather than using their default IE6 browser) very difficult and the lack of html tag support means we cannot ease it.

Once probation are migrated they will have justice.gov.uk addresses that will receive the standard multipart email in any event and this work could be removed.