### PR TITLE
CT-3301 Increase no of master images to keep

### DIFF
--- a/config/kubernetes/production/cronjob-delete-old-ecr-images.yaml
+++ b/config/kubernetes/production/cronjob-delete-old-ecr-images.yaml
@@ -28,7 +28,7 @@ spec:
                   set -o pipefail
 
                   repo=peoplefinder/peoplefinder-ecr
-                  total_master_images_to_keep=10
+                  total_master_images_to_keep=25
                   days_to_keep_non_master_images=14
                   region=eu-west-2
 


### PR DESCRIPTION
## Description
Increase number of left over master images to 25 for safety against losing the one on production (if 10 master images are built, that are not on prod, then the prod one would be deleted).- so reduce risk - make it 25

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3301

### Deployment
n/a

### Manual testing instructions
n/a - once on production, we should gradually see master images increase to 25. this can be tested by querying the images using this command: aws ecr list-images --region eu-west-2 --repository-name [repo name]  --query 'imageIds[*]' --output json
