### PR TITLE
Avoid validation when updating user

### DIFF
--- a/app/services/never_logged_in_notifier.rb
+++ b/app/services/never_logged_in_notifier.rb
@@ -18,7 +18,7 @@ module NeverLoggedInNotifier
     person.reload
     if NeverLoggedInNotifier.send_never_logged_in_reminder? person, within
       ReminderMailer.never_logged_in(person).deliver_later
-      person.update!(last_reminder_email_at: Time.zone.now)
+      person.update_attribute!(:last_reminder_email_at, Time.zone.now)
     end
   end
 

--- a/spec/services/never_logged_in_notifier_spec.rb
+++ b/spec/services/never_logged_in_notifier_spec.rb
@@ -19,9 +19,18 @@ RSpec.describe NeverLoggedInNotifier, type: :service do
     end
 
     context "when send_never_logged_in_reminder? is true" do
+      let(:person) { Person.create!(skip_must_have_team: true, given_name: "Peter", surname: "Piper", email: "peter.piper@digital.justice.gov.uk") }
       let(:can_send) { true }
 
       include_examples "sends reminder email", :never_logged_in
+
+      it "updates the reminder sent date" do
+        allow(Rails.configuration).to receive(:send_reminder_emails).and_return true
+
+        expect {
+          described_class.send_reminders
+        }.to(change { person.reload.last_reminder_email_at })
+      end
     end
 
     context "when send_never_logged_in_reminder? is false" do


### PR DESCRIPTION
## Description
Need to avoid validation when updating the last reminder date for users that are invalid because they have not added a team.
