### PR TITLE
Ignore ar_internal_metadata table

### DIFF
--- a/lib/tasks/peoplefinder/db.rake
+++ b/lib/tasks/peoplefinder/db.rake
@@ -16,7 +16,7 @@ namespace :peoplefinder do
       conn = ActiveRecord::Base.connection
       tables = conn.tables
       tables.each do |table|
-        next if %w{ schema_migrations delayed_jobs }.include? table
+        next if %w{ schema_migrations delayed_jobs ar_internal_metadata }.include? table
         table.classify.constantize.reset_column_information
       end
     end


### PR DESCRIPTION
## Description
This table was added in Rails 5. It doesn't exist as an AR class so it needs to be skipped when resetting column information as part of the seeding task.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
