### PR TITLE
Bulk move people from an old to a new team for specific teams

### DIFF
--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -141,5 +141,35 @@ namespace :peoplefinder do
       end
     end
 
+    namespace :etc do
+      teams_to_migrate = [
+        {from: 'hmp-lewes-do-not-use', to: 'hmp-lewes'},
+        {from: 'hmp-coldingley-do-not-use', to: 'hmp-coldingley'},
+        {from: 'south-central-prisons-group-hmp-huntercombe-do-not-use-2',
+            to: 'south-central-prisons-group-hmp-huntercombe-2'}
+      ]
+
+      desc 'Bulk move people from an old to a new team, preserving existing members in new team, and delete the old team'
+      task :bulk_move_lewes_huntercombe_coldingley => :environment do
+        teams_to_migrate.each do |team|
+          begin
+            puts "Assign #{team[:from]} members to #{team[:to]}"
+            old_team = Group.find_by_slug team[:from]
+            new_team = Group.find_by_slug team[:to]
+            if old_team && new_team
+              puts "Copying #{old_team.people.count} members"
+              new_team.people << old_team.people
+              old_team.people.delete_all
+              old_team.delete
+              print '.........'
+            end
+          rescue => err
+            puts "Failed to move team members for #{team[:from]}: #{err}"
+          end
+          puts "done"
+        end
+      end
+    end
+
   end
 end

--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -146,7 +146,9 @@ namespace :peoplefinder do
         {from: 'hmp-lewes-do-not-use', to: 'hmp-lewes'},
         {from: 'hmp-coldingley-do-not-use', to: 'hmp-coldingley'},
         {from: 'south-central-prisons-group-hmp-huntercombe-do-not-use-2',
-            to: 'south-central-prisons-group-hmp-huntercombe-2'}
+            to: 'south-central-prisons-group-hmp-huntercombe-2'},
+        {from: 'south-central-prisons-group-hmp-winchester-do-not-use',
+            to: 'south-central-prisons-group-hmp-winchester'}
       ]
 
       desc 'Bulk move people from an old to a new team, preserving existing members in new team, and delete the old team'

--- a/lib/tasks/peoplefinder/data.rake
+++ b/lib/tasks/peoplefinder/data.rake
@@ -162,12 +162,14 @@ namespace :peoplefinder do
               old_team.people.delete_all
               old_team.delete
               print '.........'
+            else
+              puts "Could not find `from` and `to` teams"
             end
           rescue => err
             puts "Failed to move team members for #{team[:from]}: #{err}"
           end
-          puts "done"
         end
+        puts "done"
       end
     end
 


### PR DESCRIPTION
## Description
Support some cleaning up work that's been done to tidy up members under some specific prison establishments

The user has set up old and new teams as described in the ticket. 

Verify the team names are as they should be, then run `rake peoplefinder:data:etc:bulk_move_lewes_huntercombe_coldingley` to move all team members from the old team into the new team, preserving existing members of the new team, and delete the old team. 

The script uses `<<` to copy the members from the old team and preserve existing memberships in the new team.

The old teams have no sub teams.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[<!-- A link or list of links to relevant issues in Jira -->](https://dsdmoj.atlassian.net/browse/CDPT-117)

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
To replicate the scenario, find three teams that have members in them. Create three new empty teams and add a couple of canary users to one of them matching the scenarios below. Log into the namespace and run the rake task. You get one go and there's no rollback, so recommend testing thoroughly on non-prod environments first.

Scenarios to test
1. new team has members
2. new team has members that are duplicates of members moving in
