### PR TITLE
CT-3722 Add percent complete to UB report

### DIFF
--- a/app/controllers/admin/management_controller.rb
+++ b/app/controllers/admin/management_controller.rb
@@ -16,8 +16,7 @@ module Admin
     private
 
     def generate report_klass
-      report = serialize(report_klass)
-      GenerateReportJob.perform_later(report)
+      GenerateReportJob.perform_later(report_klass.to_s)
     end
 
     def download name:

--- a/app/jobs/generate_report_job.rb
+++ b/app/jobs/generate_report_job.rb
@@ -12,7 +12,7 @@ class GenerateReportJob < ApplicationJob
   end
 
   def max_run_time
-    10.minutes
+    20.minutes
   end
 
   def destroy_failed_jobs?

--- a/app/jobs/generate_report_job.rb
+++ b/app/jobs/generate_report_job.rb
@@ -3,7 +3,7 @@ class GenerateReportJob < ApplicationJob
   queue_as :generate_report
 
   def perform(report)
-    report = deserialize report
+    report = report.constantize
     report.publish!
   end
 
@@ -12,17 +12,11 @@ class GenerateReportJob < ApplicationJob
   end
 
   def max_run_time
-    20.minutes
+    10.minutes
   end
 
   def destroy_failed_jobs?
     true
-  end
-
-  private
-
-  def deserialize json
-    JSON.parse(json)['json_class'].constantize
   end
 
 end

--- a/app/queries/user_behavior_query.rb
+++ b/app/queries/user_behavior_query.rb
@@ -1,5 +1,7 @@
 class UserBehaviorQuery < BaseQuery
 
+  include Concerns::Completion
+
   DATE_STRING_FORMAT = '%d-%m-%Y'.freeze
 
   attr_reader :relation
@@ -25,7 +27,8 @@ class UserBehaviorQuery < BaseQuery
         team_role: rec.team_role,
         login_count: rec.login_count,
         last_login_at: rec.last_login_at&.strftime(DATE_STRING_FORMAT),
-        updates_count: rec.updates_count
+        updates_count: rec.updates_count,
+        percent_complete: self.class.average_completion_score(rec.id)
       }
     end
   end

--- a/app/queries/user_behavior_query.rb
+++ b/app/queries/user_behavior_query.rb
@@ -28,7 +28,7 @@ class UserBehaviorQuery < BaseQuery
         login_count: rec.login_count,
         last_login_at: rec.last_login_at&.strftime(DATE_STRING_FORMAT),
         updates_count: rec.updates_count,
-        percent_complete: self.class.average_completion_score(rec.id)
+        percent_complete: rec.completion_score
       }
     end
   end

--- a/app/queries/user_behavior_query.rb
+++ b/app/queries/user_behavior_query.rb
@@ -1,7 +1,5 @@
 class UserBehaviorQuery < BaseQuery
 
-  include Concerns::Completion
-
   DATE_STRING_FORMAT = '%d-%m-%Y'.freeze
 
   attr_reader :relation
@@ -18,19 +16,13 @@ class UserBehaviorQuery < BaseQuery
   end
 
   def data
-    call.map do |rec|
-      { id: rec.id,
-        full_name: rec.full_name,
-        address: rec.address, # can't use location as the name as this is a method on person model
-        team_name: rec.team_name,
-        ancestors: team_name_map(rec.ancestors),
-        team_role: rec.team_role,
-        login_count: rec.login_count,
-        last_login_at: rec.last_login_at&.strftime(DATE_STRING_FORMAT),
-        updates_count: rec.updates_count,
-        percent_complete: rec.completion_score
-      }
+    data = []
+    call.find_in_batches do |people|
+      people.each do |person|
+        data << map_data_hash(person)
+      end
     end
+    data
   end
 
   def team_mapping
@@ -50,6 +42,21 @@ class UserBehaviorQuery < BaseQuery
   end
 
   private
+
+  def map_data_hash(rec)
+    {
+      id: rec.id,
+      full_name: rec.full_name,
+      address: rec.address, # can't use location as the name as this is a method on person model
+      team_name: rec.team_name,
+      ancestors: team_name_map(rec.ancestors),
+      team_role: rec.team_role,
+      login_count: rec.login_count,
+      last_login_at: rec.last_login_at&.strftime(DATE_STRING_FORMAT),
+      updates_count: rec.updates_count,
+      percent_complete: rec.completion_score
+    }
+  end
 
   def joins_sql
     <<~SQL

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -8,4 +8,4 @@ Delayed::Worker.queue_attributes = {
 
 Delayed::Worker.max_attempts = 5
 Delayed::Worker.max_run_time = 1.hour
-Delayed::Worker.logger = Logger.new(Rails.root.join('log/delayed_job.log')) if Rails.env.development?
+Delayed::Worker.logger = Logger.new(Rails.root.join('log/delayed_job.log')) # if Rails.env.development?

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -8,4 +8,4 @@ Delayed::Worker.queue_attributes = {
 
 Delayed::Worker.max_attempts = 5
 Delayed::Worker.max_run_time = 1.hour
-Delayed::Worker.logger = Logger.new(Rails.root.join('log/delayed_job.log')) # if Rails.env.development?
+Delayed::Worker.logger = Logger.new(Rails.root.join('log/delayed_job.log')) if Rails.env.development?

--- a/spec/jobs/generate_report_job_spec.rb
+++ b/spec/jobs/generate_report_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe GenerateReportJob, type: :job do
   context 'when enqueued' do
     it "enqueues with appropriate config settings" do
       expect(job.queue_name).to eq 'generate_report'
-      expect(job.max_run_time).to eq 10.minutes
+      expect(job.max_run_time).to eq 20.minutes
       expect(job.max_attempts).to eq 3
       expect(job.destroy_failed_jobs?).to eq true
     end

--- a/spec/jobs/generate_report_job_spec.rb
+++ b/spec/jobs/generate_report_job_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 RSpec.describe GenerateReportJob, type: :job do
 
   let(:csv_report) { CsvPublisher::UserBehaviorReport }
-  let(:serialized_csv_report) do
-    {
-      'json_class' => csv_report.name
-    }.to_json
-  end
+  let(:serialized_csv_report) { csv_report.name }
 
   let(:perform_later) { described_class.perform_later(serialized_csv_report) }
   let(:perform_now) { described_class.perform_now(serialized_csv_report) }
@@ -16,7 +12,7 @@ RSpec.describe GenerateReportJob, type: :job do
   context 'when enqueued' do
     it "enqueues with appropriate config settings" do
       expect(job.queue_name).to eq 'generate_report'
-      expect(job.max_run_time).to eq 20.minutes
+      expect(job.max_run_time).to eq 10.minutes
       expect(job.max_attempts).to eq 3
       expect(job.destroy_failed_jobs?).to eq true
     end

--- a/spec/queries/user_behavior_query_spec.rb
+++ b/spec/queries/user_behavior_query_spec.rb
@@ -96,7 +96,8 @@ describe UserBehaviorQuery, versioning: true do
           ancestors: [moj.name, csg.name].join(' > '),
           login_count: 0,
           last_login_at: nil,
-          updates_count: 0
+          updates_count: 0,
+          percent_complete: person1.completion_score
         },
         {
           id: person1.id,
@@ -107,7 +108,8 @@ describe UserBehaviorQuery, versioning: true do
           ancestors: [moj.name, csg.name].join(' > '),
           login_count: 0,
           last_login_at: nil,
-          updates_count: 0
+          updates_count: 0,
+          percent_complete: person1.completion_score
         },
         {
           id: person1.id,
@@ -118,7 +120,8 @@ describe UserBehaviorQuery, versioning: true do
           ancestors: moj.name,
           login_count: 0,
           last_login_at: nil,
-          updates_count: 0
+          updates_count: 0,
+          percent_complete: person1.completion_score
         },
         {
           id: person2.id,
@@ -129,7 +132,8 @@ describe UserBehaviorQuery, versioning: true do
           ancestors: nil,
           login_count: 2,
           last_login_at: "22-05-2017",
-          updates_count: 0
+          updates_count: 0,
+          percent_complete: person2.completion_score
         },
         {
           id: person3.id,
@@ -140,7 +144,8 @@ describe UserBehaviorQuery, versioning: true do
           ancestors: nil,
           login_count: 3,
           last_login_at: "21-05-2016",
-          updates_count: 2
+          updates_count: 2,
+          percent_complete: person3.completion_score
         }
       ]
     end


### PR DESCRIPTION
## Description
Adds percent_complete column to the User Behaviour report

There were a few errors appearing with this which meant it took a while to solve

firstly, adding this adds a little bit more work to the query generation so  I had to batch the creation of the report with `find_in_batches` to stop using up all the RAM.  This allowed the reports to be generated manually but there were still errors on the various environments as the job to generate in the background was failing.

some errors over how we passed the constant report name to the generator meant that the worker was failing to to generate the report.

This was the case in `main` as well, so I know it was unrelated to my changes.

Its a hard one to debug as the code grabs the last report - so if there is one in the DB it will allow you to download it whether it has been refreshed or not!

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
[CT-3722](https://dsdmoj.atlassian.net/browse/CT-3722)

### Manual testing instructions

Note: you'll need to generate a new report first
admin > reports > UB report
