### PR TITLE
CDPT-2693 Peoplefinder: Amend emails for automatic and support emails to justice accounts

### DIFF
--- a/app/views/errors/internal_error.html.erb
+++ b/app/views/errors/internal_error.html.erb
@@ -2,6 +2,6 @@
   <div class="column-full">
     <h1 class="heading-large">Sorry, there is a problem with the service</h1>
     <p>Try again later.</p>
-    <p>Please contact <a href="mailto:people-finder-support@digital.justice.gov.uk" class="govuk-link">people-finder-support@digital.justice.gov.uk</a> with the details to report this issue.</p>
+    <p>Please contact <a href="mailto:PeopleFinderSupport-gg@justice.gov.uk" class="govuk-link">PeopleFinderSupport-gg@justice.gov.uk</a> with the details to report this issue.</p>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,6 +3,6 @@
     <h1 class="heading-large">Page not found</h1>
     <p>If you typed the web address, check it is correct.</p>
     <p>If you pasted the web address, check you copied the entire address.</p>
-    <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:people-finder-support@digital.justice.gov.uk" class="govuk-link">people-finder-support@digital.justice.gov.uk</a> with the details to report this issue.</p>
+    <p>If the web address is correct or you selected a link or button, please contact <a href="mailto:PeopleFinderSupport-gg@justice.gov.uk" class="govuk-link">PeopleFinderSupport-gg@justice.gov.uk</a> with the details to report this issue.</p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,7 @@ en:
       log_in_google: Log in
       log_in_email: Request link
       contact_support_html: |
-        Contact us at <a href="mailto:people-finder-support@digital.justice.gov.uk">people-finder-support@digital.justice.gov.uk</a>
+        Contact us at <a href="mailto:PeopleFinderSupport-gg@justice.gov.uk">PeopleFinderSupport-gg@justice.gov.uk</a>
         if you experience a problem with People Finder.
     unsupported_browser:
       unsupported_browser_warning_html: |
@@ -103,7 +103,7 @@ en:
       title: Link sent — check your email
       body_intro: We’re just emailing you a link to access People Finder. This can take up to 5 minutes.
       body_ttl_warning: "When it arrives, click on the link (which is active for %{ttl}). This will log you in to People Finder and enable you to make any changes."
-      body_informative_html: Please check your inbox for this email from <a href="mailto:people-finder-support@digital.justice.gov.uk">people-finder-support@digital.justice.gov.uk</a>.
+      body_informative_html: Please check your inbox for this email from <a href="mailto:PeopleFinderSupport-gg@justice.gov.uk">PeopleFinderSupport-gg@justice.gov.uk</a>.
       body_dont_panic: If you can’t find it, check your junk folder and add our address to your safe list.
       token_auth_disabled: "Sorry, the alternate login method is not availabe. Please login using your Google account."
   controllers:


### PR DESCRIPTION
## Description
Update contact details from digital email to justice accounts.

- If automated email use: [NoReplyPeopleFinder-gg@justice.gov.uk](mailto:NoReplyPeopleFinder-gg@justice.gov.uk)
- If offering support use: [PeopleFinderSupport-gg@justice.gov.uk](mailto:PeopleFinderSupport-gg@justice.gov.uk)

NB: Gov UK Notify automatic reply has been amended to NoReplyPeopleFinder-gg@justice.gov.uk

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-2693

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
