### PR TITLE
CDPT-1148:PF Remove beta1 version from cron jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ references:
 
   deploy_container_config: &deploy_container_config
     docker:
-      - image: ministryofjustice/cloud-platform-tools:1.29
+      - image: ministryofjustice/cloud-platform-tools:2.7.0
 
   # These are defining the steps which are used below in the jobs
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -689,7 +689,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.11.0)
+    selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -745,7 +745,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/config/kubernetes/production/cron-never-logged-in-notifier.yaml
+++ b/config/kubernetes/production/cron-never-logged-in-notifier.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: never-logged-in-notifier

--- a/config/kubernetes/production/cron-person-notifier.yaml
+++ b/config/kubernetes/production/cron-person-notifier.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: person-notifier

--- a/config/kubernetes/production/cron-person-update-reminder.yaml
+++ b/config/kubernetes/production/cron-person-update-reminder.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: person-update-reminder

--- a/config/kubernetes/production/cron-photo-profiles-report.yaml
+++ b/config/kubernetes/production/cron-photo-profiles-report.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: photo-profiles-report-publish

--- a/config/kubernetes/production/cron-profile-changed-report.yaml
+++ b/config/kubernetes/production/cron-profile-changed-report.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: profile-changed-report-publish

--- a/config/kubernetes/production/cron-profile-completions-report.yaml
+++ b/config/kubernetes/production/cron-profile-completions-report.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: profile-completions-report-publish

--- a/config/kubernetes/production/cron-profile-percentage-report.yaml
+++ b/config/kubernetes/production/cron-profile-percentage-report.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: profiles-percentage-report-publish

--- a/config/kubernetes/production/cron-team-description-notifier.yaml
+++ b/config/kubernetes/production/cron-team-description-notifier.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: team-description-notifier

--- a/config/kubernetes/production/cron-total-profiles-report.yaml
+++ b/config/kubernetes/production/cron-total-profiles-report.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: total-profiles-report-publish

--- a/config/kubernetes/production/cron-user-behaviour-report.yaml
+++ b/config/kubernetes/production/cron-user-behaviour-report.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: user-behaviour-report-publish


### PR DESCRIPTION
## Description
The Cloud Platform Kubernetes cluster is being updated and support is being dropped for the current CronJob API we use.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [x ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
