### PR TITLE
Enable save button on profile picture upload

### DIFF
--- a/app/assets/javascripts/peoplefinder/photo_upload.js.erb
+++ b/app/assets/javascripts/peoplefinder/photo_upload.js.erb
@@ -199,6 +199,7 @@ var PhotoUpload = (function (){
       PhotoUpload.setState(els, 'cropped');
 
       $('.save-cancel-actions input').show();
+      $('.save-cancel-actions input').prop('disabled', false);
     },
 
     cropAgain: function ( event ){


### PR DESCRIPTION
Fixes bug whereby uploaded profile photos were not able to save after upload/cropping as the save button appears as disabled.

The issue is that the button was disabled (greyed out) as in this screen cap:
<img width="978" alt="Screenshot 2020-09-22 at 15 58 23" src="https://user-images.githubusercontent.com/13377553/93899834-a0e40180-fcec-11ea-86f2-4c2a16e1e2dd.png">


**To test:**
- run the app locally 
- find a profile
- click `edit this profile` > `change this photo` > `choose file`
- upload the profile pic you want
- crop the photo and click `crop photo`
- click save (**Note this should no longer be greyed out**)
- the profile photo should now reflect your uploaded photo.