### PR TITLE
Monkey patch escape JavaScript method to prevent XSS vulnerability

### DIFF
--- a/config/initializers/action_view_patch.rb
+++ b/config/initializers/action_view_patch.rb
@@ -3,26 +3,23 @@
 # Monkey patch escape JavaScript method to prevent XSS vulnerability
 # https://github.com/ministryofjustice/peoplefinder/network/alert/Gemfile.lock/actionview/open
 
-ActionView::Helpers::JavaScriptHelper::JS_ESCAPE_MAP.merge!(
-  {
-    "`" => "\\`",
-    "$" => "\\$"
-  }
-)
-
+ActionView::Helpers::JavaScriptHelper::JS_ESCAPE_MAP['`'] = '\\`'
+ActionView::Helpers::JavaScriptHelper::JS_ESCAPE_MAP['$'] = '\\$'
+# rubocop:disable Rails/OutputSafety
 module ActionView::Helpers::JavaScriptHelper
   alias old_ej escape_javascript
   alias old_j j
 
   def escape_javascript(javascript)
     javascript = javascript.to_s
-    if javascript.empty?
-      result = ""
-    else
-      result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u, JS_ESCAPE_MAP)
-    end
+    result = if javascript.empty?
+               ''
+             else
+               javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u, JS_ESCAPE_MAP)
+             end
     javascript.html_safe? ? result.html_safe : result
   end
 
   alias j escape_javascript
 end
+# rubocop:enable Rails/OutputSafety

--- a/config/initializers/action_view_patch.rb
+++ b/config/initializers/action_view_patch.rb
@@ -1,0 +1,28 @@
+# TO-DO https://dsdmoj.atlassian.net/browse/CT-2832
+# remove this file after update to Rails 5.2
+# Monkey patch escape JavaScript method to prevent XSS vulnerability
+# https://github.com/ministryofjustice/peoplefinder/network/alert/Gemfile.lock/actionview/open
+
+ActionView::Helpers::JavaScriptHelper::JS_ESCAPE_MAP.merge!(
+  {
+    "`" => "\\`",
+    "$" => "\\$"
+  }
+)
+
+module ActionView::Helpers::JavaScriptHelper
+  alias old_ej escape_javascript
+  alias old_j j
+
+  def escape_javascript(javascript)
+    javascript = javascript.to_s
+    if javascript.empty?
+      result = ""
+    else
+      result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u, JS_ESCAPE_MAP)
+    end
+    javascript.html_safe? ? result.html_safe : result
+  end
+
+  alias j escape_javascript
+end


### PR DESCRIPTION
"There is a possible XSS vulnerability in ActionView's JavaScript literal escape helpers. Views that use the j or escape_javascript methods may be susceptible to XSS attacks.

For those that can't upgrade, the following monkey patch may be used
See GHSA-65cv-r6x7-79hv"