### PR TITLE
Remove CodeClimate and save coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ references:
     run:
       name: Install dependencies
       command: |
-        sudo apt install bc
+        sudo apt-get install bc
         if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
           bundle config deployment true
           bundle check || bundle install && bundle clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,7 @@ jobs:
       - *brakeman
       - *run_unit_and_feature_tests
       - *store_coverage
+      - *check_coverage
 
   build_branch_and_push_to_ecr:
     executor: machine_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ references:
         limit=100
         cov_val=$(grep -o '"line":.*' coverage/.last_run.json | cut -d" " -f2-)
         if (( $(echo "$cov_val < $limit" | bc -l) )); then
+          echo "Test coverage is under $limit%. Go to the Artifacts tab to see details."
           exit 1
         fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ references:
     run:
       name: Install dependencies
       command: |
-        apt install bc
+        sudo apt install bc
         if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
           bundle config deployment true
           bundle check || bundle install && bundle clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ references:
     run:
       name: Install dependencies
       command: |
+        apk add --no-cache --no-progress bc
         if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
           bundle config deployment true
           bundle check || bundle install && bundle clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,10 +131,12 @@ references:
     run:
       name: Check test coverage
       command: |
-        limit=100
-        cov_val=$(grep -o '"line":.*' coverage/.last_run.json | cut -d" " -f2-)
-        if (( $(echo "$cov_val < $limit" | bc -l) )); then
-          echo "Test coverage is under $limit%. Go to the Artifacts tab to see details."
+        limit=95 # Coverage percentage below this number will cause the build to fail
+        coverage=$(grep -o '"line":.*' coverage/.last_run.json | cut -d" " -f2-)
+        echo "Details of test coverage is available from the Artifacts tab"
+        echo "Tests cover $coverage% of code"
+        if (( $(echo "$coverage < $limit" | bc -l) )); then
+          echo "This is under the target of $limit%"
           exit 1
         fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ references:
     run:
       name: Install dependencies
       command: |
-        apk add --no-cache --no-progress bc
+        apt install bc
         if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
           bundle config deployment true
           bundle check || bundle install && bundle clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ references:
 
   brakeman: &brakeman
     run:
-      name: Run Brakeman
+      name: Run brakeman
       command: bundle exec brakeman
 
   run_unit_and_feature_tests: &run_unit_and_feature_tests
@@ -129,7 +129,7 @@ references:
 
   check_coverage: &check_coverage
     run:
-      name: Check coverage
+      name: Check test coverage
       command: |
         limit=100
         cov_val=$(grep -o '"line":.*' coverage/.last_run.json | cut -d" " -f2-)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ references:
       command: |
         limit=100
         cov_val=$(grep -o '"line":.*' coverage/.last_run.json | cut -d" " -f2-)
-        if (( $cov_val < $limit )); then
+        if [ "$cov_val" -lt "$limit" ]; then
           exit 1
         fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ references:
       command: |
         limit=100
         cov_val=$(grep -o '"line":.*' coverage/.last_run.json | cut -d" " -f2-)
-        if [ "$cov_val" -lt "$limit" ]; then
+        if (( $(echo "$cov_val < $limit" | bc -l) )); then
           exit 1
         fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,16 @@ references:
     store_artifacts:
       path: coverage
 
+  check_coverage: &check_coverage
+    run:
+      name: Check coverage
+      command: |
+        limit=100
+        cov_val=$(grep -o '"line":.*' coverage/.last_run.json | cut -d" " -f2-)
+        if (( $cov_val < $limit )); then
+          exit 1
+        fi
+
   aws_setup: &aws_setup
     # Authenticate to AWS using OIDC v2 with the AWS CLI
     aws-cli/setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,26 +115,15 @@ references:
       name: Run Brakeman
       command: bundle exec brakeman
 
-  setup_test_reporter: &setup_test_reporter
-    run:
-      name: Setup Code Climate test-reporter
-      command: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-        ./cc-test-reporter before-build
-
   run_unit_and_feature_tests: &run_unit_and_feature_tests
     run:
       name: Run unit and feature tests
       command: |
-        SKIP_SIMPLECOV=false bundle exec rspec
+        bundle exec rspec
 
-  upload_test_coverage: &upload_test_coverage
-    run:
-      name: Upload the test coverage into codeclimate
-      command: |
-        ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
-        ./cc-test-reporter sum-coverage --output - coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
+  store_coverage: &store_coverage
+    store_artifacts:
+      path: coverage
 
   aws_setup: &aws_setup
     # Authenticate to AWS using OIDC v2 with the AWS CLI
@@ -217,9 +206,8 @@ jobs:
       - *set_up_the_database
       - *rubocop
       - *brakeman
-      - *setup_test_reporter
       - *run_unit_and_feature_tests
-      - *upload_test_coverage
+      - *store_coverage
 
   build_branch_and_push_to_ecr:
     executor: machine_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ references:
     run:
       name: Install dependencies
       command: |
+        sudo apt-get update
         sudo apt-get install bc
         if [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
           bundle config deployment true

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :test do
   gem "database_cleaner", "~> 1.8.5"
   gem "rails-controller-testing"
   gem "rspec-json_expectations"
-  gem "simplecov", "~> 0.22", require: false
+  gem "simplecov", require: false
   gem "site_prism"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -811,7 +811,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers
-  simplecov (~> 0.22)
+  simplecov
   site_prism
   sprockets-rails
   text

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,14 +10,6 @@ require "capybara/rspec"
 require "site_prism"
 require "awesome_print"
 
-if ENV["SKIP_SIMPLECOV"].to_s.downcase == "false"
-  require "simplecov"
-  SimpleCov.start "rails" do
-    add_filter "/gem/"
-    add_filter ".bundle"
-  end
-end
-
 Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require "simplecov"
+SimpleCov.start "rails"
+
 require "webmock/rspec"
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Description
- Stops uploading test coverage details to CodeClimate
- Adds saving of coverage as an artifact in CircleCI
- Fails build if test coverage is under a set percentage (currently 95%)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
