### PR TITLE
CDPT-2128 Ensure profile completion

### DIFF
--- a/app/controllers/concerns/session_person_creator.rb
+++ b/app/controllers/concerns/session_person_creator.rb
@@ -24,6 +24,7 @@ module SessionPersonCreator
       if person&.new_record?
         confirm_or_create person
       elsif person
+        incomplete_profile(person) unless person.valid?
         login_person(person)
       else
         render :failed
@@ -60,8 +61,7 @@ module SessionPersonCreator
     def create_person_and_login(person)
       person_creator = PersonCreator.new(person, current_user, StateManagerCookie.new(cookies))
       person_creator.create!
-      warning :complete_profile
-      session[:desired_path] = edit_person_path(@person, page_title: "Create profile")
+      incomplete_profile(@person)
       login_person(@person)
     end
 
@@ -70,6 +70,11 @@ module SessionPersonCreator
 
       @people = Person.namesakes(@person)
       @people.present?
+    end
+
+    def incomplete_profile(person)
+      warning :complete_profile
+      session[:desired_path] = edit_person_path(person, page_title: "Create profile")
     end
   end
 end

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -12,7 +12,6 @@ class TokensController < ApplicationController
   end
 
   def show
-    session[:desired_path] = params[:desired_path] if params[:desired_path]
     if logged_in_regular?
       render_desired_path_or_profile
     else

--- a/spec/features/person_edit_notifications_spec.rb
+++ b/spec/features/person_edit_notifications_spec.rb
@@ -6,68 +6,80 @@ describe "Person edit notifications" do
 
   let(:person) { create(:person, email: "test.user@digital.justice.gov.uk") }
 
-  before do
-    token_log_in_as(person.email)
+  describe "logged in" do
+    before do
+      token_log_in_as(person.email)
+    end
+
+    it "Creating a person with different email" do
+      visit new_person_path
+
+      fill_in "First name", with: "Bob"
+      fill_in "Last name", with: "Smith"
+      fill_in "Main email", with: "bob.smith@digital.justice.gov.uk"
+      expect {
+        click_button "Save", match: :first
+      }.to change(QueuedNotification, :count).by(1)
+
+      notification = QueuedNotification.last
+      expect(notification.current_user_id).to eq person.id
+      expect(notification.sent).to be false
+      expect(notification.edit_finalised).to be true
+      expect(notification.changes_hash["data"]["raw"]).to include(
+        "given_name" => [nil, "Bob"],
+        "surname" => [nil, "Smith"],
+        "location_in_building" => [nil, ""],
+        "building" => [nil, ""],
+        "city" => [nil, ""],
+        "primary_phone_number" => [nil, ""],
+        "secondary_phone_number" => [nil, ""],
+        "pager_number" => [nil, ""],
+        "email" => [nil, "bob.smith@digital.justice.gov.uk"],
+        "secondary_email" => [nil, ""],
+        "description" => [nil, ""],
+        "current_project" => [nil, ""],
+        "slug" => [nil, "bob-smith"],
+      )
+    end
+
+    it "Editing a person with different email" do
+      digital = create(:group, name: "Digital")
+      person = create(:person, :member_of, team: digital, given_name: "Bob", surname: "Smith", email: "bob.smith@digital.justice.gov.uk")
+      visit person_path(person)
+      click_edit_profile
+      fill_in "Last name", with: "Smelly Pants"
+      expect {
+        click_button "Save", match: :first
+      }.to change(QueuedNotification, :count).by(1)
+      expect(QueuedNotification.last.changes_hash["data"]["raw"]["surname"]).to eq(["Smith", "Smelly Pants"])
+    end
+
+    it "Editing a person with same email" do
+      visit person_path(person)
+      click_edit_profile
+      fill_in "Last name", with: "Smelly Pants"
+      expect {
+        click_button "Save", match: :first
+      }.not_to(change { ActionMailer::Base.deliveries.count })
+    end
   end
 
-  it "Creating a person with different email" do
-    visit new_person_path
+  describe "accessing via token link" do
+    let(:bob) { create(:person, email: "bob@digital.justice.gov.uk", surname: "bob") }
 
-    fill_in "First name", with: "Bob"
-    fill_in "Last name", with: "Smith"
-    fill_in "Main email", with: "bob.smith@digital.justice.gov.uk"
-    expect {
-      click_button "Save", match: :first
-    }.to change(QueuedNotification, :count).by(1)
+    it "Verifying the link to bob that is render in the emails" do
+      visit token_url(Token.for_person(bob))
 
-    notification = QueuedNotification.last
-    expect(notification.current_user_id).to eq person.id
-    expect(notification.sent).to be false
-    expect(notification.edit_finalised).to be true
-    expect(notification.changes_hash["data"]["raw"]).to include(
-      "given_name" => [nil, "Bob"],
-      "surname" => [nil, "Smith"],
-      "location_in_building" => [nil, ""],
-      "building" => [nil, ""],
-      "city" => [nil, ""],
-      "primary_phone_number" => [nil, ""],
-      "secondary_phone_number" => [nil, ""],
-      "pager_number" => [nil, ""],
-      "email" => [nil, "bob.smith@digital.justice.gov.uk"],
-      "secondary_email" => [nil, ""],
-      "description" => [nil, ""],
-      "current_project" => [nil, ""],
-      "slug" => [nil, "bob-smith"],
-    )
-  end
+      within("h1") do
+        expect(page).to have_text("bob")
+      end
+    end
 
-  it "Editing a person with different email" do
-    digital = create(:group, name: "Digital")
-    person = create(:person, :member_of, team: digital, given_name: "Bob", surname: "Smith", email: "bob.smith@digital.justice.gov.uk")
-    visit person_path(person)
-    click_edit_profile
-    fill_in "Last name", with: "Smelly Pants"
-    expect {
-      click_button "Save", match: :first
-    }.to change(QueuedNotification, :count).by(1)
-    expect(QueuedNotification.last.changes_hash["data"]["raw"]["surname"]).to eq(["Smith", "Smelly Pants"])
-  end
+    it "tells user that their profile is not complete" do
+      bob.update_attribute(:given_name, nil) # rubocop:disable Rails/SkipsModelValidations
+      visit token_url(Token.for_person(bob))
 
-  it "Editing a person with same email" do
-    visit person_path(person)
-    click_edit_profile
-    fill_in "Last name", with: "Smelly Pants"
-    expect {
-      click_button "Save", match: :first
-    }.not_to(change { ActionMailer::Base.deliveries.count })
-  end
-
-  it "Verifying the link to bob that is render in the emails" do
-    bob = create(:person, email: "bob@digital.justice.gov.uk", surname: "bob")
-    visit token_url(Token.for_person(bob), desired_path: person_path(bob))
-
-    within("h1") do
-      expect(page).to have_text("bob")
+      expect(page).to have_text("You need to create or update a People Finder account to finish signing in")
     end
   end
 end


### PR DESCRIPTION
## Description
When a user inputs their email address for the first time a profile is created and a login URL sent. This URL will take them to their profile page and prompt them to fill in required details such as their team.

If they don't update their profile and generate a login link again at a later date they may end up on the new profile creation page without realising their profile already exists.

Now, if they generate a login link and have not yet updated the mandatory fields, they will be taken to the profile edit page  where they can finish the profile setup.