### PR TITLE
Update CircleCI badge and remove Gemnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-
 # MoJ People Finder
 
-![Build Status](https://circleci.com/gh/ministryofjustice/peoplefinder.png?circle-token=7af6dba1153f14c5e9b4ca7aec831720aeb00b1c)
+[![CircleCI](https://circleci.com/gh/ministryofjustice/peoplefinder/tree/main.svg?style=svg)](https://circleci.com/gh/ministryofjustice/peoplefinder/tree/main)
 [![Code
 Climate](https://codeclimate.com/github/ministryofjustice/peoplefinder/badges/gpa.svg)](https://codeclimate.com/github/ministryofjustice/peoplefinder)
 [![Test
 Coverage](https://codeclimate.com/github/ministryofjustice/peoplefinder/badges/coverage.svg)](https://codeclimate.com/github/ministryofjustice/peoplefinder/coverage)
-[![Dependency Status](https://gemnasium.com/badges/github.com/ministryofjustice/peoplefinder.svg)](https://gemnasium.com/github.com/ministryofjustice/peoplefinder)
-
 
 ## Installing for development
 


### PR DESCRIPTION

## Description

In a recent audit, it was raised as a false alarm the fact the CircleCI badge contains a token.

However this token scope is only "status" and can only be used to retrieve the status of a build (pass/fail).

The token is there because this repo used to be private, and private repos badges can only work with a token.

As the repo is no longer private, and in order to no raise more false alarms in the future, I'm updating the badge to the "public" one, no longer needing a token, and will revoke the token so it cannot be used.

Also, removed the badge for gemnasium because that service is no longer active.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
