### PR TITLE
Fix person-notifier cronjob crash looping.

### DIFF
--- a/config/kubernetes/production/cron-person-notifier.yaml
+++ b/config/kubernetes/production/cron-person-notifier.yaml
@@ -43,5 +43,5 @@ spec:
             command:
               - /bin/sh
               - "-c"
-              - "rails runner 'NotificationSender.new.send!'"
+              - "bundle exec rails runner 'NotificationSender.new.send!'"
           restartPolicy: OnFailure


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
Currently the person-notifier cronjob is crash/looping.  Attempting to view logs returns a “/bin/sh: rails: not found” error.
To fix this, the cron-person-notifier.yaml file was updated prefixing 'bundle exec' to runner rails command.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
N/A

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
N/A
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
N/A
### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
When viewing the pods with kubectl  the person-notifier-xxxxxxxx-xxxxx pod should not be in a 'CrashLoopBackOff' state.

