### PR TITLE
CT-3763 Skips some validation if users don't have a team

### DIFF
--- a/app/services/person_update_notifier.rb
+++ b/app/services/person_update_notifier.rb
@@ -21,6 +21,7 @@ module PersonUpdateNotifier
     person.reload
     if send_update_reminder? person, within
       ReminderMailer.person_profile_update(person).deliver_later
+      person.skip_must_have_team = true
       person.update(last_reminder_email_at: Time.zone.now)
     end
   end


### PR DESCRIPTION
this allows their last_email_remider_at field to be updated

previously this wasn't happening, which meant some people receiving
emails everyday.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-3763](https://dsdmoj.atlassian.net/browse/CT-3763)


### Manual testing instructions
n/a
Comment out: https://github.com/ministryofjustice/peoplefinder/blob/ec4aa84a4357f824156ab62f17670218b08673d8/app/services/person_update_notifier.rb#L24 and you should see the new tests fail.