### PR TITLE
CT-3138 Fix workflow for Circleci demo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,9 +367,13 @@ workflows:
       - deploy_master_to_dev:
           requires:
             - build_master_and_push_to_ecr
+      - deploy_master_to_demo_approval:
+          type: approval
+          requires:
+            - build_master_and_push_to_ecr      
       - deploy_master_to_demo:
           requires:
-            - deploy_master_to_dev            
+            - deploy_master_to_demo_approval           
       - deploy_master_to_staging_approval:
           type: approval
           requires:


### PR DESCRIPTION
## Description
Deploy master to demo was being done automatically, we rather want it to deploy to demo on approval with no dependency on dev.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3138

### Deployment
requires deployment to be tested after merging on circleci

### Manual testing instructions
merge this, you should then it should deploy to dev automatically, but demo should be optional, and staging should depend on dev, and production on staging (plus approvals)
