### PR TITLE
Reduce replicas down to 1 for non-prod environments

### DIFF
--- a/config/kubernetes/demo/deployment.yaml
+++ b/config/kubernetes/demo/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: peoplefinder
 spec:
-  replicas: 2
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/config/kubernetes/staging/deployment.yaml
+++ b/config/kubernetes/staging/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: peoplefinder
 spec:
-  replicas: 2
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
For demo, dev and staging we only need 1 Kubernetes webserver pod, as it's non-critical env - 