### PR TITLE
CDPTKAN-273 depandabot updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
       dotenv (= 3.1.2)
       railties (>= 6.1)
     drb (2.2.3)
-    erb (5.0.2)
+    erb (5.1.1)
     erubi (1.13.1)
     erubis (2.7.0)
     excon (0.110.0)
@@ -610,7 +610,7 @@ GEM
       racc
     pg (1.5.9)
     plek (5.2.0)
-    pp (0.6.2)
+    pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
     prism (1.4.0)
@@ -673,9 +673,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.14.2)
+    rdoc (6.15.0)
       erb
       psych (>= 4.0.0)
+      tsort
     regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
@@ -767,10 +768,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (5.23.0)
+    sentry-rails (5.28.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.23.0)
-    sentry-ruby (5.23.0)
+      sentry-ruby (~> 5.28.0)
+    sentry-ruby (5.28.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     sexp_processor (4.16.1)
@@ -807,6 +808,7 @@ GEM
     tilt (2.0.10)
     timecop (0.9.10)
     timeout (0.4.3)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2024.2)


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This branch rolls into one PR four dependabot updates.

The updates are:
- Bump capybara-lockstep from 2.2.3 to 2.3.0
- Bump database_cleaner from 2.0.2 to 2.1.0
- Bump rack from 3.1.16 to 3.1.18
- Bump sentry-rails from 5.23.0 to 5.28.0

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
N/A

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoi.atlassian.net/browse/CDPTKAN-2731

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
N/A

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
All 'happy tests' should pass