### PR TITLE
CT-3424 Autoloading has changed - require module from /lib directory directly

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -74,6 +74,8 @@ module Peoplefinder
     # NOTE: may need to eager load paths instead if lib code is commonly called
     config.autoload_paths << Rails.root.join('lib')
 
+    require Rails.root.join('lib', 'csv_publisher', 'user_behavior_report.rb')
+
     config.active_record.sqlite3.represent_boolean_as_integer = true
   end
 


### PR DESCRIPTION
## Description
Generate user behaviour report in production mode failed with
NameError (uninitialized constant Admin::ManagementController::CsvPublisher):
 app/controllers/admin/management_controller.rb:7:in `generate_user_behavior_report'

Rails autoloader is expecting files in lib to have the right naming conventions mapping file name to module and class names. The class gets included when app runs in development mode (i.e. tests pass and app works locally) but not when running in production mode, causing a crash when trying to generate the user behaviour report on K8s environments. Tried eager loading all the classes in /lib as described in some sources, but the eager load path is a frozen variable now; also, this the behaviour that Rails core team [decided to deprecate](https://github.com/rails/rails/issues/13142#issuecomment-74586224) with the changes in autoloading, so decided to just require the specific module. 
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Clicking Generate here used to 500
![image](https://user-images.githubusercontent.com/1161161/107361701-b3aa7780-6acf-11eb-9a34-64f3cc6629be.png)

![image](https://user-images.githubusercontent.com/1161161/107361670-a55c5b80-6acf-11eb-982f-e59a0ccda448.png)

Now it generates the CSV
![image](https://user-images.githubusercontent.com/1161161/107361849-e5bbd980-6acf-11eb-9e7c-1814ae80cc51.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3424

### Deployment
n/a

### Manual testing instructions
As a "super admin" user, go to the Manage tab on k8s environment (you need to be on the old VPN rather than global protect or you get a 404) and generate the user behaviour report. This was going to an error screen and should now generate the report successfully. 