### PR TITLE
amend token time limit warning

### DIFF
--- a/app/views/sessions/_login_page.html.haml
+++ b/app/views/sessions/_login_page.html.haml
@@ -12,10 +12,10 @@
 
     %p.lede
       - if @unauthorised_login
-        - t('.intro_unauthorised').each_line do |line|
+        - t('.intro_unauthorised', ttl: distance_of_time_in_words(Token.ttl)).each_line do |line|
           = line
       -else
-        - t('.intro').each_line do |line|
+        - t('.intro', ttl: distance_of_time_in_words(Token.ttl)).each_line do |line|
           = line
 
 - if feature_enabled?('token_auth')

--- a/app/views/tokens/create.html.haml
+++ b/app/views/tokens/create.html.haml
@@ -7,7 +7,7 @@
       = t('tokens.create.body_intro')
     - if @unauthorised_login
       %p
-        = t('tokens.create.body_unauthorised')
+        = t('tokens.create.body_ttl_warning', ttl: distance_of_time_in_words(Token.ttl))
     %p
       = t('tokens.create.body_informative_html')
     %p

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,10 +43,10 @@ en:
       heading: Request link to access People Finder
       heading_unauthorised: Log in to edit People Finder
       intro: |
-        We will email you a secure link so you can log in to People Finder and create or edit profiles. The link will be active for 3 hours.
+        We will email you a secure link so you can log in to People Finder and create or edit profiles. The link will be active for %{ttl}.
       intro_unauthorised: |
         For security reasons, you have to be logged in to People Finder to make any changes.
-        We will email you a secure link so you can log in. This link will be active for 3 hours.
+        We will email you a secure link so you can log in. This link will be active for %{ttl}.
       heading_google: Got a government Google account?
       body_google:
         If you have a Google account ending in gov.uk, you can log in now.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,7 +99,7 @@ en:
     create:
       title: Link sent — check your email
       body_intro: We’re just emailing you a link to access People Finder. This can take up to 5 minutes.
-      body_unauthorised: When it arrives, click on the link (which is active for 3 hours). This will log you in to People Finder and enable you to make any changes.
+      body_ttl_warning: "When it arrives, click on the link (which is active for %{ttl}). This will log you in to People Finder and enable you to make any changes."
       body_informative_html: Please check your inbox for this email from <a href="mailto:people-finder-support@digital.justice.gov.uk">people-finder-support@digital.justice.gov.uk</a>.
       body_dont_panic: If you can’t find it, check your junk folder and add our address to your safe list.
       token_auth_disabled: "Sorry, the alternate login method is not availabe. Please login using your Google account."

--- a/spec/features/login_page_spec.rb
+++ b/spec/features/login_page_spec.rb
@@ -40,7 +40,7 @@ feature 'Login page' do
       login_page.request_button.click
 
       expect(token_created_page).to be_displayed
-      expect(token_created_page.info).to have_text('When it arrives, click on the link (which is active for 3 hours). This will log you in to People Finder and enable you to make any changes.')
+      expect(token_created_page.info).to have_text('When it arrives, click on the link (which is active for 1 day). This will log you in to People Finder and enable you to make any changes.')
     end
   end
 end

--- a/spec/features/token_authentication_spec.rb
+++ b/spec/features/token_authentication_spec.rb
@@ -18,6 +18,13 @@ feature 'Token Authentication' do
     ActionMailer::Base.deliveries = []
   end
 
+  scenario 'trying to log in with a valid email address' do
+    visit '/'
+    fill_in 'token_user_email', with: 'valid.email@digital.justice.gov.uk'
+    expect { click_button 'Request link' }.to change { ActionMailer::Base.deliveries.count }
+    expect(page).to have_text('When it arrives, click on the link (which is active for 1 day)')
+  end
+
   scenario 'trying to log in with an invalid email address' do
     visit '/'
     fill_in 'token_user_email', with: 'Bob'
@@ -122,11 +129,11 @@ feature 'Token Authentication' do
     end
   end
 
-  scenario "requesting token more than once within 3 hours sends same token url in email" do
+  scenario "requesting token more than once within 24 hours sends same token url in email" do
     create(:person, given_name: 'Bob', surname: 'Smith', email: 'test.user@digital.justice.gov.uk')
 
     first_token_url = nil
-    Timecop.freeze(Time.now - (2.hours + 59.minutes)) do
+    Timecop.freeze(Time.now - (23.hours + 59.minutes)) do
       visit '/'
       fill_in 'token_user_email', with: 'test.user@digital.justice.gov.uk'
       expect { click_button 'Request link' }.to change { ActionMailer::Base.deliveries.count }.by(1)
@@ -143,7 +150,7 @@ feature 'Token Authentication' do
     expect(page).to have_text('Signed in as Bob Smith')
   end
 
-  scenario 'requesting token a second time after 3 hours sends different token url in email' do
+  scenario 'requesting token a second time after 24 hours sends different token url in email' do
     first_token_url = nil
     Timecop.freeze(Time.now - 24.hours) do
       visit '/'


### PR DESCRIPTION
**What**
Change token sent page content to reflect new token expiry limit

**Why**
The TTL was changed but the time limit warning content was hardcoded
with no tests. This PR makes it dynamic and adds a test.