### PR TITLE
add scope/query for unnecessary department level memberships

### DIFF
--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -132,11 +132,11 @@ namespace :peoplefinder do
         end
       end
 
-      desc 'Deletes department level team memberships for those in another team'
+      desc 'Deletes department level team memberships with no role for people with memberships in another team'
       task :remove_unnecessary_department_memberships => :environment do
         puts "Remove #{Person.department_members_in_other_teams.count} unnecessary #{department} memberships"
         Person.department_members_in_other_teams.each do |person|
-          person.memberships.find_by(group_id: department).destroy_all
+          person.department_memberships_with_no_role.destroy_all
         end
       end
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -170,6 +170,35 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe '#department_memberships_with_no_role' do
+    subject { person.department_memberships_with_no_role }
+
+    before do
+      person.save!
+      person.memberships.create(group: create(:group, name: 'Technology'))
+    end
+
+    it 'returns AssociationRelation of memberships' do
+      is_expected.to be_kind_of ActiveRecord::AssociationRelation
+      expect(subject.first).to be_kind_of Membership
+    end
+
+    it 'returns department memberships only' do
+      expect(subject.map(&:group)).to eql [Group.department]
+    end
+
+    it 'returns department memberships with no role' do
+      expect(subject.count).to eql 1
+      expect(subject.map(&:role)).to eq [nil]
+    end
+
+    it 'treats whitespace only roles as null' do
+      person.memberships.find_by(group_id: Group.department.id).update(role: ' ')
+      expect(subject.count).to eql 1
+      expect(subject.map(&:role)).to eq [' ']
+    end
+  end
+
   describe '#name' do
     context 'with a given_name and surname' do
       let(:person) { build(:person, given_name: 'Jon', surname: 'von Brown') }


### PR DESCRIPTION
**What**
remove redundant team memberships.

**Why**
There are some profiles that have a department level
membership and a sub-team membership and the department level
membership has no role. The membership therefore serves no purpose 
and is a blocker to possible validations.
