### PR TITLE
CT-3206 Switch probe endpoints to stop cluster dropping all pods

### DIFF
--- a/config/kubernetes/demo/deployment.yaml
+++ b/config/kubernetes/demo/deployment.yaml
@@ -91,7 +91,7 @@ spec:
                 name: environment-variables
           readinessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -102,7 +102,7 @@ spec:
               periodSeconds: 60
           livenessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto

--- a/config/kubernetes/development/deployment.yaml
+++ b/config/kubernetes/development/deployment.yaml
@@ -91,7 +91,7 @@ spec:
                 name: environment-variables
           readinessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -102,7 +102,7 @@ spec:
               periodSeconds: 60
           livenessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto

--- a/config/kubernetes/production/deployment.yaml
+++ b/config/kubernetes/production/deployment.yaml
@@ -91,7 +91,7 @@ spec:
                 name: environment-variables
           readinessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -102,7 +102,7 @@ spec:
               periodSeconds: 60
           livenessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto

--- a/config/kubernetes/staging/deployment.yaml
+++ b/config/kubernetes/staging/deployment.yaml
@@ -91,7 +91,7 @@ spec:
                 name: environment-variables
           readinessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -102,7 +102,7 @@ spec:
               periodSeconds: 60
           livenessProbe:
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
               httpHeaders:
                 - name: X-Forwarded-Proto

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
+
+## Self-review checklist
+<!-- Action these things before requesting reviews -->
+* [ ] (1) Quick stakeholder demo done OR
+* [ ] (2) ...bug with before and after screenshots
+* [ ] (3) Tests passing
+* [ ] (4) Branch ready to be merged (not work in progress)
+* [ ] (5) No superfluous changes in diff
+* [ ] (6) No TODO's without new ticket numbers
+* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
+
+### Screenshots
+<!-- Screenshots of the new changes if appropriate -->
+
+### Related JIRA tickets
+<!-- A link or list of links to relevant issues in Jira -->
+
+### Deployment
+<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
+
+### Manual testing instructions
+<!-- Step-by-step instructions for the reviewer to manually test the changes -->


### PR DESCRIPTION
## Description
Because we use the same endpoint /healthcheck for both pingdom and our liveness probes, it prevents us from viewing the error message when there is an outage, as it removes all our pods from the service. It looks like this is an antipattern. Poornima suggests we follow the practice of using /ping for the liveness and readiness probes (as CCCD does), and reserve healthcheck for Pingdom.

When outages appear we should be able to get information more directly from the app because the pods will still be reachable by http

ALSO Added PR template :) 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3206

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
