### PR TITLE
Update group description word limit

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -19,7 +19,7 @@ class Group < ApplicationRecord
   include Concerns::Hierarchical
   include Concerns::Placeholder
 
-  MAX_DESCRIPTION = 1000
+  MAX_DESCRIPTION = 2000
 
   has_paper_trail versions: { class_name: 'Version' },
                   ignore: [:updated_at, :created_at, :slug, :id,

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -6,7 +6,7 @@
 
   .grid-row
     .column-two-thirds
-      = f.text_area :description, placeholder: t('.placeholder'), rows: 10, "data-limit": 1000
+      = f.text_area :description, placeholder: t('.placeholder'), rows: 10, "data-limit": 2000
 
     .column-one-third
       .form-group.help-area

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Group, type: :model do
   include PermittedDomainHelper
 
   it { should have_many(:leaders) }
-  it { should validate_length_of(:description).is_at_most(1000) }
+  it { should validate_length_of(:description).is_at_most(2000) }
 
   it "gives first orphaned groups as department" do
     parent = create(:department)


### PR DESCRIPTION
## Description

Ups the word limit for team descriptions. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-3518](https://dsdmoj.atlassian.net/browse/CT-3518)

### Manual testing instructions
1. Log in locally
2. Create a new team.
3. Description input in form should read "Maximum 2000 characters, including spaces. (2000 remaining)"
4. Add 2000 chars:
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam efficitur lectus nisl, sit amet congue nisl tincidunt vel. Donec in ultrices nulla. Nullam sodales tortor sit amet mauris accumsan, ac porttitor felis ultrices. Nulla suscipit egestas sapien et sodales. Proin eleifend velit in libero molestie tristique. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nunc suscipit est eget lectus rhoncus consequat. Maecenas id condimentum erat, a faucibus sapien. Nullam tempus enim eu sodales elementum. Morbi sit amet dictum mi.
Etiam vestibulum velit nisi, eu sollicitudin felis posuere eu. Nunc vitae felis a nunc fermentum facilisis in a est. Suspendisse dictum nisl vitae massa ultrices, ac faucibus dui sollicitudin. Nunc convallis a nunc nec condimentum. Nunc ullamcorper rhoncus neque, et tempus massa egestas et. Maecenas sagittis justo vitae ultrices vehicula. Sed laoreet fermentum aliquam. Donec consequat nisl metus, ut hendrerit turpis congue eu. Phasellus nec nunc vel augue sagittis consequat id nec purus. In porttitor tristique quam, nec scelerisque mi tristique non. Mauris feugiat efficitur ipsum, vel luctus nisl posuere at. Curabitur eget semper nulla. Nunc non nulla tellus. Etiam ut eleifend dui, nec placerat lacus. Vivamus ultricies imperdiet malesuada.
Sed quis eleifend lectus, id volutpat lorem. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec et rhoncus velit. Ut interdum id leo a tristique. Fusce mattis gravida risus. Nam eu tempor turpis. Praesent elementum at massa ac maximus.
Pellentesque at suscipit elit, eget egestas leo. Pellentesque ultrices gravida diam, id iaculis velit sollicitudin ac. Donec nec velit eu neque ultrices viverra at at magna. Maecenas vestibulum nisi consectetur, faucibus dolor at, vehicula augue. Proin molestie vestibulum magna, vel mollis massa dictum vitae. nulla accumsan egestas vitae a tellus. Quisque accumsan luctus nunc sed hendrert
```
5. Form should submit
6. Create another team
7. Add over 2000 chars - form should error.
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam efficitur lectus nisl, sit amet congue nisl tincidunt vel. Donec in ultrices nulla. Nullam sodales tortor sit amet mauris accumsan, ac porttitor felis ultrices. Nulla suscipit egestas sapien et sodales. Proin eleifend velit in libero molestie tristique. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nunc suscipit est eget lectus rhoncus consequat. Maecenas id condimentum erat, a faucibus sapien. Nullam tempus enim eu sodales elementum. Morbi sit amet dictum mi.
Etiam vestibulum velit nisi, eu sollicitudin felis posuere eu. Nunc vitae felis a nunc fermentum facilisis in a est. Suspendisse dictum nisl vitae massa ultrices, ac faucibus dui sollicitudin. Nunc convallis a nunc nec condimentum. Nunc ullamcorper rhoncus neque, et tempus massa egestas et. Maecenas sagittis justo vitae ultrices vehicula. Sed laoreet fermentum aliquam. Donec consequat nisl metus, ut hendrerit turpis congue eu. Phasellus nec nunc vel augue sagittis consequat id nec purus. In porttitor tristique quam, nec scelerisque mi tristique non. Mauris feugiat efficitur ipsum, vel luctus nisl posuere at. Curabitur eget semper nulla. Nunc non nulla tellus. Etiam ut eleifend dui, nec placerat lacus. Vivamus ultricies imperdiet malesuada.
Sed quis eleifend lectus, id volutpat lorem. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec et rhoncus velit. Ut interdum id leo a tristique. Fusce mattis gravida risus. Nam eu tempor turpis. Praesent elementum at massa ac maximus.
Pellentesque at suscipit elit, eget egestas leo. Pellentesque ultrices gravida diam, id iaculis velit sollicitudin ac. Donec nec velit eu neque ultrices viverra at at magna. Maecenas vestibulum nisi consectetur, faucibus dolor at, vehicula augue. Proin molestie vestibulum magna, vel mollis massa dictum vitae. nulla accumsan egestas vitae a tellus. Quisque accumsan luctus nunc sed hendrert.
Vivamus ultricies imperdiet malesuada.
Sed quis eleifend lectus, id volutpat lorem. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec et rhoncus velit.
```
8. Check that form saves team okay.

