### PR TITLE
Log health check errors in Sentry

### DIFF
--- a/app/services/health_check_service.rb
+++ b/app/services/health_check_service.rb
@@ -16,6 +16,7 @@ class HealthCheckService
     if errors.empty?
       HealthCheckReport.new("200", "All Components OK")
     else
+      Sentry.capture_message(errors)
       HealthCheckReport.new("500", errors)
     end
   end

--- a/spec/services/health_check_service_spec.rb
+++ b/spec/services/health_check_service_spec.rb
@@ -50,4 +50,21 @@ describe HealthCheckService do
       ],
     )
   end
+
+  it "sends error details to Sentry" do
+    allow_any_instance_of(HealthCheck::Database) # rubocop:disable RSpec/AnyInstance
+      .to receive(:available?).and_return(false)
+    allow_any_instance_of(HealthCheck::OpenSearch) # rubocop:disable RSpec/AnyInstance
+      .to receive(:available?).and_return(true)
+    allow_any_instance_of(HealthCheck::Database) # rubocop:disable RSpec/AnyInstance
+      .to receive(:accessible?).and_return(true)
+    allow_any_instance_of(HealthCheck::OpenSearch) # rubocop:disable RSpec/AnyInstance
+      .to receive(:accessible?).and_return(true)
+    allow_any_instance_of(HealthCheck::Database) # rubocop:disable RSpec/AnyInstance
+      .to receive(:errors)
+      .and_return(["DB Message 1"])
+
+    expect(Sentry).to receive(:capture_message).with(["DB Message 1"])
+    health_check_report.report
+  end
 end


### PR DESCRIPTION
## Description
We regularly are seeing downtime issues according to Pingdom overnight. We have no visibility on the issue, so this change will send details of any health check failures to Sentry.
