### PR TITLE
CDPT-382 check csrf token present

### DIFF
--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -343,7 +343,7 @@ describe 'Person maintenance' do
     end
   end
 
-  context 'when Deleting a person' do
+  context 'when Deleting a person', with_csrf_protection: true, js: true do
     context 'with a regular user', user: :regular do
       it 'Deleting a person' do
         person = create :person
@@ -352,6 +352,7 @@ describe 'Person maintenance' do
 
         visit person_path(person)
         click_delete_profile
+        sleep 1
         expect { Person.find(person.id) }.to raise_error(ActiveRecord::RecordNotFound)
 
         expect(last_email.to).to include(email_address)
@@ -364,6 +365,7 @@ describe 'Person maintenance' do
         person = membership.person
         visit person_path(person)
         click_delete_profile
+        sleep 1
         expect { Membership.find(membership.id) }.to raise_error(ActiveRecord::RecordNotFound)
         expect { Person.find(person.id) }.to raise_error(ActiveRecord::RecordNotFound)
       end

--- a/spec/features/person_maintenance_spec.rb
+++ b/spec/features/person_maintenance_spec.rb
@@ -351,7 +351,9 @@ describe 'Person maintenance' do
         given_name = person.given_name
 
         visit person_path(person)
-        click_delete_profile
+        accept_alert do
+          click_delete_profile
+        end
         sleep 1
         expect { Person.find(person.id) }.to raise_error(ActiveRecord::RecordNotFound)
 
@@ -364,7 +366,9 @@ describe 'Person maintenance' do
         membership = create(:membership)
         person = membership.person
         visit person_path(person)
-        click_delete_profile
+        accept_alert do
+          click_delete_profile
+        end
         sleep 1
         expect { Membership.find(membership.id) }.to raise_error(ActiveRecord::RecordNotFound)
         expect { Person.find(person.id) }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,10 +37,9 @@ RSpec.configure do |config|
       File.delete(file)
     end
   end
-
-
 end
 
+# enable csrf testing in feature specs - `with_csrf_protection: true`
 RSpec.configure do |config|
   config.around(:each, :with_csrf_protection) do |example|
     orig = ActionController::Base.allow_forgery_protection

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,4 +38,18 @@ RSpec.configure do |config|
     end
   end
 
+
+end
+
+RSpec.configure do |config|
+  config.around(:each, :with_csrf_protection) do |example|
+    orig = ActionController::Base.allow_forgery_protection
+
+    begin
+      ActionController::Base.allow_forgery_protection = true
+      example.run
+    ensure
+      ActionController::Base.allow_forgery_protection = orig
+    end
+  end
 end

--- a/spec/support/profile.rb
+++ b/spec/support/profile.rb
@@ -68,7 +68,9 @@ module SpecSupport
     end
 
     def click_delete_profile(matcher = :first)
-      click_link('Delete this profile', match: matcher)
+      accept_alert do
+        click_link('Delete this profile', match: matcher)
+      end
     end
 
     def fill_in_membership_details(team_name)

--- a/spec/support/profile.rb
+++ b/spec/support/profile.rb
@@ -68,9 +68,7 @@ module SpecSupport
     end
 
     def click_delete_profile(matcher = :first)
-      accept_alert do
-        click_link('Delete this profile', match: matcher)
-      end
+      click_link('Delete this profile', match: matcher)
     end
 
     def fill_in_membership_details(team_name)


### PR DESCRIPTION
## Description
In a previous PR we accidentally deleted the CSRF token `= csrf_meta_tag` from the application template file which prevented many actions from working but didn't get flagged in our tests. This is because CSRF is disabled in the test environment in Rails 

To cover this scenario I've amended our delete user spec (the specific scenario which alerted us to the issue) to use CSRF tokens (which requires the JS driver) as a sort of canary against this in the future. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-382

### Deployment
N/A

### Manual testing instructions
Remove line 22 of application.html.haml and run the spec `spec/features/person_maintenance_spec.rb` and it will throw an exception 

![image](https://user-images.githubusercontent.com/1161161/203499047-fa0050cf-e707-4157-ae3d-42fae9d78a92.png)
