### PR TITLE
CDPT-391 Handle deleted person in mailer

### DIFF
--- a/app/mailers/user_update_mailer.rb
+++ b/app/mailers/user_update_mailer.rb
@@ -13,8 +13,10 @@ class UserUpdateMailer < ApplicationMailer
   end
 
   def updated_profile_email(person, changes, by_email = nil)
+    return if person.nil?
+
     @person = person
-    present changes
+    present(changes)
     @by_email = by_email
     @profile_url = profile_url(person)
     mail to: person.email, cc: @changes.raw['email']&.first
@@ -32,7 +34,7 @@ class UserUpdateMailer < ApplicationMailer
     person_url(person)
   end
 
-  def present changes
+  def present(changes)
     @changes = ProfileChangesPresenter.deserialize(changes)
   end
 end

--- a/spec/mailers/user_update_mailer_spec.rb
+++ b/spec/mailers/user_update_mailer_spec.rb
@@ -205,11 +205,11 @@ describe UserUpdateMailer do
       end
     end
 
-    context 'updating deleted person' do
+    context 'when updating deleted person' do
       let(:person) { nil }
       let(:changes_presenter) { nil }
       let(:serialized_changes) do
-        { "data": { "raw": { "given_name":[ "Smith", "Jones" ] } } }.to_json
+        { 'data': { 'raw': { 'given_name': ['Smith', 'Jones'] } } }.to_json
       end
 
       it 'does not error' do

--- a/spec/mailers/user_update_mailer_spec.rb
+++ b/spec/mailers/user_update_mailer_spec.rb
@@ -204,6 +204,18 @@ describe UserUpdateMailer do
         end
       end
     end
+
+    context 'updating deleted person' do
+      let(:person) { nil }
+      let(:changes_presenter) { nil }
+      let(:serialized_changes) do
+        { "data": { "raw": { "given_name":[ "Smith", "Jones" ] } } }.to_json
+      end
+
+      it 'does not error' do
+        expect { mail }.to_not raise_error
+      end
+    end
   end
 
   describe ".deleted_profile_email" do


### PR DESCRIPTION
## Description
Exceptions are being caused in the mailer to notify when a profile has been updated due to the person not existing.
This is likely because a person has been deleted.

This change means it will not attempt to send an email if the person no longer exists.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
