### PR TITLE
Photo upload error message fix

### DIFF
--- a/app/assets/javascripts/peoplefinder/photo_upload.js.erb
+++ b/app/assets/javascripts/peoplefinder/photo_upload.js.erb
@@ -109,7 +109,6 @@ var PhotoUpload = (function (){
           els.$photo_id.val(uploadData.id);
         }
 
-        els.$input.val('');
         PhotoUpload.showUploadButton(els, false);
         $iframe.remove();
       }


### PR DESCRIPTION
Why are we doing this:
Users have reported issues in IE11 with the photo uploader.
In IE11 any error message returned by the server is not visible.

What this PR does:
In ie11, when a file input is cleared, it will also fire the change event. This caused the error message to be hidden right after it was shown

@jsugarman  smashed it and found what the issue was

See:
https://github.com/facebook/react/issues/8793