### PR TITLE
Copy .ruby-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV LC_ALL C.UTF-8
 ENV APPUSER moj
 ENV PUMA_PORT 3000
 
-COPY Gemfile* ./
+COPY Gemfile* .ruby-version ./
 RUN gem install bundler -v 2.4.13
 RUN bundle config --global frozen 1 && \
     bundle config --path=vendor/bundle && \


### PR DESCRIPTION
## Description
This fixes production build as the Gemfile now gets the ruby version from .ruby-version, but the file was not being copied across when bundle was being run in the image.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
