### PR TITLE
CT-3449 fix govuk gem

### DIFF
--- a/config/kubernetes/demo/deployment.yaml
+++ b/config/kubernetes/demo/deployment.yaml
@@ -27,6 +27,10 @@ spec:
           env:
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
+            - name: GOVUK_APP_DOMAIN
+              value: 'peoplefinder.service.gov.uk'
+            - name: GOVUK_WEBSITE_ROOT
+              value: 'demo'
             - name: MOJ_PF_ES_URL
               value: 'http://aws-es-proxy-service:9200'
             - name: SECRET_KEY_BASE
@@ -123,6 +127,10 @@ spec:
           command: ["./run.sh"]
           args: ["worker"]
           env:
+            - name: GOVUK_APP_DOMAIN
+              value: 'peoplefinder.service.gov.uk'
+            - name: GOVUK_WEBSITE_ROOT
+              value: 'demo'
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:

--- a/config/kubernetes/development/deployment.yaml
+++ b/config/kubernetes/development/deployment.yaml
@@ -27,6 +27,8 @@ spec:
           env:
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
+            - name: GOVUK_APP_DOMAIN
+              value: 'development.peoplefinder.service.gov.uk'
             - name: MOJ_PF_ES_URL
               value: 'http://aws-es-proxy-service:9200'
             - name: SECRET_KEY_BASE
@@ -123,6 +125,8 @@ spec:
           command: ["./run.sh"]
           args: ["worker"]
           env:
+            - name: GOVUK_APP_DOMAIN
+              value: 'development.peoplefinder.service.gov.uk'
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:

--- a/config/kubernetes/development/deployment.yaml
+++ b/config/kubernetes/development/deployment.yaml
@@ -28,7 +28,9 @@ spec:
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
             - name: GOVUK_APP_DOMAIN
-              value: 'development.peoplefinder.service.gov.uk'
+              value: 'peoplefinder.service.gov.uk'
+            - name: GOVUK_WEBSITE_ROOT
+              value: 'development'
             - name: MOJ_PF_ES_URL
               value: 'http://aws-es-proxy-service:9200'
             - name: SECRET_KEY_BASE
@@ -126,7 +128,9 @@ spec:
           args: ["worker"]
           env:
             - name: GOVUK_APP_DOMAIN
-              value: 'development.peoplefinder.service.gov.uk'
+              value: 'peoplefinder.service.gov.uk'
+            - name: GOVUK_WEBSITE_ROOT
+              value: 'development'
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:

--- a/config/kubernetes/production/deployment.yaml
+++ b/config/kubernetes/production/deployment.yaml
@@ -27,6 +27,10 @@ spec:
           env:
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
+            - name: GOVUK_APP_DOMAIN
+              value: 'peoplefinder.service.gov.uk'
+            - name: GOVUK_WEBSITE_ROOT
+              value: 'www'
             - name: MOJ_PF_ES_URL
               value: 'http://aws-es-proxy-service:9200'
             - name: SECRET_KEY_BASE
@@ -123,6 +127,10 @@ spec:
           command: ["./run.sh"]
           args: ["worker"]
           env:
+            - name: GOVUK_APP_DOMAIN
+              value: 'peoplefinder.service.gov.uk'
+            - name: GOVUK_WEBSITE_ROOT
+              value: 'www'
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:

--- a/config/kubernetes/staging/deployment.yaml
+++ b/config/kubernetes/staging/deployment.yaml
@@ -27,6 +27,10 @@ spec:
           env:
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
+            - name: GOVUK_APP_DOMAIN
+              value: 'peoplefinder.service.gov.uk'
+            - name: GOVUK_WEBSITE_ROOT
+              value: 'staging'
             - name: MOJ_PF_ES_URL
               value: 'http://aws-es-proxy-service:9200'
             - name: SECRET_KEY_BASE
@@ -123,6 +127,10 @@ spec:
           command: ["./run.sh"]
           args: ["worker"]
           env:
+            - name: GOVUK_APP_DOMAIN
+              value: 'peoplefinder.service.gov.uk'
+            - name: GOVUK_WEBSITE_ROOT
+              value: 'staging'
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Description
We use the govspeak gem which has a bunch of gov_uk dependencies, including govuk_publishing_components and a thing  named plek (also gov uk) - this gem requires two env_vars to be set in production, which was causing deployments to fail because they were not set and the rails server was refusing to boot when the container was being launched in kubernetes. 

```iananderson@L0419 ~/dev/moj/peoplefinder CT-3449-fix-govuk-gem $ klog peoplefinder-development webapp
running app server - unicorn
I, [2021-02-24T15:56:25.145391 #6]  INFO -- : Refreshing Gem list
Plek::NoConfigurationError: Expected GOVUK_WEBSITE_ROOT to be set. Perhaps you should run your task through govuk_setenv <appname>?
  /usr/local/bundle/gems/plek-4.0.0/lib/plek.rb:166:in `env_var_or_dev_fallback'
  /usr/local/bundle/gems/plek-4.0.0/lib/plek.rb:114:in `website_root'
  /usr/local/bundle/gems/govuk_publishing_components-24.1.0/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb:8:in `<class:PotentialSearchActionSchema>'
  /usr/local/bundle/gems/govuk_publishing_components-24.1.0/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb:5:in `<module:Presenters>'
  /usr/local/bundle/gems/govuk_publishing_components-24.1.0/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb:4:in `<module:GovukPublishingComponents>'
  /usr/local/bundle/gems/govuk_publishing_components-24.1.0/lib/govuk_publishing_components/presenters/machine_readable/potential_search_action_schema.rb:3:in `<top (required)>'
  /usr/local/bundle/gems/activesupport-5.2.4.4/lib/active_support/dependencies.rb:291:in `require'
```

This PR adds the two env vars and sets them to (hopefully) harmless values. 

I'm a bit worried because govuk_publishing_components includes a bunch of automated setup for Sentry (which is already set up and working) and other monitoring services we don't use on these services. I'm hoping there aren't any side effects from these gems; but all tests pass and the app seems to be coming up great in kubernetes now. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3449

### Deployment
n/a

### Manual testing instructions
App starts up on deployment to Kubernetes
