### PR TITLE
CT-3319 Add criminalappealoffice.justice.gov.uk to permitted domains

### DIFF
--- a/db/seeds/data/permitted_domains.yml
+++ b/db/seeds/data/permitted_domains.yml
@@ -3,6 +3,7 @@
 - cica.gov.uk
 - cica.gsi.gov.uk
 - cjs.gsi.gov.uk
+- criminalappealoffice.justice.gov.uk
 - crowncommercial.gov.uk
 - cshrcasework.justice.gov.uk
 - digital.justice.gov.uk


### PR DESCRIPTION
## Description
Add criminalappealoffice.justice.gov.uk to allowed domains for peoplefinder

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
Before
![image](https://user-images.githubusercontent.com/22935203/103280822-43391280-49c9-11eb-9ba3-1dce41220930.png)
after:
![image](https://user-images.githubusercontent.com/22935203/103290213-e6495680-49e0-11eb-8d54-9d1b147bf491.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3319

### Deployment
NOTE: After deploying, login to webapp container:
```
rails c
PermittedDomain.create(domain: 'criminalappealoffice.justice.gov.uk')
```

### Manual testing instructions
Try requesting a token for this domain, criminalappealoffice.justice.gov.uk shouldn't get error - then once on production check with the reporter - https://dsdmoj.atlassian.net/browse/CT-3319 