### PR TITLE
CT-2940 Remove deprecated k8s apis june 2020

### DIFF
--- a/config/kubernetes/demo/deployment.yaml
+++ b/config/kubernetes/demo/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: peoplefinder

--- a/config/kubernetes/demo/ingress.yaml
+++ b/config/kubernetes/demo/ingress.yaml
@@ -1,11 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: peoplefinder-ingress
   namespace: peoplefinder-demo
 spec:
   tls:
-    - hosts: 
+    - hosts:
       - demo.peoplefinder.service.gov.uk
       secretName: peoplefinder-certificate
   rules:

--- a/config/kubernetes/development/deployment.yaml
+++ b/config/kubernetes/development/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: peoplefinder

--- a/config/kubernetes/development/ingress.yaml
+++ b/config/kubernetes/development/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: peoplefinder-ingress

--- a/config/kubernetes/production/deployment.yaml
+++ b/config/kubernetes/production/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: peoplefinder

--- a/config/kubernetes/production/ingress.yaml
+++ b/config/kubernetes/production/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: peoplefinder-ingress

--- a/config/kubernetes/staging/deployment.yaml
+++ b/config/kubernetes/staging/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: peoplefinder

--- a/config/kubernetes/staging/ingress.yaml
+++ b/config/kubernetes/staging/ingress.yaml
@@ -1,11 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: peoplefinder-ingress
   namespace: peoplefinder-staging
 spec:
   tls:
-    - hosts: 
+    - hosts:
       - staging.peoplefinder.service.gov.uk
       secretName: peoplefinder-certificate
   rules:


### PR DESCRIPTION
## Description
Prepare for Kubernetes upgrade to 1.16

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2940 (task)
https://dsdmoj.atlassian.net/browse/CT-2890 (ticket)


### Deployment
Need to apply Ingress and Deployment files at the very least. Might be best to full deploy anyway.

### Manual testing instructions
First deploy dev / staging etc, and see if it works. Then prod. And then...
Check if the application still works on all namespaces after CP upgrade the week commencing API on 12th July.