### PR TITLE
CDPT-1952 Enable modsec detection mode on production

### DIFF
--- a/config/kubernetes/production/ingress-live.yaml
+++ b/config/kubernetes/production/ingress-live.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: peoplefinder-ingress
+  name: peoplefinder-ingress-modsec
   namespace: peoplefinder-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: peoplefinder-ingress-peoplefinder-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: peoplefinder-ingress-modsec-peoplefinder-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |

--- a/config/kubernetes/production/ingress-live.yaml
+++ b/config/kubernetes/production/ingress-live.yaml
@@ -6,8 +6,13 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: peoplefinder-ingress-peoplefinder-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=peoplefinder-production"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
     - hosts:
         - peoplefinder.service.gov.uk


### PR DESCRIPTION
## Description
Enables [modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) in detection mode on production so we can be aware of any issues and evaluate if more protection is required.