### PR TITLE
Update email address to correct one

### DIFF
--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -64,7 +64,7 @@
                     If you're unsure an email is from the MOJ:
                     %br/
                     • forward it to
-                    %a{href: "mailto:phishing@digital.justice.gov.uk", target: "_blank"} phishing@digital.justice.gov.uk
+                    %a{href: "mailto:security@justice.gov.uk", target: "_blank"} security@justice.gov.uk
                   %td{width: "20"}
                 %tr
                   %td{colspan: "3", height: "40", width: "600"}

--- a/app/views/layouts/email.text.erb
+++ b/app/views/layouts/email.text.erb
@@ -8,4 +8,4 @@ People Finder
 ------------------------------------------
 If you're unsure an email is from the MOJ:
 
-• forward it to phishing@digital.justice.gov.uk
+• forward it to security@justice.gov.uk


### PR DESCRIPTION
## Description
Emails from People Finder currently have a phishing@ email address in the footer for security help. Updating to security@ to mirror team processes. 
