### PR TITLE
CT-3088 Amend db check method

### DIFF
--- a/app/models/health_check/database.rb
+++ b/app/models/health_check/database.rb
@@ -13,7 +13,7 @@ module HealthCheck
 
     def available?
       begin
-        result = ActiveRecord::Base.connected?
+        result = ActiveRecord::Base.connection.active?
         log_error unless result == true
       rescue StandardError => e
         log_unknown_error(e)

--- a/spec/features/application_health_check_spec.rb
+++ b/spec/features/application_health_check_spec.rb
@@ -15,7 +15,7 @@ describe 'healthcheck.json' do
   end
 
   it 'when there are component errors' do
-    allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+    allow(ActiveRecord::Base.connection).to receive(:active?).and_return(false)
 
     visit '/healthcheck.json'
 

--- a/spec/models/health_check/database_spec.rb
+++ b/spec/models/health_check/database_spec.rb
@@ -9,7 +9,7 @@ describe HealthCheck::Database do
     end
 
     it 'returns false if the database is not available' do
-      allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+      allow(ActiveRecord::Base.connection).to receive(:active?).and_return(false)
       expect(subject).not_to be_available
     end
   end
@@ -29,14 +29,14 @@ describe HealthCheck::Database do
 
   describe '#errors' do
     it 'returns the exception messages if there is an error accessing the database' do
-      allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+      allow(ActiveRecord::Base.connection).to receive(:active?).and_return(false)
       subject.available?
 
       expect(subject.errors.first).to match(/could not connect with .*?_test/)
     end
 
     it 'returns an error an backtrace for errors not specific to a component' do
-      allow(ActiveRecord::Base).to receive(:connected?).and_raise(StandardError)
+      allow(ActiveRecord::Base.connection).to receive(:active?).and_raise(StandardError)
       subject.available?
 
       expect(subject.errors.first).to match(/Error: StandardError\nDetails/)


### PR DESCRIPTION
## Description
We saw consistent "outages" reported by Pingdom following the Rails 5.0->5.2 update; on investigation these seemed to be spurious, and only happened when the site was inactive - overnight or over the weekend. 

This PR changes slightly the ActiveRecord method used to see if the connection is available. 

I think the old method was checking whether ActiveRecord is ephemerally holding an open connection, which gets released if it isn't being used, and so isn't a reliable way to check whether ActiveRecord _can_ connect. The new method seems to act more like it seems to have done in the older version of Rails and is the method used in CTS which doesn't suffer from the same intermittent "failures".  

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3088

### Deployment
n/a
### Manual testing instructions
None. We just want to keep an eye on Pingdom uptime reported by the /healthcheck endpoint