### PR TITLE
CT-3391 Add ppo.gov.uk to allowed domains

### DIFF
--- a/db/seeds/data/permitted_domains.yml
+++ b/db/seeds/data/permitted_domains.yml
@@ -32,6 +32,7 @@
 - noms.gsi.gov.uk
 - offsol.gsi.gov.uk
 - paroleboard.gsi.gov.uk
+- ppo.gov.uk
 - ppo.gsi.gov.uk
 - probation.gsi.gov.uk
 - publicguardian.gsi.gov.uk


### PR DESCRIPTION
## Description
Add ppo.gov.uk domain into permitted domains list

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots (the good one is not a result of the code, rather adding the domain manually through the console. The code only activates if you reset the database e.g. dbsetup. But should be in sync regardless.

Before:

![image](https://user-images.githubusercontent.com/22935203/105508391-38218b80-5cc4-11eb-9b10-d33e53de1db2.png)

After: 
![image](https://user-images.githubusercontent.com/22935203/105508764-ad8d5c00-5cc4-11eb-9bf8-4cdb13cb312a.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3391

### Deployment
Requires manually adding domain through console for each environment

### Manual testing instructions
Try entering ppo.gov.uk email into Email check page on peoplefinder.
