### PR TITLE
Pulls rack-protection from the sinatra repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'premailer-rails', '~> 1.9'
 gem 'prometheus-client'
 gem 'pundit', '~>2.1'
 gem 'puma'
-gem 'rack-protection', '>= 1.5.5'
 gem 'recipient_interceptor', '~> 0.1.2'
 gem 'sanitize', '~> 5.2.3'
 gem 'sass-rails', '~> 5.0.6'
@@ -57,6 +56,9 @@ gem 'carrierwave',
     git: 'https://github.com/carrierwaveuploader/carrierwave.git',
     tag: 'cc39842e44edcb6187b2d379a606ec48a6b5e4a8'
 
+github 'sinatra/sinatra' do
+  gem 'rack-protection'
+end
 group :assets do
   gem 'coffee-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,13 @@ GIT
     sentry-raven (3.0.0)
       faraday (>= 1.0)
 
+GIT
+  remote: https://github.com/sinatra/sinatra.git
+  revision: 0a50b5608d3ff4fda563cc3d3a600d581c57d8e0
+  specs:
+    rack-protection (2.1.0)
+      rack
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -362,8 +369,6 @@ GEM
     rack (2.2.3)
     rack-contrib (2.2.0)
       rack (~> 2.0)
-    rack-protection (2.0.8.1)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.6)
@@ -606,7 +611,7 @@ DEPENDENCIES
   pry-rails
   puma
   pundit (~> 2.1)
-  rack-protection (>= 1.5.5)
+  rack-protection!
   rails (~> 5.2.6)
   rails-controller-testing
   rb-fsevent


### PR DESCRIPTION
This gem has been merged into the sinatra project so updates are
supplied there rather than in the deprecated repo pointed at by the
regular gemfile declaration.

See: https://github.com/sinatra/rack-protection



## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
[CT-3643](https://dsdmoj.atlassian.net/browse/CT-3643)

