### PR TITLE
CDPT-475 Make Elastic search pod host name SSL friendly

### DIFF
--- a/config/kubernetes/demo/env-configmap.yaml
+++ b/config/kubernetes/demo/env-configmap.yaml
@@ -12,5 +12,5 @@ data:
   S3_REGION: 'eu-west-2'
   GOVUK_APP_DOMAIN: 'peoplefinder.service.gov.uk'
   GOVUK_WEBSITE_ROOT: 'demo'
-  MOJ_PF_ES_URL: 'http://aws-es-proxy-service:9200'
+  MOJ_PF_ES_URL: 'aws-es-proxy-service:9200'
   

--- a/config/kubernetes/development/env-configmap.yaml
+++ b/config/kubernetes/development/env-configmap.yaml
@@ -12,5 +12,5 @@ data:
   S3_REGION: 'eu-west-2'
   GOVUK_APP_DOMAIN: 'peoplefinder.service.gov.uk'
   GOVUK_WEBSITE_ROOT: 'development'
-  MOJ_PF_ES_URL: 'http://aws-es-proxy-service:9200'
+  MOJ_PF_ES_URL: 'aws-es-proxy-service:9200'
   

--- a/config/kubernetes/production/env-configmap.yaml
+++ b/config/kubernetes/production/env-configmap.yaml
@@ -12,4 +12,4 @@ data:
   S3_REGION: 'eu-west-2'
   GOVUK_APP_DOMAIN: 'peoplefinder.service.gov.uk'
   GOVUK_WEBSITE_ROOT: 'www'
-  MOJ_PF_ES_URL: 'http://aws-es-proxy-service:9200'
+  MOJ_PF_ES_URL: 'aws-es-proxy-service:9200'

--- a/config/kubernetes/staging/env-configmap.yaml
+++ b/config/kubernetes/staging/env-configmap.yaml
@@ -12,5 +12,5 @@ data:
   S3_REGION: 'eu-west-2'
   GOVUK_APP_DOMAIN: 'peoplefinder.service.gov.uk'
   GOVUK_WEBSITE_ROOT: 'staging'
-  MOJ_PF_ES_URL: 'http://aws-es-proxy-service:9200'
+  MOJ_PF_ES_URL: 'aws-es-proxy-service:9200'
   


### PR DESCRIPTION
## Description
Upgrading security of Peoplefinder on Cloud Platform means that the URL for the new pod no longer works when creating index. Therefore we have to remove the HTTP.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-475

### Deployment
n/a

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
