### PR TITLE
CT-4200 Remove report a problem from logged out pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew search elasticsearch
 The version of elasticsearch we use is 7.10.x
 
 ```cmd
-docker run --name elasticsearch  --publish 9200:9200 bitnami/elasticsearch:6.8.6-r1
+docker run --name elasticsearch  --publish 9200:9200 bitnami/elasticsearch:7.10.2
 ```
 
 Install remaining dependencies on Mac OSX:
@@ -235,10 +235,11 @@ Or, alternatively:
 rake peoplefinder:es:index_people
 ```
 
-Or you can create the index from the console:
+Or you can create the index from the console if the above rake commands fail:
 
-```
-Person.__elasticsearch__.create_index! index: Person.index_name, force: true`
+```ruby
+Elasticsearch::Client.new.index(index: Person.index_name, body: {})
+Person.__elasticsearch__.create_index! index: Person.index_name, force: true
 ```
 
 And populate it:
@@ -252,6 +253,10 @@ You can also delete the index:
 To run specs without Elasticsearch:
 
 `bundle exec rspec . --tag ~elastic`
+
+If your shell is Zsh, you have to escape `~` by using `\~`.
+
+**Note:** Unfortunately, at the moment there is no way to avoid having ES running locally, but you can use a docker container as mentioned above.
 
 ## Images
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Pundit
+  include Pundit::Authorization
   include FeatureHelper
 
   protect_from_forgery with: :exception

--- a/app/views/sessions/_login_page.html.haml
+++ b/app/views/sessions/_login_page.html.haml
@@ -12,11 +12,9 @@
 
     %p.lede
       - if @unauthorised_login
-        - t('.intro_unauthorised', ttl: distance_of_time_in_words(Token.ttl)).each_line do |line|
-          = line
-      -else
-        - t('.intro', ttl: distance_of_time_in_words(Token.ttl)).each_line do |line|
-          = line
+        = t('.intro_unauthorised', ttl: distance_of_time_in_words(Token.ttl))
+      - else
+        = t('.intro', ttl: distance_of_time_in_words(Token.ttl))
 
 - if feature_enabled?('token_auth')
   %h2.heading-medium
@@ -25,4 +23,8 @@
   = form_for (@token ||= Token.new) do |f|
     = f.text_field :user_email
     = f.hidden_field(:unauthorised_login, value: @unauthorised_login)
-    = f.submit t('.log_in_email'), { class: 'button', data: token_request_analytics_attributes }
+    .form-group
+      = f.submit t('.log_in_email'), { class: 'button', data: token_request_analytics_attributes }
+
+  %p
+    = t('.contact_support_html')

--- a/app/views/shared/_feedback_form.html.haml
+++ b/app/views/shared/_feedback_form.html.haml
@@ -1,3 +1,5 @@
+- return unless logged_in_regular?
+
 #feedback_container
   %a{href: '#feedback', id: 'feedbackToggle'}
     Report a problem
@@ -7,9 +9,7 @@
 
     = f.text_area :problem
 
-    - unless logged_in_regular?
-      = f.text_field :person_email
-
     = f.hidden_field :browser
 
-    = f.submit class: 'button'
+    .form-group
+      = f.submit class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,9 @@ en:
       heading_other: Enter your MOJ email address
       log_in_google: Log in
       log_in_email: Request link
+      contact_support_html: |
+        Contact us at <a href="mailto:people-finder-support@digital.justice.gov.uk">people-finder-support@digital.justice.gov.uk</a>
+        if you experience a problem with People Finder.
     unsupported_browser:
       unsupported_browser_warning_html: |
         <h1 id='error-summary-heading' class='heading-medium error-summary-heading'>

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -42,26 +42,9 @@ describe 'Report a problem', js: true do
   end
 
   context 'when not logged in' do
-    it 'Reporting a problem', js: true do
+    it 'does not show the feedback form' do
       visit new_sessions_path
-
-      click_link 'Report a problem' # includes a wait, which is required for the slideToggle jquery behaviour
-      fill_in 'What were you trying to do?', with: 'Rhubarb'
-      fill_in 'What went wrong?', with: 'Custard'
-      fill_in 'Your email', with: 'test@example.com'
-      expect { click_button 'Report' }.to change { ActionMailer::Base.deliveries.count }.by(1)
-
-      expect(page).to have_current_path(new_sessions_path, ignore_query: true)
-
-      expect(last_email.to).to eq([Rails.configuration.support_email])
-      body = last_email.body.encoded
-
-      expect(body).to have_text('Rhubarb')
-      expect(body).to have_text('Custard')
-      expect(body).to match(/Browser: .*?Mozilla/)
-      expect(body).to have_text('Email: test@example.com')
-      expect(body).to have_text('Person ID: unknown')
-      expect(body).to match(/Reported: 2014-09-09T21:27:..Z/)
+      expect(page).not_to have_selector('#feedback_container')
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -113,10 +113,9 @@ describe 'Searching feature', elastic: true do
     end
 
     it 'highlights individual current project terms' do
-      pending "TODO CT-2691 - commented out test to get ES update working"
       fill_in 'query', with: 'Digital Prisons Browne'
       click_button 'Search'
-      within '.cb-person-current-project' do
+      within '.cb-person-current-project', match: :first do
         expect(page).to have_selector('.es-highlight', text: 'Digital')
         expect(page).to have_selector('.es-highlight', text: 'Prisons')
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,7 +36,7 @@ Capybara.register_driver :headless_chrome do |app|
     options.add_argument('--enable-features=NetworkService,NetworkServiceInProcess')
   end
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: options)
 end
 
 Capybara.javascript_driver = :headless_chrome


### PR DESCRIPTION
## Description
Due to the spamming that has been received into Google Groups, it has been suggested that we remove the ‘Report a problem’ located in the footer from all the logged out pages.

In addition, so people still have a way to report login issues, the support email address has been added to the sign in / request link page.

The copy/placement can be discussed.

Note: as part of this work, I had some issues setting up ElasticSearch locally and making it work, so I tweaked the README instructions with what, in the end, helped me getting this up and running.

Also, when running the app/tests there were several deprecation warnings that I resolved (Pundit, Selenium...)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<img width="1000" alt="Screenshot 2022-05-18 at 09 54 52" src="https://user-images.githubusercontent.com/687910/169277853-615a4d79-45d1-40fc-8122-0dfb938335f2.png">

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4200

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
1. When logged out, the "report a problem" doesn't show in the footer.
2. When logged in, the "report a problem" will show in the footer.
3. In addition, the "request a link" page contains a link to contact support.