### PR TITLE
CT-3087 Add publicguardian.gov.uk to permitted domains

### DIFF
--- a/db/seeds/data/permitted_domains.yml
+++ b/db/seeds/data/permitted_domains.yml
@@ -34,6 +34,7 @@
 - ppo.gsi.gov.uk
 - probation.gsi.gov.uk
 - publicguardian.gsi.gov.uk
+- publicguardian.gov.uk
 - sentencingcouncil.gov.uk
 - sentencingcouncil.gsi.gov.uk
 - yjb.gsi.gov.uk


### PR DESCRIPTION
Add “@publicguardian.gov.uk” to the existing approved list of email domains.

OPG staff now have gov.uk email addresses (not gsi) but the people finder will not allow the email addresses to be updated. 

Deployment: run `rake db:seed` on the namespace to update the list of permitted domains
Testing - verify this task is non-destructive and makes no other changes
