### PR TITLE
Increase token throttle limit to 24 hours

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -24,7 +24,7 @@ class Token < ActiveRecord::Base
   validate :valid_email_address
   validate :within_throttle_limit, on: :create
 
-  DEFAULT_TTL = 10_800
+  DEFAULT_TTL = 86_400
   DEFAULT_MAX_TOKENS_PER_HOUR = 8
   DEFAULT_EXTRA_EXPIRY_PERIOD = 10.minutes
 

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -81,8 +81,8 @@ feature 'Token Authentication' do
     expect(page).to have_text("The authentication token has expired.")
   end
 
-  scenario "logging in with a token that's more than 3 hours old" do
-    token = create(:token, created_at: 4.hours.ago)
+  scenario "logging in with a token that's more than 24 hours old" do
+    token = create(:token, created_at: 25.hours.ago)
     visit token_path(token)
 
     expect(page).to_not have_text('Signed in as')
@@ -145,7 +145,7 @@ feature 'Token Authentication' do
 
   scenario 'requesting token a second time after 3 hours sends different token url in email' do
     first_token_url = nil
-    Timecop.freeze(Time.now - 3.hours) do
+    Timecop.freeze(Time.now - 24.hours) do
       visit '/'
       fill_in 'token_user_email', with: 'test.user@digital.justice.gov.uk'
       expect { click_button 'Request link' }.to change { ActionMailer::Base.deliveries.count }.by(1)

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe Token, type: :model do
 
   context 'time dependent tokens' do
     describe '#ttl' do
-      it 'defaults to 10800 seconds (3 hours)' do
-        expect(token.ttl).to eql(10_800)
+      it 'defaults to 86400 seconds (24 hours)' do
+        expect(token.ttl).to eql(86_400)
       end
     end
 
@@ -158,23 +158,23 @@ RSpec.describe Token, type: :model do
       before { token.save }
 
       context 'in production environment' do
-        it 'returns true if token is less than 10800 seconds old and not spent' do
+        it 'returns true if token is less than 86400 seconds old and not spent' do
           expect(token.active?).to be_truthy
           expect(token.spent?).to be_falsey
-          Timecop.freeze(10_790.seconds.from_now) do
+          Timecop.freeze(86_390.seconds.from_now) do
             expect(token).to be_active
           end
         end
 
-        it 'returns false if token is less than 10800 seconds old but already used' do
+        it 'returns false if token is less than 86400 seconds old but already used' do
           expect do
             token.spend!
             token.reload
           end.to change { token.spent? }.from(false).to(true)
         end
 
-        it 'returns false if token is 10800 seconds or more old' do
-          Timecop.freeze(4.hours.from_now) do
+        it 'returns false if token is 86400 seconds or more old' do
+          Timecop.freeze(25.hours.from_now) do
             expect(token).not_to be_active
           end
         end


### PR DESCRIPTION
requested by PM in an attempt to cut down
on support requests related to expired
tokens, particularly for individuals using
shared mailboxes.